### PR TITLE
MIsc. comment and doc typos

### DIFF
--- a/pipenv/pipenv.1
+++ b/pipenv/pipenv.1
@@ -759,7 +759,7 @@ is unique.
 .SS $ pipenv uninstall
 .sp
 \fB$ pipenv uninstall\fP supports all of the parameters in \fI\%pipenv install\fP,
-as well as one additonal, \fB\-\-all\fP\&.
+as well as one additional, \fB\-\-all\fP\&.
 .INDENT 0.0
 .INDENT 3.5
 .INDENT 0.0
@@ -800,7 +800,7 @@ The shell launched in interactive mode. This means that if your shell reads its 
 .UNINDENT
 .SS ☤ A Note about VCS Dependencies
 .sp
-Pipenv will resolve the sub–depencies of VCS dependencies, but only if they are editable, like so:
+Pipenv will resolve the sub–dependencies of VCS dependencies, but only if they are editable, like so:
 .INDENT 0.0
 .INDENT 3.5
 .sp
@@ -1178,7 +1178,7 @@ instead of the global virtualenv manager \fBpew\fP\&.
 .IP \(bu 2
 \fBPIPENV_NOSPIN\fP — Disable terminal spinner, for cleaner logs. Automatically set in CI environments.
 .IP \(bu 2
-\fBPIPENV_MAX_DEPTH\fP — Set to an integer for the maximum number of directories to resursively
+\fBPIPENV_MAX_DEPTH\fP — Set to an integer for the maximum number of directories to recursively
 search for a Pipfile.
 .IP \(bu 2
 \fBPIPENV_TIMEOUT\fP — Set to an integer for the max number of seconds Pipenv will

--- a/tests/test_pipenv.py
+++ b/tests/test_pipenv.py
@@ -709,7 +709,7 @@ requests = {version = "*"}
                 assert venv_path == normalize_drive(os.path.normpath(c.out.strip()))
                 # Have pew run 'pip freeze' in the virtualenv
                 # This is functionally the same as spawning a subshell
-                # If we can do this we can theoretically amke a subshell
+                # If we can do this we can theoretically make a subshell
                 # This test doesn't work on *nix
                 if os.name == 'nt':
                     args = ['pew', 'in', '.venv', 'pip', 'freeze']


### PR DESCRIPTION
Found via `codespell -q 3 --skip="./patched"`