### PR TITLE
Fix installation dead links with good RST linkage

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -57,9 +57,9 @@ Pipenv is a python package and so can be installed using ``pip`` as you would ex
 If you have excellent taste, there are various other installation methods which
 prevent pipenv and its dependencies from interfering with the rest of your
 Python installation. These include
-`Pipsi <https://docs.pipenv.org/install.html#fancy-installation-of-pipenv>`_,
-`Nix <https://docs.pipenv.org/install.html#referentially-transparent-installation-of-pipenv>`_
-and `Homebrew <https://docs.pipenv.org/install.html#homebrew-installation-of-pipenv>`_.
+:ref:`Pipsi <proper_installation>`,
+:ref:`Nix <more_proper_installation>`
+and :ref:`Homebrew <homebrew_installation>`.
 
 .. toctree::
    :maxdepth: 2

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -253,7 +253,7 @@ To upgrade pipenv at any time::
 
     $ pip install --user --upgrade pipenv
 
-.. _crude_installation:
+.. _homebrew_installation:
 
 ☤ Homebrew Installation of Pipenv
 =================================
@@ -271,6 +271,8 @@ Once you have installed `Homebrew <https://brew.sh/>`_ simply run::
 To upgrade pipenv at any time::
 
     $ brew upgrade pipenv
+
+.. _crude_installation:
 
 ☤ Crude Installation of Pipenv
 ==============================


### PR DESCRIPTION
These links are 404-ing on docs.pipenv.org. This PR fixes that!

http://www.sphinx-doc.org/en/stable/markup/inline.html#cross-referencing-arbitrary-locations