### PR TITLE
WIP: Stop Treating Specifiers as Paths on Windows

### DIFF
--- a/pipenv/utils.py
+++ b/pipenv/utils.py
@@ -869,6 +869,16 @@ def is_installable_file(path):
         path = urlparse(path['file']).path if 'file' in path else path['path']
     if not isinstance(path, six.string_types) or path == '*':
         return False
+    # If the string starts with a valid specifier operator, test if it is a valid
+    # specifier set before making a path object (to avoid breakng windows)
+    if any(path.startswith(spec) for spec in '!=<>'):
+        try:
+            pip.utils.packaging.specifiers.SpecifierSet(path)
+        # If this is not a valid specifier, just move on and try it as a path
+        except pip.utils.packaging.specifiers.InvalidSpecifier:
+            pass
+        else:
+            return False
     lookup_path = Path(path)
     return lookup_path.is_file() or (lookup_path.is_dir() and
             pip.utils.is_installable_dir(lookup_path.resolve().as_posix()))

--- a/tests/test_pipenv.py
+++ b/tests/test_pipenv.py
@@ -434,7 +434,7 @@ setup(
 tablib = "<0.12"
                 """.strip()
                 f.write(contents)
-            c = p.pipenv(install)
+            c = p.pipenv('install')
             assert c.return_code == 0
             assert 'tablib' in p.pipfile['packages']
             assert 'tablib' in p.lockfile['default']

--- a/tests/test_pipenv.py
+++ b/tests/test_pipenv.py
@@ -424,6 +424,22 @@ setup(
             assert 'urllib3' in p.lockfile['default']
             assert 'certifi' in p.lockfile['default']
 
+    @pytest.mark.install
+    @pytest.mark.pin
+    def test_windows_pinned_pipfile(self):
+        with PipenvInstance() as p:
+            with open(p.pipfile_path, 'w') as f:
+                contents = """
+[packages]
+tablib = "<0.12"
+                """.strip()
+                f.write(contents)
+            c = p.pipenv(install)
+            assert c.return_code == 0
+            assert 'tablib' in p.pipfile['packages']
+            assert 'tablib' in p.lockfile['default']
+
+
     @pytest.mark.run
     @pytest.mark.install
     def test_multiprocess_bug_and_install(self):


### PR DESCRIPTION
- For some reason pipenv treats pipfile entries with leading specifiers as paths on windows
- Might want to add a fix for 9.0.1

- [x] Add failing test
- [x] Fix path checking for entries with leading specifiers

[![Build status](https://ci.appveyor.com/api/projects/status/a383f9obssqlucox/branch/bugfix/windows-specifier-check?svg=true)](https://ci.appveyor.com/project/techalchemy/pipenv/branch/bugfix/windows-specifier-check)