### PR TITLE
Add instruction how to enable bash/zsh completion to website

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -394,6 +394,10 @@ To enable completion in fish, add this to your config::
 
     eval (pipenv --completion)
 
+Alternatively, with bash or zsh, add this to your config::
+
+    eval "$(pipenv --completion)"
+
 Magic shell completions are now enabled!
 
 ✨🍰✨


### PR DESCRIPTION
bash and zsh require different syntax for enabling shell completion than
fish. That difference was accounted for in README, but not in docs (and,
consequently, on website).