### PR TITLE
Cache parsed pipfile

### DIFF
--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -291,6 +291,7 @@ def ensure_pipfile(validate=True, skip_requirements=False):
     if validate and project.virtualenv_exists and not PIPENV_SKIP_VALIDATION:
         # Ensure that Pipfile is using proper casing.
         p = project.parsed_pipfile
+        p.clear_pipfile_cache()
         changed = ensure_proper_casing(pfile=p)
         # Write changes out to disk.
         if changed:

--- a/pipenv/project.py
+++ b/pipenv/project.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-import copy
 import json
 import os
 import re
@@ -304,7 +303,7 @@ class Project(object):
             parsed = self._parse_pipfile(contents)
             _cache.pipfile_cache[cache_key] = parsed
         # deepcopy likely unnecessary but why not avoid bugs?
-        return copy.deepcopy(_cache.pipfile_cache[cache_key])
+        return _cache.pipfile_cache[cache_key]
 
     def _parse_pipfile(self, contents):
         # If any outline tables are present...

--- a/pipenv/project.py
+++ b/pipenv/project.py
@@ -300,8 +300,8 @@ class Project(object):
         # Open the pipfile, read it into memory.
         with open(self.pipfile_location) as f:
             contents = f.read()
-        # this should be pretty fast (ish) and we need this pipfile a lot
-        cache_key = (self.pipfile_location, hashlib.md5(contents.encode('utf8')).hexdigest())
+        # use full contents to get around str/bytes 2/3 issues
+        cache_key = (self.pipfile_location, contents)
         if cache_key not in _cache.pipfile_cache:
             parsed = self._parse_pipfile(contents)
             _cache.pipfile_cache[cache_key] = parsed


### PR DESCRIPTION
On a (390+ line) Pipfile, it takes ~5s to parse the entire thing :O.  Pipenv has to parse the pipfile repeatedly and all over the place, so caching the contents speeds things up dramatically when trying to do `pipenv lock` (at least in this case).

This PR makes a little cache based upon file location + md5sum of contents for the pipfile (and the hashing is pretty fast here), which takes ~0.09ms on a cache hit. Given that the cache key is based on the file contents, should be completely fine to do (only possible issue is if parsed_pipfile gets mutated).  I tried returning a copy of the object, but `contoml` throws super weird exceptions if you do that, so I added a helper to clear the pipfile cache in places where it *might* be mutated (even tho I think it's likely overly defensive).
