### PR TITLE
Show pip info level logging with verbose

### DIFF
--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -5,6 +5,8 @@
  - Comment out invalid (to pip's hash checking mode) packages from `$ pipenv lock -r`.
  - Updated patched version of dotenv.
  - Do not allow `$ pipenv install --system packagename `to be used.
+ - Show pip install logs with --verbose
+ - Allow -v as shorthand for --verbose for all commands.
 9.0.3:
  - v9.0.1.
 9.0.2:

--- a/pipenv/cli.py
+++ b/pipenv/cli.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import logging
 import os
 import sys
 
@@ -33,6 +34,11 @@ $$/       $$/ $$$$$$$/   $$$$$$$/ $$/   $$/     $/     $$/
 click_completion.init()
 
 CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
+
+def setup_verbose(ctx, param, value):
+    if value:
+        logging.getLogger('pip').setLevel(logging.INFO)
+    return value
 
 
 @click.group(invoke_without_command=True, context_settings=CONTEXT_SETTINGS)
@@ -186,7 +192,7 @@ def cli(
 @click.option('--system', is_flag=True, default=False, help="System pip management.")
 @click.option('--requirements', '-r', nargs=1, default=False, help="Import a requirements.txt file.")
 @click.option('--code', '-c', nargs=1, default=False, help="Import from codebase.")
-@click.option('--verbose', is_flag=True, default=False, help="Verbose mode.")
+@click.option('--verbose', '-v', is_flag=True, default=False, help="Verbose mode.", callback=setup_verbose)
 @click.option('--ignore-pipfile', is_flag=True, default=False, help="Ignore Pipfile when installing, using the Pipfile.lock.")
 @click.option('--sequential', is_flag=True, default=False, help="Install dependencies one-at-a-time, instead of concurrently.")
 @click.option('--skip-lock', is_flag=True, default=False, help=u"Ignore locking mechanisms when installing—use the Pipfile, instead.")
@@ -214,7 +220,7 @@ def install(
 @click.option('--three/--two', is_flag=True, default=None, help="Use Python 3/2 when creating virtualenv.")
 @click.option('--python', default=False, nargs=1, help="Specify which version of Python virtualenv should use.")
 @click.option('--system', is_flag=True, default=False, help="System pip management.")
-@click.option('--verbose', is_flag=True, default=False, help="Verbose mode.")
+@click.option('--verbose', '-v', is_flag=True, default=False, help="Verbose mode.", callback=setup_verbose)
 @click.option('--lock', is_flag=True, default=True, help="Lock afterwards.")
 @click.option('--all-dev', is_flag=True, default=False, help="Un-install all package from [dev-packages].")
 @click.option('--all', is_flag=True, default=False, help="Purge all package(s) from virtualenv. Does not edit Pipfile.")
@@ -234,7 +240,7 @@ def uninstall(
 @click.command(short_help="Generates Pipfile.lock.")
 @click.option('--three/--two', is_flag=True, default=None, help="Use Python 3/2 when creating virtualenv.")
 @click.option('--python', default=False, nargs=1, help="Specify which version of Python virtualenv should use.")
-@click.option('--verbose', is_flag=True, default=False, help="Verbose mode.")
+@click.option('--verbose', '-v', is_flag=True, default=False, help="Verbose mode.", callback=setup_verbose)
 @click.option('--requirements', '-r', is_flag=True, default=False, help="Generate output compatible with requirements.txt.")
 @click.option('--dev', '-d', is_flag=True, default=False, help="Generate output compatible with requirements.txt for the development dependencies.")
 @click.option('--clear', is_flag=True, default=False, help="Clear the dependency cache.")
@@ -361,7 +367,7 @@ def run_open(module, three=None, python=None):
 
 @click.command(short_help="Uninstalls all packages, and re-installs package(s) in [packages] to latest compatible versions.")
 @click.argument('package_name', default=False)
-@click.option('--verbose', '-v', is_flag=True, default=False, help="Verbose mode.")
+@click.option('--verbose', '-v', is_flag=True, default=False, help="Verbose mode.", callback=setup_verbose)
 @click.option('--dev', '-d', is_flag=True, default=False, help="Additionally install package(s) in [dev-packages].")
 @click.option('--three/--two', is_flag=True, default=None, help="Use Python 3/2 when creating virtualenv.")
 @click.option('--python', default=False, nargs=1, help="Specify which version of Python virtualenv should use.")

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -2,6 +2,7 @@
 
 import contextlib
 import codecs
+import logging
 import os
 import sys
 import shutil
@@ -1334,6 +1335,7 @@ def pip_install(
 
     if verbose:
         click.echo(crayons.normal('Installing {0!r}'.format(package_name), bold=True), err=True)
+        pip.logger.setLevel(logging.INFO)
 
     # Create files for hash mode.
     if (not ignore_hashes) and (r is None):


### PR DESCRIPTION
Closes #1434. 

Changes:

1. `-v` now always allowed as shorthand for `--verbose`
2. added callback that sets pip.logger's log level to INFO if `--verbose` specified.

Open questions:

1. Does using callback with `--verbose` look like a reasonable way to do this? I like that it is simple and combines log setting/verbosity into one place (but I don't know if it's "click-ish")
2. Level of log output look okay? ([success example](https://gist.github.com/jtratner/606469d9f896fce1f6c8f9aa439b18ab) +  see example from "bad" install at end).  Perhaps only pip.utils should get this log level applied with verbose? (other stuff is so noisy it's a bit of a bummer)
3. Should I attempt to colorize output with log handler? 

Failing build dumps pip log info - yay!
```
Pipfile.lock not found, creating…
Locking [dev-packages] dependencies…
INFO:pip._vendor.requests.packages.urllib3.connectionpool:Starting new HTTPS connection (1): pypi.counsyl.com
INFO:pip.req.req_set:Collecting ipython==6.2.1
INFO:pip.download:File was already downloaded /Users/jtratner/Library/Caches/pipenv/pkgs/ipython-6.2.1.tar.gz
INFO:pip.utils:Complete output from command python setup.py egg_info:
INFO:pip.utils:
IPython 6.0+ does not support Python 2.6, 2.7, 3.0, 3.1, or 3.2.
When using Python 2.7, please install IPython 5.x LTS Long Term Support version.
Beginning with IPython 6.0, Python 3.3 and above is required.

See IPython `README.rst` file for more information:

    https://github.com/ipython/ipython/blob/master/README.rst

Python sys.version_info(major=2, minor=7, micro=14, releaselevel='final', serial=0) detected.



----------------------------------------
```