### PR TITLE
Fix: quote src for safer handling

### DIFF
--- a/pipenv/cli.py
+++ b/pipenv/cli.py
@@ -1350,7 +1350,7 @@ def pip_install(
 
         # Don't specify a source directory when using --system.
         if not allow_global and ('PIP_SRC' not in os.environ):
-            src = '--src {0}'.format(project.virtualenv_src_location)
+            src = '--src "{0}"'.format(project.virtualenv_src_location)
         else:
             src = ''
     else:


### PR DESCRIPTION
Wrap the `src` path in quotes for safer handling of paths that include special characters (discovered when using a path that contained parens).