### PR TITLE
Fix `do_outdated()` when `pip freeze` is blank

### DIFF
--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -1701,6 +1701,7 @@ def do_py(system=False):
 def do_outdated():
     packages = {}
     results = delegator.run('{0} freeze'.format(which('pip'))).out.strip().split('\n')
+    results = filter(bool, results)
     for result in results:
         packages.update(convert_deps_from_pip(result))
 


### PR DESCRIPTION
- If no packages are installed, `results` contains a single empty string. This causes problems in the subsequent call to `convert_deps_from_pip`. Therefore filter out empty strings from `results` to avoid this.
- Fixes #1699