### PR TITLE
Ask py.exe for its opinion when choosing a Python

### DIFF
--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -369,12 +369,12 @@ def find_python_from_py(python):
     import subprocess
     for ver_arg in reversed(version_args):
         try:
-            python_exe = subprocess.check_output(
-                [py, ver_arg, '-c', 'import sys; print(sys.executable)'],
-                encoding=sys.getdefaultencoding(),
-            ).strip()
+            python_exe = subprocess.check_output([py, ver_arg, '-c', 'import sys; print(sys.executable)'])
         except subprocess.CalledProcessError:
             continue
+        if not isinstance(python_exe, str):
+            python_exe = python_exe.decode(sys.getdefaultencoding())
+        python_exe = python_exe.strip()
         version = python_version(python_exe)
         if (version or '').startswith(python):
             return python_exe


### PR DESCRIPTION
Hopefully a viable alternative to #1620. In addition to looking for executables in PATH, also asks py.exe (if there is one) for its opinion when choosing an executable. Windows users would be able to use `--two`, `--three`, and `--python=<VERSION>`; this will be passed on to py.exe and ask if it can find any matching executable.

Non-Windows users will not be affected because there wouldn't be a `py.exe` to start with.