### PR TITLE
Ignore virtualenvs created using pyenv-virtualenv

### DIFF
--- a/pipenv/cli.py
+++ b/pipenv/cli.py
@@ -402,6 +402,8 @@ def ensure_python(three=None, python=None):
                         os.sep
                     )
                 ):
+                    if os.path.islink(found):
+                        continue
                     pyenv_paths[os.path.split(found)[1]] = '{0}{1}bin'.format(found, os.sep)
 
                 for version_str, pyenv_path in pyenv_paths.items():


### PR DESCRIPTION
All virtualenvs created using pyenv-virtualenv plugin are created as a symbolic link in the version directory.
Ignoring this venvs will avoid the pipenv of create a venv from another venv.

```
$ ll ~/.pyenv/versions/
     inode Permissions Links Size Blocks User    Group Date Modified Name
  16519298 drwxr-xr-x      7    -      - robinho staff  2 Aug 15:58  2.7.13
  22839920 drwxr-xr-x      7    -      - robinho staff 17 Oct 19:24  2.7.14
  15102867 drwxr-xr-x      7    -      - robinho staff 13 Jul 14:40  3.6.1
  17745071 drwxr-xr-x      7    -      - robinho staff  4 Aug 20:15  3.6.2
  22832937 drwxr-xr-x      7    -      - robinho staff 13 Nov 16:37  3.6.3
  17781573 lrwxr-xr-x      1   49      0 robinho staff  4 Aug 20:15  crawler -> ~/.pyenv/versions/3.6.2/envs/crawler
  19263729 lrwxr-xr-x      1   54      0 robinho staff 29 Aug  9:44  kube-render -> ~/.pyenv/versions/2.7.13/envs/kube-render
8593489288 lrwxr-xr-x      1   49      0 robinho staff 13 Nov 16:37  neovim -> ~/.pyenv/versions/2.7.14/envs/neovim
8593487731 lrwxr-xr-x      1   49      0 robinho staff 13 Nov 16:37  neovim3 -> ~/.pyenv/versions/3.6.3/envs/neovim3
  24778496 lrwxr-xr-x      1   53      0 robinho staff 18 Oct 21:54  prometheus -> ~/.pyenv/versions/2.7.14/envs/prometheus
  21001387 lrwxr-xr-x      1   50      0 robinho staff 19 Sep 16:58  tornado -> ~/.pyenv/versions/2.7.13/envs/tornado
```