### PR TITLE
Fix backup resolver

### DIFF
--- a/pipenv/utils.py
+++ b/pipenv/utils.py
@@ -523,7 +523,8 @@ def actually_resolve_reps(deps, index_lookup, markers_lookup, project, sources, 
 
         raise RuntimeError
 
-    return resolved_tree
+    return resolved_tree, resolver
+
 
 def resolve_deps(deps, which, which_pip, project, sources=None, verbose=False, python=False, clear=False, pre=False):
     """Given a list of dependencies, return a resolved list of dependencies,
@@ -542,7 +543,7 @@ def resolve_deps(deps, which, which_pip, project, sources=None, verbose=False, p
     with HackedPythonVersion(python_version=python, python_path=python_path):
 
         try:
-            resolved_tree = actually_resolve_reps(deps, index_lookup, markers_lookup, project, sources, verbose, clear, pre)
+            resolved_tree, resolver = actually_resolve_reps(deps, index_lookup, markers_lookup, project, sources, verbose, clear, pre)
         except RuntimeError:
             # Don't exit here, like usual.
             resolved_tree = None
@@ -554,10 +555,9 @@ def resolve_deps(deps, which, which_pip, project, sources=None, verbose=False, p
             try:
                 # Attempt to resolve again, with different Python version information,
                 # particularly for particularly particular packages.
-                resolved_tree = actually_resolve_reps(deps, index_lookup, markers_lookup, project, sources, verbose, clear, pre)
+                resolved_tree, resolver = actually_resolve_reps(deps, index_lookup, markers_lookup, project, sources, verbose, clear, pre)
             except RuntimeError:
                 sys.exit(1)
-
 
 
     for result in resolved_tree:

--- a/tests/test_pipenv.py
+++ b/tests/test_pipenv.py
@@ -498,6 +498,23 @@ tpfd = "*"
             c = p.pipenv('run python -c "import requests; import idna; import certifi; import records; import tpfd; import parse;"')
             assert c.return_code == 0
 
+    @pytest.mark.install
+    @pytest.mark.resolver
+    @pytest.mark.backup_resolver
+    def test_backup_resolver(self):
+        with PipenvInstance() as p:
+            with open(p.pipfile_path, 'w') as f:
+                contents = """
+[packages]
+"ibm-db-sa-py3" = "==0.3.1-1"
+                """.strip()
+                f.write(contents)
+
+            c = p.pipenv('install')
+            assert c.return_code == 0
+            assert 'ibm-db-sa-py3' in p.lockfile['default']
+
+
     @pytest.mark.sequential
     @pytest.mark.install
     @pytest.mark.update


### PR DESCRIPTION
Re-merge of  #1200

- Backup resolver was broken when hash resolution was split out into two
functions
- This PR returns the resolver to the caller function
- This is for edge cases where the PyPI json API and the pip resolver
don't return the same authoritative result for a package lookup (a name
can be resolved in one source but not the other)
- Added test to prevent future regression
- Fixes #1195