### PR TITLE
Fix: shellquote src path

### DIFF
--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -1344,7 +1344,7 @@ def pip_install(
 
         # Don't specify a source directory when using --system.
         if not allow_global and ('PIP_SRC' not in os.environ):
-            src = '--src {0}'.format(project.virtualenv_src_location)
+            src = '--src {0}'.format(shellquote(project.virtualenv_src_location))
         else:
             src = ''
     else:


### PR DESCRIPTION
Re-work former PR https://github.com/pypa/pipenv/pull/1204 to get the fix back into the new `master` branch using the `shellquote` helper, as mentioned in https://github.com/pypa/pipenv/pull/1361#issuecomment-360797751.