### PR TITLE
Fix inline comments causing install error

### DIFF
--- a/pipenv/patched/prettytoml/elements/traversal/__init__.py
+++ b/pipenv/patched/prettytoml/elements/traversal/__init__.py
@@ -1,6 +1,6 @@
 from prettytoml import tokens
 from prettytoml.elements import common
-from prettytoml.elements.metadata import PunctuationElement, NewlineElement
+from prettytoml.elements.metadata import PunctuationElement, NewlineElement, CommentElement
 from prettytoml.elements.traversal import predicates
 
 
@@ -61,7 +61,7 @@ class TraversalMixin:
         """
         Returns the index of the following newline element after the given index, or -Infinity.
         """
-        return self.__find_following_element(index, lambda e: isinstance(e, NewlineElement))
+        return self.__find_following_element(index, lambda e: isinstance(e, NewlineElement) or isinstance(e, CommentElement))
 
     def _find_following_comment(self, index):
         """


### PR DESCRIPTION
### Environment
 * pipenv, version 10.1.0
 * Python 3.6.4 (Homebrew)
 * macOS High Sierra, version 10.13.3

### Steps to reproduce
1. Create a simple Pipfile with inline comments followed by a whole-line comment within packages:
```
[[source]]

url = "https://pypi.python.org/simple"
verify_ssl = true
name = "pypi"


[packages]

# Django related packages
django = ">=2.0"
pillow = "*"  # necessary for django ImageField
# OAuth / Security related packages
django-oauth-toolkit = "*"


[requires]

python_version = "3.6"
```
2. Run `pipenv install rules`

### Expected behaviour
`rules` package is installed, and added to Pipfile

### Resulting behaviour
Fatal error with message:
```
$ pipenv install rules
Creating a virtualenv for this project…
Using /usr/local/bin/python3.6m to create virtualenv…
⠋Running virtualenv with interpreter /usr/local/bin/python3.6m
Using base prefix '/usr/local/Cellar/python3/3.6.4_2/Frameworks/Python.framework/Versions/3.6'
New python executable in /Users/serialx/.local/share/virtualenvs/api-k66jWLAd/bin/python3.6
Also creating executable in /Users/serialx/.local/share/virtualenvs/api-k66jWLAd/bin/python
Installing setuptools, pip, wheel...done.

Virtualenv location: /Users/serialx/.local/share/virtualenvs/api-k66jWLAd
Installing rules…
Collecting rules
Installing collected packages: rules
Successfully installed rules-1.3

Adding rules to Pipfile's [packages]…
Traceback (most recent call last):
  File "/usr/local/Cellar/pipenv/10.1.0/libexec/bin/pipenv", line 11, in <module>
    load_entry_point('pipenv==10.1.0', 'console_scripts', 'pipenv')()
  File "/usr/local/Cellar/pipenv/10.1.0/libexec/lib/python3.6/site-packages/pipenv/vendor/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/Cellar/pipenv/10.1.0/libexec/lib/python3.6/site-packages/pipenv/vendor/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/usr/local/Cellar/pipenv/10.1.0/libexec/lib/python3.6/site-packages/pipenv/vendor/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/Cellar/pipenv/10.1.0/libexec/lib/python3.6/site-packages/pipenv/vendor/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/Cellar/pipenv/10.1.0/libexec/lib/python3.6/site-packages/pipenv/vendor/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/Cellar/pipenv/10.1.0/libexec/lib/python3.6/site-packages/pipenv/cli.py", line 197, in install
    selective_upgrade=selective_upgrade
  File "/usr/local/Cellar/pipenv/10.1.0/libexec/lib/python3.6/site-packages/pipenv/core.py", line 1875, in do_install
    project.add_package_to_pipfile(package_name, dev)
  File "/usr/local/Cellar/pipenv/10.1.0/libexec/lib/python3.6/site-packages/pipenv/project.py", line 507, in add_package_to_pipfile
    p = self._pipfile
  File "/usr/local/Cellar/pipenv/10.1.0/libexec/lib/python3.6/site-packages/pipenv/project.py", line 292, in _pipfile
    p_section[norm_key] = p_section.pop(key)
  File "/usr/local/Cellar/pipenv/10.1.0/libexec/lib/python3.6/site-packages/pipenv/patched/prettytoml/elements/table.py", line 114, in pop
    v = self[key]
  File "/usr/local/Cellar/pipenv/10.1.0/libexec/lib/python3.6/site-packages/pipenv/patched/prettytoml/elements/abstracttable.py", line 58, in __getitem__
    raise KeyError
KeyError
```

### Possible solution to this error
I've debugged the code and found the root cause is when using `pop()` method in prettytoml package. For prettytoml to delete an element, it finds the starting point and finds the nearest `NewlineElement` and deletes the whole section from starting point to the newline element. The problem is that newlines with preceding comment token is unified into a single `CommentElement` entity. Thus prettytoml mistakenly deletes the next line of the comment. In which, this case it would be `django-oauth-toolkit = "*"`.

I've propose a simple patch to also find `CommentElement` when trying to find the following newline element.

~The side effect of this patch is that, since all comment line metadata is deleted, the newly contructed Pipfile has comments in the wrong lines:~ The comment related code-path seems to be unrelated to this patch.

```
[[source]]

url = "https://pypi.python.org/simple"
verify_ssl = true
name = "pypi"


[packages]

# Django related packages
django = ">=2.0"# necessary for django ImageField
# OAuth / Security related packages
pillow = "*"
django-oauth-toolkit = "*"
rules = "*"


[requires]

python_version = "3.6"
```