### PR TITLE
Fix "update" command casing problem

### DIFF
--- a/pipenv/cli.py
+++ b/pipenv/cli.py
@@ -2565,16 +2565,16 @@ def update(ctx, dev=False, three=None, python=None, dry_run=False, bare=False, d
             crayons.green('All dependencies are now up-to-date!')
         )
     else:
+        norm_name = pep423_name(package_name)
 
-        if package_name in project.all_packages:
-
+        if norm_name in project.all_packages:
             click.echo(
                 u'Uninstalling {0}…'.format(
-                    crayons.green(package_name)
+                    crayons.green(norm_name)
                 )
             )
 
-            cmd = '"{0}" uninstall {1} -y'.format(which_pip(), package_name)
+            cmd = '"{0}" uninstall {1} -y'.format(which_pip(), norm_name)
             c = delegator.run(cmd)
 
             try:
@@ -2584,13 +2584,13 @@ def update(ctx, dev=False, three=None, python=None, dry_run=False, bare=False, d
                 click.echo(crayons.blue(c.err))
                 # sys.exit(1)
 
-            p_name = convert_deps_to_pip({package_name: project.all_packages[package_name]}, r=False)
+            p_name = convert_deps_to_pip({norm_name: project.all_packages[norm_name]}, r=False)
             ctx.invoke(install, package_name=p_name[0])
 
         else:
             click.echo(
                 '{0} was not found in your {1}!'.format(
-                    crayons.green(package_name),
+                    crayons.green(norm_name),
                     crayons.normal('Pipfile', bold=True)
                 )
             )

--- a/pipenv/project.py
+++ b/pipenv/project.py
@@ -357,8 +357,8 @@ class Project(object):
     @property
     def all_packages(self):
         """Returns a list of all packages."""
-        p = dict(self.parsed_pipfile.get('dev-packages', {}))
-        p.update(self.parsed_pipfile.get('packages', {}))
+        p = dict(self._pipfile.get('dev-packages', {}))
+        p.update(self._pipfile.get('packages', {}))
         return p
 
     @property


### PR DESCRIPTION
Closes #1316 

- `all_packages` method now retrieves data from `_pipfile`, rather than `_parsed_pipfile`, which normalizes all package names from `_parsed_pipfile`
- `update` method now transforms `package_name` into normalized one and then uses it for building response messages and removing/instaslling package

Modifiyng `all_packages` method should not cause any problems, because it is used literally in two places and both of them are in `update` method.

Actually, with these changes done to `all_packages` method, it can be also used in `uninstall` command, but probably you need to check healthiness of this PR first.