### PR TITLE
Publish universal wheels when uploading to pypi

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,6 @@
+[bdist_wheel]
+universal = 1
+
 [flake8]
 exclude = .git,__pycache__,docs/,pipenv/vendor/,get-pipenv.py,setup.py
 ignore =

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,7 @@ class UploadCommand(Command):
 
         self.status('Building Source distribution…')
         os.system('{0} setup.py sdist'.format(sys.executable))
+        os.system('{0} setup.py bdist_wheel'.format(sys.executable))
 
         self.status('Uploading the package to PyPi via Twine…')
         os.system('twine upload dist/*')


### PR DESCRIPTION
This ought to work - checked that these two commands generated what I expected:

```
›› rm -rf dist && time python setup.py sdist &> sdist.txt && time python setup.py bdist_wheel &> bdist.txt
python setup.py sdist &> sdist.txt  1.76s user 0.38s system 99% cpu 2.154 total
python setup.py bdist_wheel &> bdist.txt  1.10s user 0.45s system 97% cpu 1.581 total
›› ls dist
pipenv-11.0.2-py2.py3-none-any.whl pipenv-11.0.2.tar.gz
```

and thus `twine upload dist/*` should be good enough. (successfully installed pipenv from the wheel too)