### PR TITLE
[WIP] Refactor Python lookups and Add PEP 512 Finder for Windows

### DIFF
--- a/pipenv/pythonfinders/__init__.py
+++ b/pipenv/pythonfinders/__init__.py
@@ -1,0 +1,77 @@
+# -*- coding: utf-8 -*-
+
+import click
+import crayons
+
+from pip._vendor.packaging.version import parse as parse_version, Version
+
+from pipenv.environments import (
+    PIPENV_DONT_USE_PYENV, PIPENV_YES, PYENV_INSTALLED,
+    SESSION_IS_INTERACTIVE,
+)
+
+from . import pathname
+
+
+class PythonInstallationNotFoundError(Exception):
+    """Raised when a Python installation is not found on the current system.
+    """
+
+
+def iter_finders():
+    if PYENV_INSTALLED:
+        from . import pyenv
+        yield pyenv
+    yield pathname
+
+
+def confirm_install(prompt):
+    if PIPENV_YES:
+        return True
+    return click.confirm(prompt, default=True)
+
+
+def find_python(name, try_to_install=True):
+    version = parse_version(name)
+    if not isinstance(version, Version):    # Only support X[.Y[.Z]] schemes.
+        raise PythonInstallationNotFoundError(name)
+    for finder in iter_finders():
+        try:
+            find = finder.find_python
+        except AttributeError:
+            continue
+        python = find(version)
+        if python:
+            return python
+
+    if name is None or PIPENV_DONT_USE_PYENV or not SESSION_IS_INTERACTIVE:
+        raise PythonInstallationNotFoundError(name)
+
+    # We need to install Python.
+    click.echo(
+        u'{0}: Python {1} {2}'.format(
+            crayons.red('Warning', bold=True),
+            crayons.blue(name),
+            u'was not found on your system…',
+        ), err=True
+    )
+    for finder in iter_finders():
+        try:
+            install = finder.install_python
+        except AttributeError:
+            continue
+        if not install(name, user_confirm=confirm_install):
+            continue
+
+        # Try again if the installation works.
+        try:
+            return find_python(name, try_to_install=False)
+        except PythonInstallationNotFoundError:
+            click.echo(
+                '{0}: The Python you just installed cannot be located.'.format(
+                    crayons.red('Warning', bold=True),
+                ), err=True
+            )
+            raise
+
+    raise PythonInstallationNotFoundError(name)

--- a/pipenv/pythonfinders/base.py
+++ b/pipenv/pythonfinders/base.py
@@ -1,0 +1,10 @@
+from pip._vendor.packaging.version import Version
+
+
+def match_version(target, candidate):
+    target_release = target._key[1]
+    return (
+        isinstance(candidate, Version) and
+        not candidate.is_prerelease and
+        candidate._key[1][:len(target_release)] == target_release
+    )

--- a/pipenv/pythonfinders/pathname.py
+++ b/pipenv/pythonfinders/pathname.py
@@ -1,0 +1,33 @@
+import os
+
+from pip._vendor.packaging.version import parse as parse_version
+from pipenv.utils import python_version, system_which
+
+from .base import match_version
+
+
+def iter_python_names(release):
+    names = [
+        'python',
+        'python{0}'.format(*release)
+    ]
+    if len(release) > 1:
+        names.extend([
+            'python{0}{1}'.format(*release),
+            'python{0}.{1}'.format(*release),
+            'python{0}.{1}m'.format(*release),
+        ])
+    for name in reversed(names):
+        for ext in os.environ.get('PATHEXT', '').split(';'):
+            if ext:
+                yield '{stem}.{ext}'.format(stem=name, ext=ext)
+            else:
+                yield name
+
+
+def find_python(version):
+    for exe_name in iter_python_names(version._key[1]):
+        full_path = system_which(exe_name)
+        exe_ver_s = python_version(full_path)
+        if exe_ver_s and match_version(version, parse_version(exe_ver_s)):
+            return full_path

--- a/pipenv/pythonfinders/pyenv.py
+++ b/pipenv/pythonfinders/pyenv.py
@@ -1,0 +1,101 @@
+# -*- coding: utf-8 -*-
+
+import os
+
+import blindspin
+import click
+import crayons
+import delegator
+
+from pip._vendor.packaging.version import parse as parse_version
+from pipenv.environments import PIPENV_INSTALL_TIMEOUT, PYENV_ROOT
+
+from .base import match_version
+
+
+def find_python(version):
+    versions_dir = os.path.join(PYENV_ROOT, 'versions')
+    if os.path.isdir(versions_dir):
+        versions = (
+            v for v in (parse_version(n) for n in os.listdir(versions_dir))
+            if match_version(version, v)
+        )
+    else:
+        click.echo(
+            '{0}: PYENV_ROOT is not set. New Python paths will '
+            'probably not be exported properly after installation.'
+            ''.format(crayons.red('Warning', bold=True)),
+            err=True,
+        )
+        versions = []
+    try:
+        best = max(versions)
+    except ValueError:
+        pass
+    else:
+        return os.path.join(versions_dir, best.base_version, 'bin', 'python')
+
+
+def install_python(name, user_confirm):
+    version_map = {
+        # TODO: Keep this up to date!
+        # These versions appear incompatible with pew:
+        # '2.5': '2.5.6',
+        '2.6': '2.6.9',
+        '2.7': '2.7.14',
+        # '3.1': '3.1.5',
+        # '3.2': '3.2.6',
+        '3.3': '3.3.7',
+        '3.4': '3.4.7',
+        '3.5': '3.5.4',
+        '3.6': '3.6.4',
+    }
+    try:
+        if len(name.split('.')) == 2:
+            # Find the latest version of Python available.
+            version = version_map[name]
+        else:
+            version = name
+    except KeyError:
+        return False
+
+    # Prompt the user to continue...
+    ok = user_confirm('{0} {1} {2}'.format(
+        'Would you like us to install',
+        crayons.green('CPython {0}'.format(version)),
+        'with pyenv?',
+    ))
+    if not ok:
+        return False
+
+    # Tell the user we're installing Python.
+    click.echo(
+        u'{0} {1} {2} {3}{4}'.format(
+            crayons.normal(u'Installing', bold=True),
+            crayons.green(u'CPython {0}'.format(version), bold=True),
+            crayons.normal(u'with pyenv', bold=True),
+            crayons.normal(u'(this may take a few minutes)'),
+            crayons.normal(u'…', bold=True)
+        )
+    )
+
+    with blindspin.spinner():
+        # Install Python.
+        c = delegator.run(
+            'pyenv install {0} -s'.format(version),
+            timeout=PIPENV_INSTALL_TIMEOUT,
+            block=False
+        )
+
+        # Wait until the process has finished...
+        c.block()
+
+        if c.return_code != 0:
+            click.echo(u'Something went wrong…')
+            click.echo(crayons.blue(c.err), err=True)
+            return False
+
+        # Print the results, in a beautiful blue...
+        click.echo(crayons.blue(c.out), err=True)
+
+    return True

--- a/pipenv/utils.py
+++ b/pipenv/utils.py
@@ -1197,3 +1197,31 @@ def normalize_drive(path):
     if drive.islower() and len(drive) == 2 and drive[1] == ':':
         return '{}{}'.format(drive.upper(), tail)
     return path
+
+
+def system_which(command, mult=False):
+    """Emulates the system's which. Returns None if not found."""
+
+    _which = 'which -a' if not os.name == 'nt' else 'where'
+
+    c = delegator.run('{0} {1}'.format(_which, command))
+    try:
+        # Which Not found...
+        if c.return_code == 127:
+            click.echo(
+                '{}: the {} system utility is required for Pipenv to find Python installations properly.'
+                '\n  Please install it.'.format(
+                    crayons.red('Warning', bold=True),
+                    crayons.red(_which)
+                ), err=True
+            )
+        assert c.return_code == 0
+    except AssertionError:
+        return None if not mult else []
+
+    result = c.out.strip() or c.err.strip()
+
+    if mult:
+        return result.split('\n')
+    else:
+        return result.split('\n')[0]


### PR DESCRIPTION
Tries to kickstart #1150

* Move system_which() to utils so the finders can use it.
* Find pyenv versions with a different method. Instead of adding them all into PATH, resolve their names directly to find a best match.
* Install the finders into pipenv.pythonfinders based on environment configuration. Currently this simply install pyenv if available, and then the PATH lookup (always).
* Implement PEP 512 finder on Windows.
* Move automatic pyenv installation into the finder submodule.

TODO:

* Add tests for finders.
  