### PR TITLE
Support Powershell Core (pwsh.exe) on Windows

### DIFF
--- a/pipenv/patched/pew/_win_utils.py
+++ b/pipenv/patched/pew/_win_utils.py
@@ -14,7 +14,7 @@ from ctypes.wintypes import DWORD, LONG
 
 ERROR_NO_MORE_FILES = 18
 INVALID_HANDLE_VALUE = c_void_p(-1).value
-SHELL_NAMES = ['cmd', 'powershell', 'cmder']
+SHELL_NAMES = ['cmd', 'powershell', 'pwsh', 'cmder']
 
 class PROCESSENTRY32(Structure):
     _fields_ = [

--- a/pipenv/patched/pew/pew.py
+++ b/pipenv/patched/pew/pew.py
@@ -195,7 +195,7 @@ def shell(env, cwd=None):
     env = str(env)
     shell = _detect_shell()
     shell_name = Path(shell).stem
-    if shell_name not in ('Cmder', 'bash', 'elvish', 'powershell', 'klingon', 'cmd'):
+    if shell_name not in ('Cmder', 'bash', 'elvish', 'powershell', 'pwsh', 'klingon', 'cmd'):
         # On Windows the PATH is usually set with System Utility
         # so we won't worry about trying to check mistakes there
         shell_check = (sys.executable + ' -c "from pipenv.patched.pew.pew import '


### PR DESCRIPTION
So for some reason Microsoft thinks it’s a good idea to call a thing PowerShell but uses a different executable name. Let’s add `pwsh` wherever there is a `powershell`.

I only fix the `pipenv shell` usage. Completion likely won’t work (because I didn’t do anything about it) but ¯\\\_(ツ)\_/¯