### PR TITLE
Update `pipenv check` docs for Safety-DB removal

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -187,12 +187,13 @@ Example::
 
 .. note::
 
-   Commercial redistributors of `pipenv` should be aware that the public `Safety-DB`
-   project backing this feature is licensed as CC-BY-NC-SA by `pyup.io`. While
-   `pyup.io` have [stated explicitly](https://github.com/pypa/pipenv/issues/1651#issuecomment-372583779)
-   that commercial *use* of this `pipenv` feature is fine, commercial redistributors may want
-   to perform their own legal assessment and perhaps chat directly to `pyup.io` about
-   the specific licensing terms.
+   In order to enable this functionality while maintaining its permissive
+   copyright license, `pipenv` embeds an API client key for the backend
+   Safety API operated by pyup.io rather than including a full copy of the
+   CC-BY-NC-SA licensed Safety-DB database. This embedded client key is
+   shared across all `pipenv check` users, and hence will be subject to
+   API access throttling based on overall usage rather than individual
+   client usage.
 
 
 ☤ Community Integrations


### PR DESCRIPTION
We removed the embedded copy of Safety-DB, so there's
no longer any copyright concern about the CC-BY-NC-SA
license, but it does mean `pipenv check` may end up throttled
eventually as all requests to the backend API use a common
key.