### PR TITLE
[fix] Make sure we close tempfiles.

### DIFF
--- a/pipenv/utils.py
+++ b/pipenv/utils.py
@@ -462,8 +462,8 @@ def actually_resolve_reps(deps, index_lookup, markers_lookup, project, sources, 
     constraints = []
 
     for dep in deps:
-        t = tempfile.mkstemp(prefix='pipenv-', suffix='-requirement.txt')[1]
-        with open(t, 'w') as f:
+        fh, t = tempfile.mkstemp(prefix='pipenv-', suffix='-requirement.txt')
+        with os.fdopen(fh, 'w') as f:
             f.write(dep)
 
         if dep.startswith('-e '):

--- a/pipenv/utils.py
+++ b/pipenv/utils.py
@@ -462,8 +462,8 @@ def actually_resolve_reps(deps, index_lookup, markers_lookup, project, sources, 
     constraints = []
 
     for dep in deps:
-        fh, t = tempfile.mkstemp(prefix='pipenv-', suffix='-requirement.txt')
-        with os.fdopen(fh, 'w') as f:
+        fd, t = tempfile.mkstemp(prefix='pipenv-', suffix='-requirement.txt')
+        with os.fdopen(fd, 'w') as f:
             f.write(dep)
 
         if dep.startswith('-e '):


### PR DESCRIPTION
### Issue:
When trying to `pipenv lock` on project with (too) many dependencies (>300), `pipenv` crashes with:
```shell
OSError: [Errno 24] Too many open files: '/var/folders/4h/s6ttpgkd1d1ddm85n3n5kw4w0000gn/T/pipenv-m5smono2-requirement.txt'
```  
### Reason:
Looks like `pipenv` is currently not closing tempfiles during the lock process. We are thus accumulating open files during lock and if we have more dependencies than the current open file limit `pipenv` will throw.

The underlying issue seems to be that `tempfile.mkstemp` actually opens the file. And while we are using `open` as context manager, we're not closing that first file descriptor.

### Fix:
Use `os.fdopen`, thus getting a file object for the fd we get from `mkstemp`, that will be closed when we leave context.