### PR TITLE
Avoid running another process to print completion script

### DIFF
--- a/pipenv/cli.py
+++ b/pipenv/cli.py
@@ -48,15 +48,15 @@ def cli(
 ):
     if completion:  # Handle this ASAP to make shell startup fast.
         if PIPENV_SHELL:
-            os.environ['_PIPENV_COMPLETE'] = 'source-{0}'.format(PIPENV_SHELL.split(os.sep)[-1])
+            click.echo(click_completion.get_code(
+                shell=PIPENV_SHELL.split(os.sep)[-1], prog_name='pipenv'
+            ))
         else:
             click.echo(
                 'Please ensure that the {0} environment variable '
                 'is set.'.format(crayons.normal('SHELL', bold=True)), err=True)
             sys.exit(1)
 
-        c = delegator.run('pipenv')
-        click.echo(c.out)
         sys.exit(0)
 
     from . import core


### PR DESCRIPTION
Currently Pipenv reinvokes itself with the _PIPENV_COMPLETE environment variable set in order to make click_completion print out the completion function; this is slow (I measured around 480ms) and it would be nice if `pipenv --completion` was as fast as possible.

To that end, this PR switches to using the `click_completion.get_code` function to ask click_completion for the completion function directly.

- we now have to pass `prog_name`, as we're no longer going through Click's completion code (Click has a little thing to [guess the program name](https://github.com/pallets/click/blob/55682f6f5348f5220a557f89c3a796321a52aebf/click/core.py#L694) based on sys.argv)
- this changes the output *slightly*, but it's only removing a newline from the end, which shouldn't matter (there is still a newline at the end – previously it seems that there were two)

On my machine, this takes runtime of `pipenv --completion` from 900ms to about 550ms.

#1247