### PR TITLE
feat(graph): json flag now uses json-tree from pipdeptree

### DIFF
--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -2273,7 +2273,7 @@ def do_graph(bare=False, json=False, reverse=False):
 
     flag = ''
     if json:
-        flag = '--json'
+        flag = '--json-tree'
     if reverse:
         flag = '--reverse'
 
@@ -2288,7 +2288,6 @@ def do_graph(bare=False, json=False, reverse=False):
             ), err=True
         )
         sys.exit(1)
-
 
     cmd = '"{0}" {1} {2}'.format(
         python_path,
@@ -2305,7 +2304,7 @@ def do_graph(bare=False, json=False, reverse=False):
             data = []
             for d in simplejson.loads(c.out):
 
-                if d['package']['key'] not in BAD_PACKAGES:
+                if d['key'] not in BAD_PACKAGES:
                     data.append(d)
 
             click.echo(simplejson.dumps(data, indent=4))


### PR DESCRIPTION
Hello everyone,

`pipdeptree` has now a [new feature](https://github.com/naiquevin/pipdeptree/issues/86#issuecomment-360125873), which shows the whole json tree, like `pipenv graph`. 
Thanks to @haikoschol for it.
That's why I'm trying to update pipenv as well. 

My only concern is with `BAD_PACKAGES`, I don't understand what it should do, maybe someone can help me. 

I kept the same behavior as the old `json`, basically removing `BAD_PACKAGES` from the first level, but not from the nested elements.

I'm not sure if `BAD_PACKAGES` should be removed from everywhere, if that were the case I will have to write some kind of filter for all the nested dicts, which might also be too complex.

So far the results were promising, the same as `pipenv graph`.

PD: If we want to keep the current `--json`, introducing `--json-tree` would be an alternative.

I hope you like it.

Cheers!