### PR TITLE
Updates cli.py with proper requirements filename

### DIFF
--- a/pipenv/cli.py
+++ b/pipenv/cli.py
@@ -307,7 +307,7 @@ def ensure_pipfile(validate=True):
 
         # If there's a requirements file, but no Pipfile...
         if project.requirements_exists:
-            click.echo(crayons.normal(u'Requirements.txt found, instead of Pipfile! Converting…', bold=True))
+            click.echo(crayons.normal(u'requirements.txt found, instead of Pipfile! Converting…', bold=True))
 
             # Create a Pipfile...
             python = which('python') if not USING_DEFAULT_PYTHON else False


### PR DESCRIPTION
In some systems `Requirements.txt` != `requirements.txt` and this line could possibly bring confusion to users.
Since we are only searching for actual `requirements.txt` in `find_requirements()`: https://github.com/pypa/pipenv/blob/cbcc89bee73e5af2e34252deb686ad7578e14c61/pipenv/utils.py#L1121