### PR TITLE
Bump VS Code support to no longer be listed as in-progress

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -185,10 +185,10 @@ different products which integrate with Pipenv projects:
 - `PyUp <https://pyup.io>`_ (Security Notification)
 - `Emacs <https://github.com/pwalsh/pipenv.el>`_ (Editor Integration)
 - `Fish Shell <https://github.com/fisherman/pipenv>`_ (Automatic ``$ pipenv shell``!)
+- `VS Code <https://code.visualstudio.com/docs/python/environments>`_ (Editor Integration)
 
 Works in progress:
 
-- `Microsoft VSCode <https://github.com/Microsoft/vscode-python/issues/404>`_ (Editor Integration)
 - `Sublime Text <https://github.com/kennethreitz/pipenv-sublime>`_ (Editor Integration)
 - `PyCharm <https://www.jetbrains.com/pycharm/download/>`_ (Editor Integration)
 - Mysterious upcoming Google Cloud product (Cloud Hosting)


### PR DESCRIPTION
And since VS Code's integration is live, if there's any desire to update the instructions to point to VS Code instead of Sublime whose support is still in-development, let me know and I can send a PR for that.