### PR TITLE
pipenv.help output command formatting fixes

### DIFF
--- a/pipenv/help.py
+++ b/pipenv/help.py
@@ -12,6 +12,7 @@ from .pep508checker import lookup
 
 def main():
     print('<details><summary>$ python -m pipenv.help output</summary>')
+    print('')
     print('Pipenv version: `{0!r}`'.format(__version__))
     print('')
     print('Pipenv location: `{0!r}`'.format(os.path.dirname(pipenv.__file__)))

--- a/pipenv/help.py
+++ b/pipenv/help.py
@@ -82,7 +82,7 @@ def main():
         with open(project.lockfile_location, 'r') as f:
             print(f.read())
         print('```')
-        print('</details>')
+    print('</details>')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
* The `<details>` tag did not always close itself
* GitHub seems to require an additional line break after HTML to respect Markdown formatting again

Both were encountered when I was creating an issue