### PR TITLE
document pip commands from pipenv

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -151,6 +151,9 @@ Fish is the best shell. You should use it.
        Install a local setup.py into your virtual environment/Pipfile:
        $ pipenv install -e .
 
+       Use a lower-level pip command to get info about a package:
+       $ pipenv run pip show requests
+
     Commands:
       check      Checks for security vulnerabilities and...
       graph      Displays currently–installed dependency graph...

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -109,7 +109,7 @@ Other Commands
 
 - ``graph`` will show you a dependency graph, of your installed dependencies.
 - ``shell`` will spawn a shell with the virtualenv activated.
-- ``run`` will run a given command from the virtualenv, with any arguments forwarded (e.g. ``$ pipenv run python``).
+- ``run`` will run a given command from the virtualenv, with any arguments forwarded (e.g. ``$ pipenv run python``). Notably, ``run`` can be used to invoke various pip utility commands, as in ``$ pipenv run pip show requests``.
 - ``check`` checks for security vulnerabilities and asserts that PEP 508 requirements are being met by the current environment.
 
 

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -1537,6 +1537,9 @@ Usage Examples:
    Install a local setup.py into your virtual environment/Pipfile:
    $ {5}
 
+   Use a lower-level pip command to get info about a package:
+   $ {8}
+
 Commands:""".format(
         crayons.red('pipenv --three'),
         crayons.red('pipenv --python 3.6'),
@@ -1546,6 +1549,7 @@ Commands:""".format(
         crayons.red('pipenv install -e .'),
         crayons.red('pipenv lock --pre'),
         crayons.red('pipenv check'),
+        crayons.red('pipenv run pip show requests'),
     )
 
     help = help.replace('Commands:', additional_help)


### PR DESCRIPTION
Explicitly point out in first page of docs that you can use `pipenv run pip ...` to invoke pip utility commands.

I previously made #1461, which was sensibly rejected on the grounds that it wasn't actually needed. Somebody pointed out in #1462 that I'm not the first person to make this mistake. The proposed change is perhaps not the strongest possible guarantee that nobody will make the mistake again, but also could help. Maybe. It's at any rate extremely unlikely to hurt.