### PR TITLE
Fix uninstall package error in verbose mode

### DIFF
--- a/pipenv/cli.py
+++ b/pipenv/cli.py
@@ -1995,14 +1995,13 @@ def uninstall(
             crayons.green(package_name))
         )
 
-        cmd = '"{0}" uninstall {1} -y'
+        command = '"{0}" uninstall {1} -y'.format(
+            which_pip(allow_global=system), package_name
+        )
         if verbose:
-            click.echo('$ {0}').format(cmd)
+            click.echo('$ {0}'.format(command))
 
-        c = delegator.run(cmd.format(
-            which_pip(allow_global=system),
-            package_name
-        ))
+        c = delegator.run(command)
 
         click.echo(crayons.blue(c.out))
 


### PR DESCRIPTION
When i uninstall the package in verbose mode, pipenv throws the following error:

```bash
❯ pipenv uninstall --verbose elasticsearch-dsl
Courtesy Notice: Pipenv found itself running within a virtual environment, so it will automatically use that environment, instead of creating its own for any project.
Un-installing elasticsearch-dsl…
$ {0}
Traceback (most recent call last):
  File "/Users/dongweiming/avalon/venv/bin/pipenv", line 11, in <module>
    load_entry_point('pipenv', 'console_scripts', 'pipenv')()
  File "/Users/dongweiming/pipenv/pipenv/vendor/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/Users/dongweiming/pipenv/pipenv/vendor/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/Users/dongweiming/pipenv/pipenv/vendor/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/dongweiming/pipenv/pipenv/vendor/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/dongweiming/pipenv/pipenv/vendor/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/Users/dongweiming/pipenv/pipenv/cli.py", line 2002, in uninstall
    click.echo('$ {0}').format(cmd)
AttributeError: 'NoneType' object has no attribute 'format'
```