### PR TITLE
use current directory if project directory doesn't exist

### DIFF
--- a/pipenv/cli.py
+++ b/pipenv/cli.py
@@ -123,7 +123,10 @@ project = Project()
 
 def load_dot_env():
     if not PIPENV_DONT_LOAD_ENV:
-        denv = dotenv.find_dotenv(PIPENV_DOTENV_LOCATION or os.sep.join([project.project_directory, '.env']))
+        # If the project doesn't exist yet, check current directory for a .env file
+        project_directory = project.project_directory or '.'
+
+        denv = dotenv.find_dotenv(PIPENV_DOTENV_LOCATION or os.sep.join([project_directory, '.env']))
         if os.path.isfile(denv):
             click.echo(crayons.normal('Loading .env environment variables…', bold=True), err=True)
         dotenv.load_dotenv(denv, override=True)
@@ -2056,6 +2059,9 @@ def lock(three=None, python=False, verbose=False, requirements=False, dev=False,
 
 def do_shell(three=None, python=False, fancy=False, shell_args=None):
 
+    # Ensure that virtualenv is available.
+    ensure_project(three=three, python=python, validate=False)
+
     # Set an environment variable, so we know we're in the environment.
     os.environ['PIPENV_ACTIVE'] = '1'
 
@@ -2176,9 +2182,6 @@ def shell(three=None, python=False, fancy=False, shell_args=None, anyway=False):
             ), err=True)
 
             sys.exit(1)
-
-    # Ensure that virtualenv is available.
-    # ensure_project(three=three, python=python, validate=False)
 
     # Load .env file.
     load_dot_env()

--- a/pipenv/project.py
+++ b/pipenv/project.py
@@ -109,7 +109,10 @@ class Project(object):
 
     @property
     def project_directory(self):
-        return os.path.abspath(os.path.join(self.pipfile_location, os.pardir))
+        if self.pipfile_location is not None:
+            return os.path.abspath(os.path.join(self.pipfile_location, os.pardir))
+        else:
+            return None
 
     @property
     def requirements_exists(self):


### PR DESCRIPTION
#624 was partially reverted in ecbb386 without a solution to the closed issue. Ideally, we would have `project.project_directory` return the current directory if a `Pipfile` doesn't exist. I don't know what the implications of that will be though, and we're likely to introduce follow on issues mucking with it right now.

This should get us out the door for 9.0.1 without losing what #624 was trying to accomplish. I'd like a second pair of eyes to green light this before we merge.