### PR TITLE
Always try to generate a hash for packages in Pipfile.lock

### DIFF
--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -1,5 +1,6 @@
 next:
  - Assume `PIPENV_VENV_IN_PROJECT` if `./.venv/` already exists.
+ - Use and generate hashes for PyPI mirrors and custom indexes.
 10.1.0:
  - Default dependencies now take precidence over Develop dependencies when
    creating a Pipfile.lock.

--- a/pipenv/utils.py
+++ b/pipenv/utils.py
@@ -391,16 +391,20 @@ def resolve_deps(deps, which, which_pip, project, sources=None, verbose=False, p
 
                     for release in cleaned_releases[version]:
                         collected_hashes.append(release['digests']['sha256'])
-
                     collected_hashes = ['sha256:' + s for s in collected_hashes]
 
-                    # Collect un-collectable hashes.
-                    if not collected_hashes:
-                        collected_hashes = list(list(resolver.resolve_hashes([result]).items())[0][1])
 
                 except (ValueError, KeyError, ConnectionError):
                     if verbose:
                         print('Error fetching {}'.format(name))
+
+            # Collect un-collectable hashes (should work with devpi).
+            if not collected_hashes:
+                try:
+                    collected_hashes = list(list(resolver.resolve_hashes([result]).items())[0][1])
+                except (ValueError, KeyError, ConnectionError, IndexError):
+                    if verbose:
+                        print('Error generating hash for {}'.format(name))
 
             d = {'name': name, 'version': version, 'hashes': collected_hashes}
 


### PR DESCRIPTION
Even for custom package indexes!

I tested this against Counsyl's internal devpi instance and it worked perfectly :) 

That said, I worry this would cause more issues than it would fix (because it will *always* generate hashes even if the index does not present them), but it'd be really *nice* to do it :) .  Perhaps we could put this behind an environment variable and let folks opt-in to it and kick the tires.

Would fix issue in #1503.

### Evidence this works

Pipfile like this:

```
›› cat Pipfile
[[source]]

url = "https://internal-devpi/my/index/+simple"
verify_ssl = true
name = "counsyl-pypi"

[packages]

internal-package = "*"
```

installs with hashes

```
Installing 'internal-package --hash=sha256:somehash'
$ "/Users/jtratner/.virtualenvs/example-LTUvl4NZ/bin/pip" install   --verbose  --no-deps  -r /var/folders/fm/sjgpzb856kld04jvq82bxrcw0000gp/T/pipenv-KBTpdr-requirement.txt --require-hashes -i https://internal-devpi/my/index/+simple --exists-action w
Installing 'six==1.11.0 --hash=sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9  --hash=sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb'
$ "/Users/jtratner/.virtualenvs/example-LTUvl4NZ/bin/pip" install   --verbose  --no-deps  -r /var/folders/fm/sjgpzb856kld04jvq82bxrcw0000gp/T/pipenv-bi05kM-requirement.txt --require-hashes -i https://internal-devpi/my/index/+simple --exists-action w
```

and generates requirements.txt without comments - woo!