### PR TITLE
Don't shellquote backup Python executable

### DIFF
--- a/pipenv/utils.py
+++ b/pipenv/utils.py
@@ -516,7 +516,7 @@ def actually_resolve_reps(deps, index_lookup, markers_lookup, project, sources, 
             ),
             err=True)
 
-        click.echo(crayons.blue(e))
+        click.echo(crayons.blue(str(e)))
 
         if 'no version found at all' in str(e):
             click.echo(crayons.blue('Please check your version specifier and version number. See PEP440 for more information.'))

--- a/pipenv/utils.py
+++ b/pipenv/utils.py
@@ -535,7 +535,7 @@ def resolve_deps(deps, which, which_pip, project, sources=None, verbose=False, p
     markers_lookup = {}
 
     python_path = which('python', allow_global=allow_global)
-    backup_python_path = shellquote(sys.executable)
+    backup_python_path = sys.executable
 
     results = []
 

--- a/tests/test_pipenv.py
+++ b/tests/test_pipenv.py
@@ -450,8 +450,12 @@ tablib = "<0.12"
             with open(p.pipfile_path, 'w') as f:
                 contents = """
 [packages]
-requests = {git = "https://github.com/requests/requests.git", editable = true}
-"oslo.utils" = "==1.4.0"
+pypa-docs-theme = {git = "https://github.com/pypa/pypa-docs-theme", editable = true}
+
+# This version of requests depends on idna<2.6, forcing dependency resolution
+# failure
+requests = "==2.16.0"
+idna = "==2.6.0"
                 """.strip()
                 f.write(contents)
             c = p.pipenv('install')

--- a/tests/test_pipenv.py
+++ b/tests/test_pipenv.py
@@ -440,6 +440,26 @@ tablib = "<0.12"
             assert 'tablib' in p.lockfile['default']
 
 
+    @pytest.mark.e
+    @pytest.mark.install
+    @pytest.mark.vcs
+    @pytest.mark.resolver
+    def test_editable_vcs_install_in_pipfile_with_dependency_resolution_doesnt_traceback(self):
+        # See https://github.com/pypa/pipenv/issues/1240
+        with PipenvInstance() as p:
+            with open(p.pipfile_path, 'w') as f:
+                contents = """
+[packages]
+requests = {git = "https://github.com/requests/requests.git", editable = true}
+"oslo.utils" = "==1.4.0"
+                """.strip()
+                f.write(contents)
+            c = p.pipenv('install')
+            assert c.return_code == 1
+            assert 'FileNotFoundError' not in c.out
+            assert 'FileNotFoundError' not in c.err
+
+
     @pytest.mark.run
     @pytest.mark.install
     def test_multiprocess_bug_and_install(self):

--- a/tests/test_pipenv.py
+++ b/tests/test_pipenv.py
@@ -456,8 +456,8 @@ requests = {git = "https://github.com/requests/requests.git", editable = true}
                 f.write(contents)
             c = p.pipenv('install')
             assert c.return_code == 1
-            assert 'FileNotFoundError' not in c.out
-            assert 'FileNotFoundError' not in c.err
+            assert "Your dependencies could not be resolved" in c.err
+            assert 'Traceback' not in c.err
 
 
     @pytest.mark.run


### PR DESCRIPTION
This fixes #1240.

The shellquote call was added for every platform in https://github.com/pypa/pipenv/commit/908b41df75f6306a427a198d506b3b5f9ebef676, but this won't work on, at least, Linux. I've taken an educated guess at this being required on Windows as the subprocess module has [documentation explaining how Windows argument sequences are treated differently](https://docs.python.org/2/library/subprocess.html#converting-argument-sequence).

I don't have access to a Windows environment, so I can't confirm whether or not my supposition is correct.