### PR TITLE
Warn users who try to use pipenv run before installing packages

### DIFF
--- a/pipenv/cli.py
+++ b/pipenv/cli.py
@@ -2241,7 +2241,17 @@ def inline_activate_virtualenv():
 @click.option('--three/--two', is_flag=True, default=None, help="Use Python 3/2 when creating virtualenv.")
 @click.option('--python', default=False, nargs=1, help="Specify which version of Python virtualenv should use.")
 def run(command, args, three=None, python=False):
-    # Ensure that virtualenv is available.
+    # Make sure we have created the virtualenv if applicable
+    # This isn't required if we are in CI or are using system python
+    if not project.virtualenv_exists and not PIPENV_USE_SYSTEM and not 'CI' in os.environ:
+        click.echo(
+            u'This project has no virtualenv yet! Use $ {0}, for example, to create one.'.format(
+                crayons.red(u'pipenv install', bold=True)
+            ),
+            err=True
+        )
+        sys.exit(1)
+
     ensure_project(three=three, python=python, validate=False)
 
     load_dot_env()

--- a/pipenv/utils.py
+++ b/pipenv/utils.py
@@ -843,7 +843,10 @@ def is_installable_file(path):
         path = urlparse(path['file']).path if 'file' in path else path['path']
     if not isinstance(path, six.string_types) or path == '*':
         return False
-    lookup_path = Path(path)
+    try:
+        lookup_path = Path(path)
+    except OSError:
+        return False
     return lookup_path.is_file() or (lookup_path.is_dir() and
             pip.utils.is_installable_dir(lookup_path.resolve().as_posix()))
 


### PR DESCRIPTION
- Fixes #1080
- Currently, pipenv run will create a virtualenv if one doesnt exist
- However, it will not install packages if it needs to
- This allows us to install packages only if we have a new venv