### PR TITLE
Improve test & code clarity around requirements generation

### DIFF
--- a/pipenv/cli.py
+++ b/pipenv/cli.py
@@ -783,7 +783,7 @@ def do_install_dependencies(
     # Allow pip to resolve dependencies when in skip-lock mode.
     no_deps = (not skip_lock)
 
-    deps_list, dev_deps_list = merge_deps(
+    deps_list, requirements_deps_list = merge_deps(
         lockfile,
         project,
         dev=dev,
@@ -794,15 +794,8 @@ def do_install_dependencies(
     )
     failed_deps_list = []
     if requirements:
-        # Output only default dependencies
-        if not dev:
-            click.echo('\n'.join(d[0] for d in deps_list))
-            sys.exit(0)
-
-        # Output only dev dependencies
-        if dev:
-            click.echo('\n'.join(d[0] for d in dev_deps_list))
-            sys.exit(0)
+        click.echo('\n'.join(d[0] for d in requirements_deps_list))
+        sys.exit(0)
 
     procs = []
 

--- a/pipenv/utils.py
+++ b/pipenv/utils.py
@@ -1012,7 +1012,7 @@ def merge_deps(file_dict, project, dev=False, requirements=False, ignore_hashes=
         include_index = True if not suffix else False
         converted = convert_deps_to_pip(file_dict[section], project, r=False, include_index=include_index)
         deps.extend((d, no_hashes, block) for d in converted)
-        if dev and is_dev and requirements:
+        if requirements and dev == is_dev:
             requirements_deps.extend((d, no_hashes, block) for d in converted)
     return deps, requirements_deps
 

--- a/tests/test_pipenv.py
+++ b/tests/test_pipenv.py
@@ -795,7 +795,7 @@ pytest = "==3.1.1"
 
             req_list = ("requests==2.14.0", "flask==0.12.2")
 
-            dev_req_list = ("pytest==3.1.1")
+            dev_req_list = ("pytest==3.1.1",)
 
             c = p.pipenv('lock -r')
             d = p.pipenv('lock -r -d')
@@ -806,6 +806,7 @@ pytest = "==3.1.1"
                 assert req in c.out
 
             for req in dev_req_list:
+                assert req not in c.out
                 assert req in d.out
 
     @pytest.mark.lock


### PR DESCRIPTION
- Test now checks for dev dependency "pytest==3.1.1" rather than the
characters of the string
- Test verifies that dev dependencies are excluded by default
- Corrected intent of returned variables from merge_deps call in cli.py