### PR TITLE
Update activate_virtualenv again for Fish 3.0+

### DIFF
--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -1180,12 +1180,14 @@ def do_lock(verbose=False, system=False, clear=False, pre=False):
 def activate_virtualenv(source=True):
     """Returns the string to activate a virtualenv."""
 
-    # Suffix for other shells.
+    # Suffix and source command for other shells.
     suffix = ''
+    command = '.' if source else ''
 
     # Support for fish shell.
     if PIPENV_SHELL and 'fish' in PIPENV_SHELL:
         suffix = '.fish'
+        command = 'source'
 
     # Support for csh shell.
     if PIPENV_SHELL and 'csh' in PIPENV_SHELL:
@@ -1196,7 +1198,7 @@ def activate_virtualenv(source=True):
     venv_location = project.virtualenv_location.replace(' ', r'\ ')
 
     if source:
-        return '. {0}/bin/activate{1}'.format(venv_location, suffix)
+        return '{2} {0}/bin/activate{1}'.format(venv_location, suffix, command)
     else:
         return '{0}/bin/activate'.format(venv_location)
 


### PR DESCRIPTION
Fish 3 removes the `.` command in favour of `source`, so we need to adapt.

See https://github.com/pypa/pipenv/pull/1388#issuecomment-367353694