### PR TITLE
Treat conda environments as a virtual environment

### DIFF
--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -1,3 +1,5 @@
+next:
+ - Treat conda environments as virtualenvs and install into conda env's site-packages.
 10.1.2:
  - Bugfix.
 10.1.1:

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -81,7 +81,10 @@ This will fail a build if the ``Pipfile.lock`` is out–of–date, instead of ge
 ☤ ``pipenv`` and ``conda``
 --------------------------
 
-To use Pipenv with a Conda–provided Python, you simply provide the path to the Python binary::
+Pipenv will automatically detect conda environments and install into the specific environment's
+system site packages. (however if you use conda to install specific python packages, you'll need to
+pin those packages to the same version in your Pipfile)If you want to create an isolated virtualenv
+within that environment, pass pipenv the path to the anaconda python::
 
     $ pipenv install --python=/path/to/anaconda/python
 

--- a/pipenv/environments.py
+++ b/pipenv/environments.py
@@ -47,7 +47,8 @@ PIPENV_USE_SYSTEM = False
 if 'PIPENV_ACTIVE' not in os.environ:
     if 'PIPENV_IGNORE_VIRTUALENVS' not in os.environ:
         PIPENV_VIRTUALENV = os.environ.get('VIRTUAL_ENV')
-        PIPENV_USE_SYSTEM = bool(os.environ.get('VIRTUAL_ENV'))
+        PIPENV_USE_SYSTEM = bool(os.environ.get('VIRTUAL_ENV') or
+                                 os.environ.get('CONDA_DEFAULT_ENV'))
 
 # Tells Pipenv to use hashing mode.
 PIPENV_USE_HASHES = True


### PR DESCRIPTION
This PR treats conda environments as a virtual environment. (could potentially remove the entire docs section on conda now).

Open questions:

1. do we want to add a test case for this?
2. is it still worth noting in docs that your requirements can get out of sync?

### why conda is useful

Conda is a great tool for installing hard-to-build software and especially hard-to-build python packages that may or may not have wheels (most of them do, but if you want versions of, say, numpy and pandas compiled against a different BLAS library, it's way easier to do with conda + a little easier to maintain cross-platform).

### conda is like a virtualenv

Currently pipenv treats conda environments as if they need to have their own virtualenv within them; but each conda environment actually maintains a separate set of Python site-packages.