### PR TITLE
Assume PIPENV_VENV_IN_PROJECT when a local virtual environment exists

### DIFF
--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -1,3 +1,5 @@
+next:
+ - Assume `PIPENV_VENV_IN_PROJECT` if `./.venv/` already exists.
 10.1.0:
  - Default dependencies now take precidence over Develop dependencies when
    creating a Pipfile.lock.

--- a/pipenv/environments.py
+++ b/pipenv/environments.py
@@ -11,7 +11,7 @@ os.environ.pop('__PYVENV_LAUNCHER__', None)
 PIPENV_SHELL_FANCY = bool(os.environ.get('PIPENV_SHELL_FANCY'))
 
 # Create the virtualenv in the project, instead of with pew.
-PIPENV_VENV_IN_PROJECT = bool(os.environ.get('PIPENV_VENV_IN_PROJECT'))
+PIPENV_VENV_IN_PROJECT = bool(os.environ.get('PIPENV_VENV_IN_PROJECT')) or os.path.isdir('.venv')
 
 # No color mode, for unfun people.
 PIPENV_COLORBLIND = bool(os.environ.get('PIPENV_COLORBLIND'))

--- a/tests/test_pipenv.py
+++ b/tests/test_pipenv.py
@@ -664,6 +664,15 @@ requests = {version = "*"}
                 assert normalize_drive(p.path) in p.pipenv('--venv').out
 
     @pytest.mark.dotvenv
+    def test_reuse_previous_venv(self):
+        with PipenvInstance(chdir=True) as p:
+            os.mkdir('.venv')
+            c = p.pipenv('install requests')
+            assert c.return_code == 0
+
+            assert normalize_drive(p.path) in p.pipenv('--venv').out
+
+    @pytest.mark.dotvenv
     @pytest.mark.install
     @pytest.mark.complex
     @pytest.mark.shell


### PR DESCRIPTION
Frequently I run into the situation where pipenv's virtual environment was created with `PIPENV_VENV_IN_PROJECT=1` (via `Makefile` or other setup script), but when I go to run a one-off command some time later, pipenv creates a new virtual environment missing my dependencies:

```
$ PIPENV_VENV_IN_PROJECT=1 pipenv install pytest
Creating a virtualenv for this project…
⠋New python executable in /private/tmp/test/.venv/bin/python
Installing setuptools, pip, wheel...done.

Virtualenv location: /private/tmp/test/.venv
Installing pytest…
Collecting pytest
  Using cached pytest-3.4.1-py2.py3-none-any.whl
Collecting pluggy<0.7,>=0.5 (from pytest)
Collecting six>=1.10.0 (from pytest)
  Using cached six-1.11.0-py2.py3-none-any.whl
Collecting py>=1.5.0 (from pytest)
  Using cached py-1.5.2-py2.py3-none-any.whl
Collecting funcsigs; python_version < "3.0" (from pytest)
  Using cached funcsigs-1.0.2-py2.py3-none-any.whl
Requirement already satisfied: setuptools in ./.venv/lib/python2.7/site-packages (from pytest)
Collecting attrs>=17.2.0 (from pytest)
  Using cached attrs-17.4.0-py2.py3-none-any.whl
Installing collected packages: pluggy, six, py, funcsigs, attrs, pytest
Successfully installed attrs-17.4.0 funcsigs-1.0.2 pluggy-0.6.0 py-1.5.2 pytest-3.4.1 six-1.11.0

Adding pytest to Pipfile's [packages]…
Installing dependencies from Pipfile.lock (272659)…
  🐍   ▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉ 12/12 — 00:00:02
To activate this project's virtualenv, run the following:
 $ pipenv shell
```

```
$ pipenv run pytest
Creating a virtualenv for this project…
⠋New python executable in /Users/Browning/.local/share/virtualenvs/test-6C_DLGjE/bin/python
Installing setuptools, pip, wheel...done.

Virtualenv location: /Users/Browning/.local/share/virtualenvs/test-6C_DLGjE
Error: the command pytest could not be found within PATH or Pipfile's [scripts].
```

---

This change sets `PIPENV_VENV_IN_PROJECT` automatically if the virtual environment directory already exists locally. I think this will reduce many of the problems people have documented running into on https://github.com/pypa/pipenv/issues/1049.