### PR TITLE
Fix --selective-upgrade compatibility with Python 2

### DIFF
--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -1840,7 +1840,7 @@ def do_install(
     # Support for --selective-upgrade.
     if selective_upgrade:
 
-        for i, package_name in enumerate(package_names.copy()):
+        for i, package_name in enumerate(package_names[:]):
             section = project.packages if not dev else project.dev_packages
             package = convert_deps_from_pip(package_name)
             package__name = list(package.keys())[0]


### PR DESCRIPTION
`list.copy()` is equivalent to `list[:]`, but the former is only available in Python 3.