### PR TITLE
Fix ensure_project bug on windows when missing pipfile

### DIFF
--- a/pipenv/utils.py
+++ b/pipenv/utils.py
@@ -1185,7 +1185,7 @@ def normalize_drive(path):
 
     See: <https://github.com/pypa/pipenv/issues/1218>
     """
-    if os.name != 'nt':
+    if os.name != 'nt' or not isinstance(path, six.string_types):
         return path
     drive, tail = os.path.splitdrive(path)
     # Only match (lower cased) local drives (e.g. 'c:'), not UNC mounts.

--- a/tests/test_pipenv.py
+++ b/tests/test_pipenv.py
@@ -8,7 +8,7 @@ import json
 import pytest
 
 from pipenv.cli import activate_virtualenv
-from pipenv.utils import temp_environ, get_windows_path, mkdir_p
+from pipenv.utils import temp_environ, get_windows_path, mkdir_p, normalize_drive
 from pipenv.vendor import toml
 from pipenv.vendor import delegator
 from pipenv.project import Project
@@ -84,7 +84,7 @@ class TestPipenv:
     @pytest.mark.cli
     def test_pipenv_where(self):
         with PipenvInstance() as p:
-            assert p.path in p.pipenv('--where').out
+            assert normalize_drive(p.path) in p.pipenv('--where').out
 
     @pytest.mark.cli
     def test_pipenv_venv(self):
@@ -652,7 +652,7 @@ requests = {version = "*"}
                 c = p.pipenv('install requests')
                 assert c.return_code == 0
 
-                assert p.path in p.pipenv('--venv').out
+                assert normalize_drive(p.path) in p.pipenv('--venv').out
 
     @pytest.mark.dotvenv
     @pytest.mark.install
@@ -682,7 +682,7 @@ requests = {version = "*"}
                 # Compare pew's virtualenv path to what we expect
                 venv_path = get_windows_path(project.project_directory, '.venv')
                 # os.path.normpath will normalize slashes
-                assert venv_path == os.path.normpath(c.out.strip())
+                assert venv_path == normalize_drive(os.path.normpath(c.out.strip()))
                 # Have pew run 'pip freeze' in the virtualenv
                 # This is functionally the same as spawning a subshell
                 # If we can do this we can theoretically amke a subshell


### PR DESCRIPTION
- New bug introduced by #1221 throws an error when running `pipenv install` on windows in a directory with no pipfile
- This also updates the relevant tests to normalize paths for assertions to pass on appveyor
- I just set up my own appveyor with a webhook so test failures caught this


`Project.pipfile_location` is calling `utils.normalize_drive(loc)` even when `loc = None`, which throws the following error:

```python
File "C:\projects\pipenv-jqd6x\pipenv\cli.py", line 1766, in install
    ensure_project(three=three, python=python, system=system, warn=True, deploy=deploy)
  File "C:\projects\pipenv-jqd6x\pipenv\cli.py", line 607, in ensure_project
    if not project.pipfile_exists:
  File "C:\projects\pipenv-jqd6x\pipenv\project.py", line 99, in pipfile_exists
    return bool(self.pipfile_location)
  File "C:\projects\pipenv-jqd6x\pipenv\project.py", line 227, in pipfile_location
    self._pipfile_location = normalize_drive(loc)
  File "C:\projects\pipenv-jqd6x\pipenv\utils.py", line 1200, in normalize_drive
    drive, tail = os.path.splitdrive(path)
  File "c:\python27-x64\lib\ntpath.py", line 115, in splitdrive
    if len(p) > 1:
TypeError: object of type 'NoneType' has no len()
```