### PR TITLE
Pass clear flag to lock when updating

### DIFF
--- a/pipenv/cli.py
+++ b/pipenv/cli.py
@@ -2550,7 +2550,7 @@ def update(ctx, dev=False, three=None, python=None, dry_run=False, bare=False, d
         do_purge()
 
         # Lock.
-        do_lock(pre=pre)
+        do_lock(clear=clear, pre=pre)
 
         # Install everything.
         do_init(dev=dev, verbose=verbose, concurrent=concurrent)


### PR DESCRIPTION
When updating all with the `--clear` flag, it isn't passed to the `do_lock` call, so the cache isn't actually cleared.
This PR fix this behavior.