### PR TITLE
Update marker os_name to platform_version in docs

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -46,7 +46,7 @@ Here's an example ``Pipfile``, which will only install ``pywinusb`` on Windows s
 
     [packages]
     requests = "*"
-    pywinusb = {version = "*", os_name = "== 'windows'"}
+    pywinusb = {version = "*", platform_version = "== 'Windows'"}
 
 Voilà!
 

--- a/pipenv/pipenv.1
+++ b/pipenv/pipenv.1
@@ -877,7 +877,7 @@ name = "pypi"
 
 [packages]
 requests = "*"
-pywinusb = {version = "*", os_name = "== \(aqwindows\(aq"}
+pywinusb = {version = "*", platform_version = "== \(aqLinux\(aq"}
 .ft P
 .fi
 .UNINDENT


### PR DESCRIPTION
According to doc, marker ```os_name``` is ```os.name``` as a PEP 508 specifier.

In python2, ```os.name``` has following values: 'posix', 'nt', 'java'
In python3, it has following values: 'posix', 'nt', 'os2', 'ce', 'java', 'riscos'

I believe using ```platform_version = "== 'Windows'"``` is more appropriate.