### PR TITLE
Correct csh syntax in activate_virtualenv

### DIFF
--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -1218,6 +1218,7 @@ def activate_virtualenv(source=True):
     # Support for csh shell.
     if PIPENV_SHELL and 'csh' in PIPENV_SHELL:
         suffix = '.csh'
+        command = 'source'
 
     # Escape any spaces located within the virtualenv path to allow
     # for proper activation.


### PR DESCRIPTION
In `csh`, the `.` operator executes a directory, which is the wrong behaviour here. At best, when `pipenv` is installed system-wide (preferably via the operating system package manager), the result is a permission denied error from the shell.

As `csh` uses the `source` command, reflect that here.