### PR TITLE
Make white only for python 3 dev-packages

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -12,7 +12,7 @@ click = "*"
 pytest-pypy = {path = "./tests/pytest-pypi", editable = true}
 pytest-tap = "*"
 stdeb = {version="*", sys_platform="== 'linux'"}
-white = {version="*"}
+white = {version="*", markers="python_version >= '3.0'"}
 
 
 [packages]


### PR DESCRIPTION
I think white only is available for Python 3+ (with no versions for python 2). This was causing test runner to fail for me locally.