### PR TITLE
fix graph command for missing virtualenv

### DIFF
--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -2194,26 +2194,33 @@ def do_graph(bare=False, json=False, reverse=False):
     if reverse:
         flag = '--reverse'
 
+    if not project.virtualenv_exists:
+        click.echo(
+            u'{0}: No virtualenv has been created for this project yet! Consider '
+            u'running {1} first to automatically generate one for you or see'
+            u'{2} for further instructions.'.format(
+                crayons.red('Warning', bold=True),
+                crayons.green('`pipenv install`'),
+                crayons.green('`pipenv install --help`')
+            ), err=True
+        )
+        sys.exit(1)
+
+
     cmd = '"{0}" {1} {2}'.format(
         python_path,
         shellquote(pipdeptree.__file__.rstrip('cdo')),
         flag
     )
 
-    if not project.virtualenv_exists:
-        tree_output = '{}' if json else ''
-        return_code = 0
-    else:
-        # Run dep-tree.
-        c = delegator.run(cmd)
-        tree_output = c.out
-        return_code = c.return_code
+    # Run dep-tree.
+    c = delegator.run(cmd)
 
     if not bare:
 
         if json:
             data = []
-            for d in simplejson.loads(tree_output):
+            for d in simplejson.loads(c.out):
 
                 if d['package']['key'] not in BAD_PACKAGES:
                     data.append(d)
@@ -2221,7 +2228,7 @@ def do_graph(bare=False, json=False, reverse=False):
             click.echo(simplejson.dumps(data, indent=4))
             sys.exit(0)
         else:
-            for line in tree_output.split('\n'):
+            for line in c.out.split('\n'):
 
                 # Ignore bad packages as top level.
                 if line.split('==')[0] in BAD_PACKAGES and not reverse:
@@ -2235,10 +2242,10 @@ def do_graph(bare=False, json=False, reverse=False):
                 else:
                     click.echo(crayons.normal(line, bold=False))
     else:
-        click.echo(tree_output)
+        click.echo(c.out)
 
     # Return its return code.
-    sys.exit(return_code)
+    sys.exit(c.return_code)
 
 
 def do_update(ctx, install, dev=False, three=None, python=None, dry_run=False, bare=False, dont_upgrade=False, user=False, verbose=False, clear=False, unused=False, package_name=None, sequential=False):

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -2200,14 +2200,20 @@ def do_graph(bare=False, json=False, reverse=False):
         flag
     )
 
-    # Run dep-tree.
-    c = delegator.run(cmd)
+    if not project.virtualenv_exists:
+        tree_output = '{}' if json else ''
+        return_code = 0
+    else:
+        # Run dep-tree.
+        c = delegator.run(cmd)
+        tree_output = c.out
+        return_code = c.return_code
 
     if not bare:
 
         if json:
             data = []
-            for d in simplejson.loads(c.out):
+            for d in simplejson.loads(tree_output):
 
                 if d['package']['key'] not in BAD_PACKAGES:
                     data.append(d)
@@ -2215,7 +2221,7 @@ def do_graph(bare=False, json=False, reverse=False):
             click.echo(simplejson.dumps(data, indent=4))
             sys.exit(0)
         else:
-            for line in c.out.split('\n'):
+            for line in tree_output.split('\n'):
 
                 # Ignore bad packages as top level.
                 if line.split('==')[0] in BAD_PACKAGES and not reverse:
@@ -2229,10 +2235,10 @@ def do_graph(bare=False, json=False, reverse=False):
                 else:
                     click.echo(crayons.normal(line, bold=False))
     else:
-        click.echo(c.out)
+        click.echo(tree_output)
 
     # Return its return code.
-    sys.exit(c.return_code)
+    sys.exit(return_code)
 
 
 def do_update(ctx, install, dev=False, three=None, python=None, dry_run=False, bare=False, dont_upgrade=False, user=False, verbose=False, clear=False, unused=False, package_name=None, sequential=False):


### PR DESCRIPTION
Fixes https://github.com/pypa/pipenv/issues/1455

I went with the approach of bypassing the build a dependency tree when a virtualenv does not exist for optimization purposes. The other approach would have been to build a dependency tree and conditionally switch to valid empty JSON after evaluating the empty output.