### PR TITLE
Updates `activate_virtualenv`, closes #1371

### DIFF
--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -1173,7 +1173,7 @@ def activate_virtualenv(source=True):
     venv_location = project.virtualenv_location.replace(' ', r'\ ')
 
     if source:
-        return 'source {0}/bin/activate{1}'.format(venv_location, suffix)
+        return '. {0}/bin/activate{1}'.format(venv_location, suffix)
     else:
         return '{0}/bin/activate'.format(venv_location)
 


### PR DESCRIPTION
`.` is actually a `source` alias. But it works better, since `source` is not supported in raw `sh`.
As it was discussed in https://github.com/pypa/pipenv/issues/1371 some systems do not have `bash` installed.
Prove link: https://askubuntu.com/questions/25488/what-is-the-difference-between-source-and