### PR TITLE
pipenv update fails if freeze output contains comments

### DIFF
--- a/pipenv/cli.py
+++ b/pipenv/cli.py
@@ -1207,7 +1207,9 @@ def do_purge(bare=False, downloads=False, allow_global=False, verbose=False):
         return
 
     freeze = delegator.run('"{0}" freeze'.format(which_pip(allow_global=allow_global))).out
-    installed = freeze.split()
+    
+    # Remove comments from the output, if any.
+    installed = [line for line in freeze.splitlines() if not line.lstrip().startswith('#')]
 
     # Remove setuptools and friends from installed, if present.
     for package_name in BAD_PACKAGES:


### PR DESCRIPTION
If the output of ``pip freeze`` contains comments (e. g. a line like ``## !! Could not determine repository location``), then the ``pipenv update`` command fails when it tries to parse the requirements:

````
(project-cIS5-zzV) bash-3.2$ pipenv update -d
Updating all dependencies from Pipfile…
Traceback (most recent call last):
  File "/.local/bin/pipenv", line 11, in <module>
    sys.exit(cli())
  File "/.local/venvs/pipenv/lib/python3.6/site-packages/pipenv/vendor/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/.local/venvs/pipenv/lib/python3.6/site-packages/pipenv/vendor/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/.local/venvs/pipenv/lib/python3.6/site-packages/pipenv/vendor/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/.local/venvs/pipenv/lib/python3.6/site-packages/pipenv/vendor/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/.local/venvs/pipenv/lib/python3.6/site-packages/pipenv/vendor/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/.local/venvs/pipenv/lib/python3.6/site-packages/pipenv/vendor/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/.local/venvs/pipenv/lib/python3.6/site-packages/pipenv/cli.py", line 2559, in update
    do_purge()
  File "/.local/venvs/pipenv/lib/python3.6/site-packages/pipenv/cli.py", line 1230, in do_purge
    dep = convert_deps_from_pip(package)
  File "/.local/venvs/pipenv/lib/python3.6/site-packages/pipenv/utils.py", line 624, in convert_deps_from_pip
    req = get_requirement(dep)
  File "/.local/venvs/pipenv/lib/python3.6/site-packages/pipenv/utils.py", line 311, in get_requirement
    req = [r for r in requirements.parse(dep)][0]
IndexError: list index out of range
````

It tries to make sense of the ``##`` "requirement", which fails.

This commit adds a simple fix to ignore comments in the ``pip freeze`` output.