### PR TITLE
Fix error on pipenv clean with empty virtualenv

### DIFF
--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -2523,12 +2523,12 @@ def do_clean(
     # Ensure that virtualenv is available.
     ensure_project(three=three, python=python, validate=False)
     ensure_lockfile()
-    installed_packages = delegator.run(
+    installed_packages = filter(None, delegator.run(
         '{0} freeze'.format(which('pip'))
     ).out.strip(
     ).split(
         '\n'
-    )
+    ))
     installed_package_names = []
     for installed in installed_packages:
         r = get_requirement(installed)

--- a/tests/test_pipenv.py
+++ b/tests/test_pipenv.py
@@ -1051,3 +1051,9 @@ requests = "==2.14.0"
             assert target_package in p.pipfile['packages']
             assert p.pipfile['packages'][target_package] == '*'
             assert target_package in p.lockfile['default']
+
+    @pytest.mark.clean
+    def test_clean_on_empty_venv(self, pypi):
+        with PipenvInstance(pypi=pypi) as p:
+            c = p.pipenv('clean')
+            assert c.return_code == 0


### PR DESCRIPTION
Obv could also *not* create the empty virtualenv when running pipenv
clean, but in general can imagine this also occurring if you created an
empty virtualenv and then tried to do clean within it.

(installed packages was [''])

Fixes #1750.

Wanted to make most minimal change possible, but I could see also adding an `if virtualenv_does_not_exist: return` too