### PR TITLE
Allow values in Pipfile to consume Environment Variables

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -302,6 +302,27 @@ To prevent pipenv from loading the ``.env`` file, set the ``PIPENV_DONT_LOAD_ENV
 
     $ PIPENV_DONT_LOAD_ENV=1 pipenv shell
 
+☤ Support for Environment Variables
+-----------------------------------
+
+``pipenv`` supports the usage of environment variables in values. For example:
+
+    [[source]]
+    url = "https://${PYPI_USERNAME}:${PYPI_PASSWORD}@my_private_repo.example.com/simple"
+    verify_ssl = true
+    name = "pypi"
+
+    [dev-packages]
+
+    [packages]
+    requests = {version="*", index="home"}
+    maya = {version="*", index="pypi"}
+    records = "*"
+
+Environment variables may be specified as ``${MY_ENVAR}`` or ``$MY_ENVAR``.
+On Windows, ``%MY_ENVAR%`` is supported in addition to ``${MY_ENVAR}`` or ``$MY_ENVAR``.
+
+
 ☤ Configuration With Environment Variables
 ------------------------------------------
 

--- a/tests/test_vendor.py
+++ b/tests/test_vendor.py
@@ -1,5 +1,6 @@
 # Make sure we use the patched packages.
 import pipenv  # noqa
+import os
 
 from prettytoml import lexer
 from prettytoml.elements.atomic import AtomicElement
@@ -7,6 +8,7 @@ from prettytoml.elements.metadata import (
     WhitespaceElement, PunctuationElement, CommentElement
 )
 from prettytoml.elements.table import TableElement
+from pipenv.vendor.pipfile.api import PipfileParser
 
 
 def test_table():
@@ -27,3 +29,36 @@ def test_table():
     assert set(table.items()) == {('id', 42), ('age', 14)}
     del table['id']
     assert set(table.items()) == {('age', 14)}
+
+
+class TestPipfileParser:
+
+    def test_inject_environment_variables(self):
+        os.environ['PYTEST_PIPFILE_TEST'] = "XYZ"
+        p = PipfileParser()
+
+        parsed_dict = p.inject_environment_variables({
+            "a_string": "https://$PYTEST_PIPFILE_TEST@something.com",
+            "another_string": "https://${PYTEST_PIPFILE_TEST}@something.com",
+            "nested": {
+                "a_string": "https://$PYTEST_PIPFILE_TEST@something.com",
+                "another_string": "${PYTEST_PIPFILE_TEST}",
+            },
+            "list": [
+                {
+                    "a_string": "https://$PYTEST_PIPFILE_TEST@something.com",
+                    "another_string": "${PYTEST_PIPFILE_TEST}"
+                },
+                {},
+            ],
+            "bool": True,
+            "none": None,
+        })
+
+        assert parsed_dict["a_string"] == "https://XYZ@something.com"
+        assert parsed_dict["another_string"] == "https://XYZ@something.com"
+        assert parsed_dict["nested"]["another_string"] == "XYZ"
+        assert parsed_dict["list"][0]["a_string"] == "https://XYZ@something.com"
+        assert parsed_dict["list"][1] == {}
+        assert parsed_dict["bool"] is True
+        assert parsed_dict["none"] is None


### PR DESCRIPTION
Relying on `os.path.expandvars()` to inject environment variables in strings. Works on Windows, back-supports Python 2.7.

See https://github.com/pypa/pipenv/issues/1688

I'm not 100% sure that this is the correct place to do this injection.

Some thoughts:
- The Pipfile hash should be determined after values have attempted to be inserted.
- Pipfile shouldn't be intelligent by trying to differentiate env vars from regular characters—if an env var can't be inserted, the string should remain intact.
- As it stands, Pipenv's vendor folder contains some version of this repository. I don't fully understand the reasons behind this, maybe we could pin it as a requirement instead? We could then separate tests.

Mirrored Pipfile PR: https://github.com/pypa/pipfile/pull/105