### PR TITLE
Add CMD to example Dockerfile usage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,3 +22,6 @@ ONBUILD RUN set -ex && pipenv install --deploy --system
 # FROM kennethreitz/pipenv
 
 # COPY . /app
+
+# -- Replace with the correct path to your app's main executable
+# CMD python3 main.py 


### PR DESCRIPTION
This makes it clearer that you don't have to do `pipenv run python3 main.py` for instance.