### PR TITLE
Updated docs - basic usage example pipenv workflow

### DIFF
--- a/docs/basics.rst
+++ b/docs/basics.rst
@@ -139,7 +139,14 @@ Create a Pipfile.lock from the installed versions::
 Install from that Pipfile.lock::
 
     $ pipenv install --ignore-pipfile
+    
+Activate the pipenv shell::
 
+    $ pipenv shell   
+    
+Exit the pipenv shell::
+
+    $ exit   
 
 .. _initialization:
 


### PR DESCRIPTION
I'm new to python so I didn't know 'exit' was the thing to type to deactivate the pipenv shell, so I thought I would add that to the basic usage doc.