### PR TITLE
fix windows os_name marker in doc advanced.rst

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -46,7 +46,7 @@ Here's an example ``Pipfile``, which will only install ``pywinusb`` on Windows s
 
     [packages]
     requests = "*"
-    pywinusb = {version = "*", os_name = "== 'windows'"}
+    pywinusb = {version = "*", platform_system = "== 'Windows'"}
 
 Voilà!
 


### PR DESCRIPTION
See https://docs.python.org/dev/library/platform.html#module-platform and https://docs.python.org/2/library/os.html#os.name

