### PR TITLE
Fix venv creation during tests

### DIFF
--- a/tests/test_pipenv.py
+++ b/tests/test_pipenv.py
@@ -127,19 +127,22 @@ class TestPipenv:
     def test_pipenv_venv(self):
         with PipenvInstance() as p:
             p.pipenv('--python python')
-            assert p.pipenv('--venv').out
+            venv_path = p.pipenv('--venv').out.strip()
+            assert os.path.isdir(venv_path)
 
     @pytest.mark.cli
     def test_pipenv_py(self):
         with PipenvInstance() as p:
             p.pipenv('--python python')
-            assert p.pipenv('--py').out
+            python = p.pipenv('--py').out.strip()
+            assert os.path.basename(python).startswith('python')
 
     @pytest.mark.cli
     def test_pipenv_rm(self):
         with PipenvInstance() as p:
             p.pipenv('--python python')
-            venv_path = p.pipenv('--venv').out
+            venv_path = p.pipenv('--venv').out.strip()
+            assert os.path.isdir(venv_path)
 
             assert p.pipenv('--rm').out
             assert not os.path.isdir(venv_path)


### PR DESCRIPTION
Turns out #1666 and #1729 actually have the same root cause, and fixing one resolves the other. Changes made in #1729 are reverted because they are not needed anymore.

Also added some extra tests that helped me locate this problem.