### PR TITLE
Clean up temporary files created during installation

### DIFF
--- a/pipenv/utils.py
+++ b/pipenv/utils.py
@@ -462,13 +462,12 @@ def actually_resolve_reps(deps, index_lookup, markers_lookup, project, sources, 
     constraints = []
 
     for dep in deps:
-        t = tempfile.mkstemp(prefix='pipenv-', suffix='-requirement.txt')[1]
-        with open(t, 'w') as f:
-            f.write(dep)
-
         if dep.startswith('-e '):
             constraint = pip.req.InstallRequirement.from_editable(dep[len('-e '):])
         else:
+            t = tempfile.mkstemp(prefix='pipenv-', suffix='-requirement.txt')[1]
+            with open(t, 'w') as f:
+                f.write(dep)
             constraint = [c for c in pip.req.parse_requirements(t, session=pip._vendor.requests)][0]
 
         if ' -i ' in dep:

--- a/pipenv/utils.py
+++ b/pipenv/utils.py
@@ -470,7 +470,6 @@ def actually_resolve_reps(deps, index_lookup, markers_lookup, project, sources, 
             constraint = pip.req.InstallRequirement.from_editable(dep[len('-e '):])
         else:
             constraint = [c for c in pip.req.parse_requirements(t, session=pip._vendor.requests)][0]
-            # extra_constraints = []
 
         if ' -i ' in dep:
             index_lookup[constraint.name] = project.get_source(url=dep.split(' -i ')[1]).get('name')

--- a/pipenv/utils.py
+++ b/pipenv/utils.py
@@ -466,9 +466,12 @@ def actually_resolve_reps(deps, index_lookup, markers_lookup, project, sources, 
             constraint = pip.req.InstallRequirement.from_editable(dep[len('-e '):])
         else:
             t = tempfile.mkstemp(prefix='pipenv-', suffix='-requirement.txt')[1]
-            with open(t, 'w') as f:
-                f.write(dep)
-            constraint = [c for c in pip.req.parse_requirements(t, session=pip._vendor.requests)][0]
+            try:
+                with open(t, 'w') as f:
+                    f.write(dep)
+                constraint = [c for c in pip.req.parse_requirements(t, session=pip._vendor.requests)][0]
+            finally:
+                os.remove(t)
 
         if ' -i ' in dep:
             index_lookup[constraint.name] = project.get_source(url=dep.split(' -i ')[1]).get('name')

--- a/tests/test_legacy.py
+++ b/tests/test_legacy.py
@@ -25,7 +25,7 @@ class TestPipenv():
         second_cmd_return = Mock()
         second_cmd_return.return_code = 0
         mocked_delegator.side_effect = [first_cmd_return, second_cmd_return]
-        c = pip_install('package')
+        c, _ = pip_install('package')
         assert c.return_code == 0
 
     @patch('pipenv.project.Project.sources', new_callable=PropertyMock)
@@ -41,7 +41,7 @@ class TestPipenv():
         second_cmd_return = Mock()
         second_cmd_return.return_code = 1
         mocked_delegator.side_effect = [first_cmd_return, second_cmd_return]
-        c = pip_install('package')
+        c, _ = pip_install('package')
         assert c.return_code == 1
         assert c == second_cmd_return
 
@@ -58,7 +58,7 @@ class TestPipenv():
         second_cmd_return = Mock()
         second_cmd_return.return_code = 0
         mocked_delegator.side_effect = [first_cmd_return, second_cmd_return]
-        c = pip_install('package')
+        c, _ = pip_install('package')
         assert c.return_code == 0
         assert c == first_cmd_return
 

--- a/tests/test_pipenv.py
+++ b/tests/test_pipenv.py
@@ -28,6 +28,10 @@ class PipenvInstance():
         self.pipfile_path = None
         self.chdir = chdir
 
+        self.tmpdir = os.path.join(self.path, 'tmp')
+        os.mkdir(self.tmpdir)
+        self._before_tmpdir = None
+
         if pipfile:
             p_path = os.sep.join([self.path, 'Pipfile'])
             with open(p_path, 'a'):
@@ -39,11 +43,18 @@ class PipenvInstance():
     def __enter__(self):
         if self.chdir:
             os.chdir(self.path)
+        self._before_tmpdir = os.environ.pop('TMPDIR', None)
+        os.environ['TMPDIR'] = self.tmpdir
         return self
 
     def __exit__(self, *args):
         if self.chdir:
             os.chdir(self.original_dir)
+
+        if self._before_tmpdir is None:
+            del os.environ['TMPDIR']
+        else:
+            os.environ['TMPDIR'] = self._before_tmpdir
 
         shutil.rmtree(self.path)
 

--- a/tests/test_pipenv.py
+++ b/tests/test_pipenv.py
@@ -28,8 +28,7 @@ class PipenvInstance():
         self.pipfile_path = None
         self.chdir = chdir
 
-        self.tmpdir = os.path.join(self.path, 'tmp')
-        os.mkdir(self.tmpdir)
+        self.tmpdir = None
         self._before_tmpdir = None
 
         if pipfile:
@@ -44,6 +43,7 @@ class PipenvInstance():
         if self.chdir:
             os.chdir(self.path)
         self._before_tmpdir = os.environ.pop('TMPDIR', None)
+        self.tmpdir = tempfile.mkdtemp(suffix='tmp', prefix='pipenv')
         os.environ['TMPDIR'] = self.tmpdir
         return self
 
@@ -56,6 +56,7 @@ class PipenvInstance():
         else:
             os.environ['TMPDIR'] = self._before_tmpdir
 
+        shutil.rmtree(self.tmpdir)
         shutil.rmtree(self.path)
 
     def pipenv(self, cmd, block=True):

--- a/tests/test_pipenv.py
+++ b/tests/test_pipenv.py
@@ -435,6 +435,7 @@ setup(
             assert 'idna' in p.lockfile['default']
             assert 'urllib3' in p.lockfile['default']
             assert 'certifi' in p.lockfile['default']
+            assert os.listdir(p.tmpdir) == []
 
     @pytest.mark.install
     @pytest.mark.pin

--- a/tests/test_pipenv.py
+++ b/tests/test_pipenv.py
@@ -455,6 +455,25 @@ tablib = "<0.12"
 
     @pytest.mark.run
     @pytest.mark.install
+    def test_install_doesnt_leave_tmpfiles(self):
+        with temp_environ():
+            os.environ['PIPENV_MAX_SUBPROCESS'] = '2'
+
+            with PipenvInstance() as p:
+                with open(p.pipfile_path, 'w') as f:
+                    contents = """
+[packages]
+records = "*"
+                    """.strip()
+                    f.write(contents)
+
+                c = p.pipenv('install')
+                assert c.return_code == 0
+                assert os.listdir(p.tmpdir) == []
+
+
+    @pytest.mark.run
+    @pytest.mark.install
     def test_multiprocess_bug_and_install(self):
         with temp_environ():
             os.environ['PIPENV_MAX_SUBPROCESS'] = '2'


### PR DESCRIPTION
At the moment, pipenv will create a temporary file per non-leaf package during dependency resolution, and one per resolved package during installation.

This PR adds cleanup to those two cases, and a test to ensure that no temporary artifacts remain after installation.