### PR TITLE
Improve resolver path-patching

### DIFF
--- a/pipenv/__init__.py
+++ b/pipenv/__init__.py
@@ -19,7 +19,7 @@ try:
 except Exception:
     pass
 from .cli import cli
-from .import resolver
+from . import resolver
 
 if __name__ == '__main__':
     cli()

--- a/pipenv/resolver.py
+++ b/pipenv/resolver.py
@@ -4,9 +4,15 @@ import json
 import logging
 
 os.environ['PIP_PYTHON_PATH'] = sys.executable
-for _dir in ('vendor', 'patched', '..'):
-    dirpath = os.path.sep.join([os.path.dirname(__file__), _dir])
-    sys.path.insert(0, dirpath)
+
+
+def _patch_path():
+    pipenv_libdir = os.path.dirname(os.path.abspath(__file__))
+    for _dir in ('vendor', 'patched'):
+        sys.path.insert(0, os.path.join(pipenv_libdir, _dir))
+    site_packages_dir = os.path.dirname(pipenv_libdir)
+    if site_packages_dir not in sys.path:
+        sys.path.append(site_packages_dir)
 
 
 def which(*args, **kwargs):
@@ -72,4 +78,5 @@ def main():
 
 
 if __name__ == '__main__':
+    _patch_path()
     main()


### PR DESCRIPTION
Add the parent site-packages directory to sys.path *after* built-in ones, and only when it does not already exist.

This should vastly improve the resolver's robustness against hostile Python environments, such as #1753. It might help with issues like #693 as well, but I'm not sure (and not interested in figuring out either).