### PR TITLE
Temporary File Cleanup

### DIFF
--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -1341,9 +1341,9 @@ def pip_install(
         pip.logger.setLevel(logging.INFO)
 
     # Create files for hash mode.
-    if (not ignore_hashes) and (r is None):
-        r = tempfile.mkstemp(prefix='pipenv-', suffix='-requirement.txt')[1]
-        with open(r, 'w') as f:
+    if not package_name.startswith('-e ') and (not ignore_hashes) and (r is None):
+        fd, r = tempfile.mkstemp(prefix='pipenv-', suffix='-requirement.txt')
+        with os.fdopen(fd, 'w') as f:
             f.write(package_name)
 
     # Install dependencies when a package is a VCS dependency.
@@ -1380,10 +1380,10 @@ def pip_install(
         sources = project.sources
 
     for source in sources:
-        if r:
-            install_reqs = ' -r {0}'.format(r)
-        elif package_name.startswith('-e '):
+        if package_name.startswith('-e '):
             install_reqs = ' -e "{0}"'.format(package_name.split('-e ')[1])
+        elif r:
+            install_reqs = ' -r {0}'.format(r)
         else:
             install_reqs = ' "{0}"'.format(package_name)
 

--- a/pipenv/utils.py
+++ b/pipenv/utils.py
@@ -508,6 +508,9 @@ def convert_deps_to_pip(deps, project=None, r=True, include_index=False):
 
     dependencies = []
 
+    def is_star(val):
+        return isinstance(val, six.string_types) and val == '*'
+
     for dep in deps.keys():
 
         # Default (e.g. '>1.10').
@@ -516,7 +519,7 @@ def convert_deps_to_pip(deps, project=None, r=True, include_index=False):
         index = ''
 
         # Get rid of '*'.
-        if deps[dep] == '*' or str(extra) == '{}':
+        if is_star(deps[dep]) or str(extra) == '{}':
             extra = ''
 
         hash = ''
@@ -533,7 +536,7 @@ def convert_deps_to_pip(deps, project=None, r=True, include_index=False):
             extra = '[{0}]'.format(deps[dep]['extras'][0])
 
         if 'version' in deps[dep]:
-            if not deps[dep]['version'] == '*':
+            if not is_star(deps[dep]['version']):
                 version = deps[dep]['version']
 
         # For lockfile format.
@@ -544,7 +547,7 @@ def convert_deps_to_pip(deps, project=None, r=True, include_index=False):
             specs = []
             for specifier in specifiers:
                 if specifier in deps[dep]:
-                    if not deps[dep][specifier] == '*':
+                    if not is_star(deps[dep][specifier]):
                         specs.append('{0} {1}'.format(specifier, deps[dep][specifier]))
             if specs:
                 specs = '; {0}'.format(' and '.join(specs))

--- a/pipenv/utils.py
+++ b/pipenv/utils.py
@@ -6,13 +6,19 @@ import tempfile
 import sys
 import shutil
 import logging
-
+import errno
 import click
 import crayons
 import delegator
 import parse
 import requests
 import six
+import stat
+import warnings
+try:
+    from weakref import finalize
+except ImportError:
+    from backports.weakref import finalize
 from time import time
 
 logging.basicConfig(level=logging.ERROR)
@@ -40,6 +46,10 @@ from requests.exceptions import HTTPError, ConnectionError
 
 from .pep508checker import lookup
 from .environments import SESSION_IS_INTERACTIVE, PIPENV_MAX_ROUNDS, PIPENV_CACHE_DIR
+
+if six.PY2:
+    class ResourceWarning(Warning):
+        pass
 
 specifiers = [k for k in lookup.keys()]
 
@@ -255,14 +265,15 @@ def actually_resolve_reps(deps, index_lookup, markers_lookup, project, sources, 
 
     constraints = []
 
+    req_dir = tempfile.mkdtemp(prefix='pipenv-', suffix='-requirements')
     for dep in deps:
-        t = tempfile.mkstemp(prefix='pipenv-', suffix='-requirement.txt')[1]
-        with open(t, 'w') as f:
-            f.write(dep)
-
         if dep.startswith('-e '):
             constraint = pip.req.InstallRequirement.from_editable(dep[len('-e '):])
         else:
+            fd, t = tempfile.mkstemp(prefix='pipenv-', suffix='-requirement.txt', dir=req_dir)
+            with os.fdopen(fd, 'w') as f:
+                f.write(dep)
+
             constraint = [c for c in pip.req.parse_requirements(t, session=pip._vendor.requests)][0]
             # extra_constraints = []
 
@@ -273,6 +284,8 @@ def actually_resolve_reps(deps, index_lookup, markers_lookup, project, sources, 
             markers_lookup[constraint.name] = str(constraint.markers).replace('"', "'")
 
         constraints.append(constraint)
+
+    rmtree(req_dir)
 
     pip_command = get_pip_command()
 
@@ -611,6 +624,7 @@ def convert_deps_to_pip(deps, project=None, r=True, include_index=False):
     # Write requirements.txt to tmp directory.
     f = tempfile.NamedTemporaryFile(suffix='-requirements.txt', delete=False)
     f.write('\n'.join(dependencies).encode('utf-8'))
+    f.close()
     return f.name
 
 
@@ -955,6 +969,7 @@ def temp_environ():
         os.environ.clear()
         os.environ.update(environ)
 
+
 def is_valid_url(url):
     """Checks if a given string is an url"""
     pieces = urlparse(url)
@@ -1011,3 +1026,84 @@ def normalize_drive(path):
     if drive.islower() and len(drive) == 2 and drive[1] == ':':
         return '{}{}'.format(drive.upper(), tail)
     return path
+
+
+def is_readonly_path(fn):
+    """Check if a provided path exists and is readonly.
+
+    Permissions check is `bool(path.stat & stat.S_IREAD)` or `not os.access(path, os.W_OK)`
+    """
+    if os.path.exists(fn):
+        return (os.stat(fn).st_mode & stat.S_IREAD) or not os.access(fn, os.W_OK)
+    return False
+
+
+def set_write_bit(fn):
+    if os.path.exists(fn):
+        os.chmod(fn, stat.S_IWRITE | stat.S_IWUSR)
+    return
+
+
+def rmtree(directory, ignore_errors=False):
+    shutil.rmtree(directory, ignore_errors=ignore_errors, onerror=handle_remove_readonly)
+
+
+def handle_remove_readonly(func, path, exc):
+    """Error handler for shutil.rmtree.
+
+    Windows source repo folders are read-only by default, so this error handler
+    attempts to set them as writeable and then proceed with deletion."""
+    # Check for read-only attribute
+    default_warning_message = 'Unable to remove file due to permissions restriction: {!r}'
+    # split the initial exception out into its type, exception, and traceback
+    exc_type, exc_exception, exc_tb = exc
+    if is_readonly_path(path):
+        # Apply write permission and call original function
+        set_write_bit(path)
+        try:
+            func(path)
+        except (OSError, IOError) as e:
+            if e.errno in [errno.EACCES, errno.EPERM]:
+                warnings.warn(default_warning_message.format(path), ResourceWarning)
+                return
+    if exc_exception.errno in [errno.EACCES, errno.EPERM]:
+        warnings.warn(default_warning_message.format(path), ResourceWarning)
+        return
+    raise
+
+
+class TemporaryDirectory(object):
+    """Create and return a temporary directory.  This has the same
+    behavior as mkdtemp but can be used as a context manager.  For
+    example:
+
+        with TemporaryDirectory() as tmpdir:
+            ...
+
+    Upon exiting the context, the directory and everything contained
+    in it are removed.
+    """
+
+    def __init__(self, suffix=None, prefix=None, dir=None):
+        self.name = tempfile.mkdtemp(suffix, prefix, dir)
+        self._finalizer = finalize(
+            self, self._cleanup, self.name,
+            warn_message="Implicitly cleaning up {!r}".format(self))
+
+    @classmethod
+    def _cleanup(cls, name, warn_message):
+        rmtree(name)
+        warnings.warn(warn_message, ResourceWarning)
+
+    def __repr__(self):
+        return "<{} {!r}>".format(self.__class__.__name__, self.name)
+
+    def __enter__(self):
+        return self.name
+
+    def __exit__(self, exc, value, tb):
+        self.cleanup()
+
+    def cleanup(self):
+        if self._finalizer.detach():
+            rmtree(self.name)

--- a/pipenv/vendor/backports/weakref/__init__.py
+++ b/pipenv/vendor/backports/weakref/__init__.py
@@ -1,0 +1,10 @@
+"""
+Partial backport of Python 3.6's weakref module:
+
+    finalize (new in Python 3.4)
+
+Backport modifications are marked with "XXX backport".
+"""
+__all__ = ["finalize"]
+
+from .weakref import finalize

--- a/pipenv/vendor/backports/weakref/weakref.py
+++ b/pipenv/vendor/backports/weakref/weakref.py
@@ -1,0 +1,151 @@
+"""
+Partial backport of Python 3.6's weakref module:
+
+    finalize (new in Python 3.4)
+
+Backport modifications are marked with "XXX backport".
+"""
+from __future__ import absolute_import
+
+import itertools
+import sys
+from weakref import ref
+
+__all__ = ['finalize']
+
+
+class finalize(object):
+    """Class for finalization of weakrefable objects
+
+    finalize(obj, func, *args, **kwargs) returns a callable finalizer
+    object which will be called when obj is garbage collected. The
+    first time the finalizer is called it evaluates func(*arg, **kwargs)
+    and returns the result. After this the finalizer is dead, and
+    calling it just returns None.
+
+    When the program exits any remaining finalizers for which the
+    atexit attribute is true will be run in reverse order of creation.
+    By default atexit is true.
+    """
+
+    # Finalizer objects don't have any state of their own.  They are
+    # just used as keys to lookup _Info objects in the registry.  This
+    # ensures that they cannot be part of a ref-cycle.
+
+    __slots__ = ()
+    _registry = {}
+    _shutdown = False
+    _index_iter = itertools.count()
+    _dirty = False
+    _registered_with_atexit = False
+
+    class _Info(object):
+        __slots__ = ("weakref", "func", "args", "kwargs", "atexit", "index")
+
+    def __init__(self, obj, func, *args, **kwargs):
+        if not self._registered_with_atexit:
+            # We may register the exit function more than once because
+            # of a thread race, but that is harmless
+            import atexit
+            atexit.register(self._exitfunc)
+            finalize._registered_with_atexit = True
+        info = self._Info()
+        info.weakref = ref(obj, self)
+        info.func = func
+        info.args = args
+        info.kwargs = kwargs or None
+        info.atexit = True
+        info.index = next(self._index_iter)
+        self._registry[self] = info
+        finalize._dirty = True
+
+    def __call__(self, _=None):
+        """If alive then mark as dead and return func(*args, **kwargs);
+        otherwise return None"""
+        info = self._registry.pop(self, None)
+        if info and not self._shutdown:
+            return info.func(*info.args, **(info.kwargs or {}))
+
+    def detach(self):
+        """If alive then mark as dead and return (obj, func, args, kwargs);
+        otherwise return None"""
+        info = self._registry.get(self)
+        obj = info and info.weakref()
+        if obj is not None and self._registry.pop(self, None):
+            return (obj, info.func, info.args, info.kwargs or {})
+
+    def peek(self):
+        """If alive then return (obj, func, args, kwargs);
+        otherwise return None"""
+        info = self._registry.get(self)
+        obj = info and info.weakref()
+        if obj is not None:
+            return (obj, info.func, info.args, info.kwargs or {})
+
+    @property
+    def alive(self):
+        """Whether finalizer is alive"""
+        return self in self._registry
+
+    @property
+    def atexit(self):
+        """Whether finalizer should be called at exit"""
+        info = self._registry.get(self)
+        return bool(info) and info.atexit
+
+    @atexit.setter
+    def atexit(self, value):
+        info = self._registry.get(self)
+        if info:
+            info.atexit = bool(value)
+
+    def __repr__(self):
+        info = self._registry.get(self)
+        obj = info and info.weakref()
+        if obj is None:
+            return '<%s object at %#x; dead>' % (type(self).__name__, id(self))
+        else:
+            return '<%s object at %#x; for %r at %#x>' % \
+                (type(self).__name__, id(self), type(obj).__name__, id(obj))
+
+    @classmethod
+    def _select_for_exit(cls):
+        # Return live finalizers marked for exit, oldest first
+        L = [(f,i) for (f,i) in cls._registry.items() if i.atexit]
+        L.sort(key=lambda item:item[1].index)
+        return [f for (f,i) in L]
+
+    @classmethod
+    def _exitfunc(cls):
+        # At shutdown invoke finalizers for which atexit is true.
+        # This is called once all other non-daemonic threads have been
+        # joined.
+        reenable_gc = False
+        try:
+            if cls._registry:
+                import gc
+                if gc.isenabled():
+                    reenable_gc = True
+                    gc.disable()
+                pending = None
+                while True:
+                    if pending is None or finalize._dirty:
+                        pending = cls._select_for_exit()
+                        finalize._dirty = False
+                    if not pending:
+                        break
+                    f = pending.pop()
+                    try:
+                        # gc is disabled, so (assuming no daemonic
+                        # threads) the following is the only line in
+                        # this function which might trigger creation
+                        # of a new finalizer
+                        f()
+                    except Exception:
+                        sys.excepthook(*sys.exc_info())
+                    assert f not in cls._registry
+        finally:
+            # prevent any more finalizers from executing during shutdown
+            finalize._shutdown = True
+            if reenable_gc:
+                gc.enable()


### PR DESCRIPTION
This is a small piece of what might need to be a bigger cleanup of some of our backend processes.  This aims to provide the capacity to cleanly handle temporary filesystem resources, and also aims to use more carefully those resources which we do generate.

Broad fixes to testing infrastructure
- Add custom rmtree function to handle windows rms
- Only warn on failure to remove a tree
- This should mitigate a large portion of our windows test failures
- After sufficiently substantial time investment I am currently of the opinion that there is no real elegant way to handle this (I have tried programmatically finding all processes with open file handles, terminating them with a 500ms retry and a 15s timeout)
- Close and handle tempfiles in resolvers
- Only create tempfiles for non-editable deps
- set umask and `PIP_SRC` for test context
- Warn instead of throwing exceptions
- Backport TemporaryDirectory for python2/3 compatibility and reliance on custom rmtree error handling
- Vendor backport of `weakref.finalize` for `TemporaryDirectory.cleanup()`
- Add PyTest fixtures to wrap and cleanup `PIP_SRC` directory at the module level to avoid permissions errors on appveyor
- Add resource warnings for PY2 compat Lock instead of installing complex resolver test
- Add a special condition for allowing access errors
