### PR TITLE
Avoid type error when there’s no Python in PATH

### DIFF
--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -625,7 +625,7 @@ def ensure_project(three=None, python=None, validate=True, system=False, warn=Tr
             # Warn users if they are using the wrong version of Python.
             if project.required_python_version:
 
-                path_to_python = which('python')
+                path_to_python = which('python') or which('py')
 
                 if path_to_python and project.required_python_version not in (python_version(path_to_python) or ''):
                     click.echo(

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -627,7 +627,7 @@ def ensure_project(three=None, python=None, validate=True, system=False, warn=Tr
 
                 path_to_python = which('python')
 
-                if project.required_python_version not in (python_version(path_to_python) or ''):
+                if path_to_python and project.required_python_version not in (python_version(path_to_python) or ''):
                     click.echo(
                         '{0}: Your Pipfile requires {1} {2}, '
                         'but you are using {3} ({4}).'.format(
@@ -1767,7 +1767,7 @@ def do_install(
         except IOError:
             click.echo(
                 crayons.red(
-                   u'Unable to find requirements file at {0}.'.format(crayons.normal(requirements))
+                    u'Unable to find requirements file at {0}.'.format(crayons.normal(requirements))
                 ),
                 err=True
             )


### PR DESCRIPTION
I’m not sure what should be done when there’s no Python no warn about. This just skips the warning when there’s none.

Also regarding #1620 I also added detection to `py` in addition to `python`. This should be useful for Windows users (who generally use `py` whenever Un\*x users use `python`).