### PR TITLE
Upload wheel

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -7,6 +7,7 @@ sphinx = "<=1.5.5"
 twine = "*"
 sphinx-click = "*"
 pytest-xdist = "*"
+wheel = "*"
 
 
 [packages]

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ class UploadCommand(Command):
             pass
 
         self.status('Building Source distribution…')
-        os.system('{0} setup.py sdist'.format(sys.executable))
+        os.system('{0} setup.py sdist bdist_wheel'.format(sys.executable))
 
         self.status('Uploading the package to PyPi via Twine…')
         os.system('twine upload dist/*')


### PR DESCRIPTION
When installing from source package, `pipenv` script imports `pkg_resources` and
it makes the command startup slower. ([ref](https://dev.to/methane/how-to-speed-up-python-application-startup-time-nkf))

Uploading wheel package to PyPI will save many people from  this pitfall.