### PR TITLE
show warning if lockfile doesn't exist on clean

### DIFF
--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -2302,6 +2302,12 @@ def do_clean(
     # Ensure that virtualenv is available.
     ensure_project(three=three, python=python, validate=False)
 
+    if not project.lockfile_exists:
+        click.echo(
+            '{0}: Could not find Pipfile.lock'.format(crayons.red('Warning'))
+        )
+        sys.exit(1)
+
     installed_packages = delegator.run(
         '{0} freeze'.format(which('pip'))
     ).out.strip().split('\n')


### PR DESCRIPTION
Attempting to clean a project without a lockfile results in:
```
> pipenv clean
Traceback (most recent call last):
  File "/usr/local/bin/pipenv", line 11, in <module>
    load_entry_point('pipenv', 'console_scripts', 'pipenv')()
  File "/Users/dschaller/Documents/pipenv/pipenv/vendor/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/Users/dschaller/Documents/pipenv/pipenv/vendor/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/Users/dschaller/Documents/pipenv/pipenv/vendor/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/dschaller/Documents/pipenv/pipenv/vendor/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/dschaller/Documents/pipenv/pipenv/vendor/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/Users/dschaller/Documents/pipenv/pipenv/vendor/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/Users/dschaller/Documents/pipenv/pipenv/cli.py", line 381, in clean
    ctx=ctx, three=three, python=python, dry_run=dry_run, verbose=verbose
  File "/Users/dschaller/Documents/pipenv/pipenv/core.py", line 2311, in do_clean
    r = get_requirement(installed)
  File "/Users/dschaller/Documents/pipenv/pipenv/utils.py", line 110, in get_requirement
    req = [r for r in requirements.parse(dep)][0]
IndexError: list index out of range
```

After this PR:
```
> pipenv clean
Warning: Could not find Pipfile.lock
```