### PR TITLE
Make pew resolve workon home lazily

### DIFF
--- a/pipenv/patched/pew/pew.py
+++ b/pipenv/patched/pew/pew.py
@@ -52,8 +52,10 @@ if windows:
 else:
     default_home = os.path.join(
         os.environ.get('XDG_DATA_HOME', '~/.local/share'), 'virtualenvs')
-workon_home = expandpath(
-    os.environ.get('WORKON_HOME', default_home))
+
+
+def get_workon_home():
+    return expandpath(os.environ.get('WORKON_HOME', default_home))
 
 
 def makedirs_and_symlink_if_needed(workon_home):
@@ -96,7 +98,7 @@ def deploy_completions():
 
 
 def get_project_dir(env):
-    project_file = workon_home / env / '.project'
+    project_file = get_workon_home() / env / '.project'
     if project_file.exists():
         with project_file.open() as f:
             project_dir = f.readline().strip()
@@ -113,7 +115,7 @@ def unsetenv(key):
 
 
 def compute_path(env):
-    envdir = workon_home / env
+    envdir = get_workon_home() / env
     return os.pathsep.join([
         str(envdir / env_bin_dir),
         os.environ['PATH'],
@@ -127,7 +129,7 @@ def inve(env, command, *args, **kwargs):
     # we don't strictly need to restore the environment, since pew runs in
     # its own process, but it feels like the right thing to do
     with temp_environ():
-        os.environ['VIRTUAL_ENV'] = str(workon_home / env)
+        os.environ['VIRTUAL_ENV'] = str(get_workon_home() / env)
         os.environ['PATH'] = compute_path(env)
 
         unsetenv('PYTHONHOME')
@@ -216,7 +218,7 @@ def mkvirtualenv(envname, python=None, packages=[], project=None,
     if python:
         rest = ["--python=%s" % python] + rest
 
-    path = (workon_home / envname).absolute()
+    path = (get_workon_home() / envname).absolute()
 
     try:
         check_call([sys.executable, "-m", "virtualenv", str(path)] + rest)
@@ -265,7 +267,7 @@ project directory to associate with the new environment.')
 def rmvirtualenvs(envs):
     error_happened = False
     for env in envs:
-        env = workon_home / env
+        env = get_workon_home() / env
         if os.environ.get('VIRTUAL_ENV') == str(env):
             err("ERROR: You cannot remove the active environment (%s)." % env)
             error_happened = True
@@ -295,7 +297,7 @@ def packages(site_packages):
 def showvirtualenv(env):
     columns, _ = get_terminal_size()
     pkgs = sorted(packages(sitepackages_dir(env)))
-    env_python = workon_home / env / env_bin_dir / 'python'
+    env_python = get_workon_home() / env / env_bin_dir / 'python'
     l = len(env) + 2
     version = invoke(str(env_python), '-V')
     version = ' - '.join((version.out + version.err).splitlines())
@@ -317,8 +319,8 @@ def show_cmd(argv):
 
 
 def lsenvs():
-    return sorted(set(env.parts[-3] for env in
-                      workon_home.glob(os.path.join('*', env_bin_dir, 'python*'))))
+    items = get_workon_home().glob(os.path.join('*', env_bin_dir, 'python*'))
+    return sorted(set(env.parts[-3] for env in items))
 
 
 def lsvirtualenv(verbose):
@@ -347,7 +349,7 @@ def parse_envname(argv, no_arg_callback):
     env = argv[0]
     if env.startswith('/'):
         sys.exit("ERROR: Invalid environment name '{0}'.".format(env))
-    if not (workon_home / env).exists():
+    if not (get_workon_home() / env).exists():
         sys.exit("ERROR: Environment '{0}' does not exist. Create it with \
 'pew new {0}'.".format(env))
     else:
@@ -372,7 +374,7 @@ def sitepackages_dir(env=os.environ.get('VIRTUAL_ENV')):
     if not env:
         sys.exit('ERROR: no virtualenv active')
     else:
-        env_python = workon_home / env / env_bin_dir / 'python'
+        env_python = get_workon_home() / env / env_bin_dir / 'python'
         return Path(invoke(str(env_python), '-c', 'import distutils; \
 print(distutils.sysconfig.get_python_lib())').out)
 
@@ -459,6 +461,7 @@ def cp_cmd(argv):
 
 def copy_virtualenv_project(source, target):
     source = expandpath(source)
+    workon_home = get_workon_home()
     if not source.exists():
         source = workon_home / source
         if not source.exists():
@@ -490,7 +493,7 @@ def rename_cmd(argv):
 
 def setvirtualenvproject(env, project):
     print('Setting project for {0} to {1}'.format(env, project))
-    with (workon_home / env / '.project').open('wb') as prj:
+    with (get_workon_home() / env / '.project').open('wb') as prj:
         prj.write(str(project).encode())
 
 
@@ -502,7 +505,7 @@ def setproject_cmd(argv):
     env = args.get(0, os.environ.get('VIRTUAL_ENV'))
     if not env:
         sys.exit('pew setproject [virtualenv] [project_path]')
-    if not (workon_home / env).exists():
+    if not (get_workon_home() / env).exists():
         sys.exit("Environment '%s' doesn't exist." % env)
     if not os.path.isdir(project):
         sys.exit('pew setproject: %s does not exist' % project)
@@ -512,7 +515,7 @@ def setproject_cmd(argv):
 def mkproject_cmd(argv):
     """Create a new project directory and its associated virtualenv."""
     if '-l' in argv or '--list' in argv:
-        templates = [t.name[9:] for t in workon_home.glob("template_*")]
+        templates = [t.name[9:] for t in get_workon_home().glob("template_*")]
         print("Available project templates:", *templates, sep='\n')
         return
 
@@ -542,7 +545,7 @@ Create it or set PROJECT_HOME to an existing directory.' % projects_home)
     project.mkdir()
 
     for template_name in args.templates:
-        template = workon_home / ("template_" + template_name)
+        template = get_workon_home() / ("template_" + template_name)
         inve(args.envname, str(template), args.envname, str(project))
     if args.activate:
         shell(args.envname, cwd=str(project))
@@ -552,7 +555,7 @@ def mktmpenv_cmd(argv):
     """Create a temporary virtualenv."""
     parser = mkvirtualenv_argparser()
     env = '.'
-    while (workon_home / env).exists():
+    while (get_workon_home() / env).exists():
         env = hex(random.getrandbits(64))[2:-1]
 
     args, rest = parser.parse_known_args(argv)
@@ -574,10 +577,10 @@ def wipeenv_cmd(argv):
 
     if not env:
         sys.exit('ERROR: no virtualenv active')
-    elif not (workon_home / env).exists():
+    elif not (get_workon_home() / env).exists():
         sys.exit("ERROR: Environment '{0}' does not exist.".format(env))
     else:
-        env_pip = str(workon_home / env / env_bin_dir / 'pip')
+        env_pip = str(get_workon_home() / env / env_bin_dir / 'pip')
         all_pkgs = set(invoke(env_pip, 'freeze').out.splitlines())
         pkgs = set(p for p in all_pkgs if len(p.split("==")) == 2)
         ignored = sorted(all_pkgs - pkgs)
@@ -623,7 +626,7 @@ def restore_cmd(argv):
         sys.exit('You must provide a valid virtualenv to target')
 
     env = argv[0]
-    path = workon_home / env
+    path = get_workon_home() / env
     py = path / env_bin_dir / ('python.exe' if windows else 'python')
     exact_py = py.resolve().name
 
@@ -633,7 +636,7 @@ def restore_cmd(argv):
 def dir_cmd(argv):
     """Print the path for the virtualenv directory"""
     env = parse_envname(argv, lambda : sys.exit('You must provide a valid virtualenv to target'))
-    print(workon_home / env)
+    print(get_workon_home() / env)
 
 
 def install_cmd(argv):
@@ -745,7 +748,7 @@ def print_commands(cmds):
 
 
 def pew():
-    first_run = makedirs_and_symlink_if_needed(workon_home)
+    first_run = makedirs_and_symlink_if_needed(get_workon_home())
     if first_run and sys.stdin.isatty():
         first_run_setup()
 


### PR DESCRIPTION
Fix #1682. The problem is that pew resolves `workon_home` on *import time*, but we need to patch the lookup logic. This is fine when we run it with pexpect, but not when invoked programmatically. The environment variable `WORKON_HOME` is changed too late for pew to pick up.

The quick fix is to simply delay importing pew, but it is too unreliable and easy to break again in the future. In the end I decided to just change all `workon_home` occurrences to function calls, so the value is resolved lazily, and can be patched whenever we want to.