### PR TITLE
Fix dependency list type mismatch

### DIFF
--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -820,8 +820,7 @@ def do_install_dependencies(
         for l in (deps_list, dev_deps_list):
             for i, dep in enumerate(l):
                 if '--hash' not in dep[0]:
-                    l[i] = list(l[i])
-                    l[i][0] = '# {0}'.format(l[i][0])
+                    l[i] = ('# {0}'.format(l[i][0]),) + l[i][1:]
 
         # Output only default dependencies
         if not dev:


### PR DESCRIPTION
When the dependency list got sorted in 6261122d (current line 828) you'd start getting `TypeError` when the code on line 823 executed because it changed the dependency tuple to a dependency list.