### PR TITLE
Add a reference to a 3rd party plugin for tox

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -382,8 +382,11 @@ and external testing::
 .. note:: With Pipenv's default configuration, you'll need to use tox's ``passenv`` parameter
           to pass your shell's ``HOME`` variable.
 
+A 3rd party plugin, `tox-pipenv`_ is also available to use Pipenv natively with tox.
+
 .. _Requests: https://github.com/kennethreitz/requests
 .. _tox: https://tox.readthedocs.io/en/latest/
+.. _tox-pipenv: https://tox-pipenv.readthedocs.io/en/latest/
 .. _Travis-CI: https://travis-ci.org/
 
 ☤ Shell Completion


### PR DESCRIPTION
For those wanting to use/migrate to pipenv, the question of how to use Tox comes up.

Worked on a plugin for Tox that will just use pipenv instead of virtualenv and pip. 

This is an update to the docs to redirect people there. Since this is not related or supported by PyPa, it's referenced as 3rd party.