### PR TITLE
fix PYENV_ROOT-based pyenv detection

### DIFF
--- a/pipenv/environments.py
+++ b/pipenv/environments.py
@@ -89,7 +89,7 @@ PIPENV_DONT_USE_PYENV = os.environ.get('PIPENV_DONT_USE_PYENV')
 
 PYENV_ROOT = os.environ.get('PYENV_ROOT', os.path.expanduser('~/.pyenv'))
 
-PYENV_INSTALLED = (bool(os.environ.get('PYENV_SHELL')) or bool(os.environ.get('PYENV_ROOT')))
+PYENV_INSTALLED = (bool(os.environ.get('PYENV_SHELL')) or os.path.exists(PYENV_ROOT))
 
 SESSION_IS_INTERACTIVE = bool(os.isatty(sys.stdout.fileno()))
 


### PR DESCRIPTION
I noticed that Pipenv wasn't detecting my pyenv installation (just a straight-up `brew install pyenv` on my Mac) and offering to install the Python version requested by my `Pipfile`.

I believe this is because `PYENV_INSTALLED` was checking the `PYENV_ROOT` environment variable instead of the result of the `PYENV_ROOT` default get; `expanduser` also returns even invalid paths so it's important to check for existence of the pyenv root with `exists`.