### PR TITLE
Fix verbose display

### DIFF
--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -1365,7 +1365,7 @@ def do_init(
     # Write out the lockfile if it doesn't exist.
     if not project.lockfile_exists and not skip_lock:
         click.echo(crayons.normal(u'Pipfile.lock not found, creating…', bold=True), err=True)
-        do_lock(system=system, pre=pre, keep_outdated=keep_outdated)
+        do_lock(system=system, pre=pre, keep_outdated=keep_outdated, verbose=verbose)
 
     do_install_dependencies(dev=dev, requirements=requirements, allow_global=allow_global,
                             skip_lock=skip_lock, verbose=verbose, concurrent=concurrent,

--- a/pipenv/utils.py
+++ b/pipenv/utils.py
@@ -358,6 +358,8 @@ def venv_resolve_deps(deps, which, project, pre=False, verbose=False, clear=Fals
     try:
         assert c.return_code == 0
     except AssertionError:
+        if verbose:
+            click.echo(c.out, err=True)
         click.echo(c.err[int(len(c.err) / 2) - 1:], err=True)
         sys.exit(c.return_code)
 


### PR DESCRIPTION
In investigating #1552 I thought I'd try and put in a proper fix - this way the verbose output is printed whether there is an error or not, and I also traced back the `verbose` flag being dropped up the call stack.