### PR TITLE
Add a utility method for setup.py commands.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -88,6 +88,7 @@ Other Commands
 
 - ``shell`` will spawn a shell with the virtualenv activated.
 - ``run`` will run a given command from the virtualenv, with any arguments forwarded (e.g. ``$ pipenv run python``).
+- ``setuppy`` will run a setup.py command from the virtualenv (e.g. ``$ pipenv setuppy test``).
 - ``check`` asserts that PEP 508 requirements are being met by the current environment.
 - ``graph`` will print a pretty graph of all your installed dependencies.
 
@@ -158,6 +159,7 @@ Fish is the best shell. You should use it.
       lock       Generates Pipfile.lock.
       open       View a given module in your editor.
       run        Spawns a command installed into the...
+      setuppy    Runs ``python setup.py {command}`` inside the virtualenv.
       shell      Spawns a shell within the virtualenv.
       uninstall  Un-installs a provided package and removes it...
       update     Uninstalls all packages, and re-installs...

--- a/pipenv/cli.py
+++ b/pipenv/cli.py
@@ -308,6 +308,25 @@ def run(command, args, three=None, python=False):
     core.do_run(command=command, args=args, three=three, python=python)
 
 
+@click.command(
+    add_help_option=False,
+    short_help="Runs `python setup.py \{command\}` inside the virtualenv.",
+    context_settings=dict(
+        ignore_unknown_options=True,
+        allow_interspersed_args=False,
+        allow_extra_args=True
+    )
+)
+@click.argument('command')
+@click.argument('args', nargs=-1)
+@click.option('--three/--two', is_flag=True, default=None, help="Use Python 3/2 when creating virtualenv.")
+@click.option('--python', default=False, nargs=1, help="Specify which version of Python virtualenv should use.")
+def setuppy(command, args, three=None, python=False):
+    from . import core
+    command = "python setup.py {command}".format(command=command)
+    core.do_run(command=command, args=args, three=three, python=python)
+
+
 @click.command(short_help="Checks for security vulnerabilities and against PEP 508 markers provided in Pipfile.",  context_settings=dict(
     ignore_unknown_options=True,
     allow_extra_args=True
@@ -394,6 +413,7 @@ cli.add_command(check)
 cli.add_command(shell)
 cli.add_command(run)
 cli.add_command(run_open)
+cli.add_command(setuppy)
 
 
 # Only invoke the "did you mean" when an argument wasn't passed (it breaks those).


### PR DESCRIPTION
This commit adds a `pipenv setuppy` command that provides the functionality
of `pipenv run setup.py {command}`.

Running variations on `python setup.py {command}` is something that I end up doing a lot as a package maintainer. Right now, I either need to be doing all of my work in a `pipenv shell`, defeating part of the usefulness of pipenv for me, or I'm typing `pipenv run python setup.py` a lot. This hopefully makes it easier for package maintainers and those who are less requirements.txt-based to use pipenv more easily.

I'm open to suggestions for how to test, better document, or really change in any way. I want some form of this to exist so pipenv and setuptools can live in harmony, the actual syntax matters less to me.