### PR TITLE
Add help option to run command

### DIFF
--- a/pipenv/cli.py
+++ b/pipenv/cli.py
@@ -2237,8 +2237,8 @@ def inline_activate_virtualenv():
 
 
 @click.command(
-    add_help_option=False,
-    short_help="Spawns a command installed into the virtualenv.",
+    help="Run a command inside the virtualenv. This makes all your installed packages available to the command.",
+    short_help="Run a single command inside the virtualenv.",
     context_settings=dict(
         ignore_unknown_options=True,
         allow_interspersed_args=False,


### PR DESCRIPTION
This would fix https://github.com/kennethreitz/pipenv/issues/1145 (neither -h or --help work with pipenv run)

The help message for `run` was explictly disabled in commit
934d83e86de4cf036872a3dd2e68ada8a82fb1cb, but the behaviour introduced by that commit has since changed.

Currently if you run `pipenv run --help` or `-h`, pipenv treats the
option as a command and tries to run it. Unless you have something on
your path called `--help` or `-h`, this will fail with a simple error
saying it's not on the path. It doesn't give you any information about
what the command does.

On the other hand, if you just run `pipenv run` without arguments, you
do get a help message with all the options, but there is no description
of what the command is.

This is because `short_help` is only shown in the help for the
*parent* command, and the actual help string defaults to `None`.   Other
subcommands also have this issue, so if this PR is accepted maybe we
should add help strings for them too.

Proposed output:

    $ pipenv run --help
    Usage: pipenv run [OPTIONS] COMMAND [ARGS]...

      Run a command inside the virtualenv. This makes all your installed
      packages available to the command.

    Options:
      --three / --two  Use Python 3/2 when creating virtualenv.
      --python TEXT    Specify which version of Python virtualenv should
    use.
      -h, --help       Show this message and exit.

and

    $ pipenv --help
    Usage: pipenv [OPTIONS] COMMAND [ARGS]...

    Options:
      [...]

    Commands:
      check      Checks for security vulnerabilities and against PEP 508
    markers
                 provided in Pipfile.
      graph      Displays currently–installed dependency graph information.
      install    Installs provided packages and adds them to Pipfile, or (if
    none
                 is given), installs all packages.
      lock       Generates Pipfile.lock.
      open       View a given module in your editor.
      run        Run a single command inside the virtualenv.
      shell      Spawns a shell within the virtualenv.
      uninstall  Un-installs a provided package and removes it from Pipfile.
      update     Uninstalls all packages, and re-installs package(s) in
    [packages]
                 to latest compatible versions.