### PR TITLE
fix prepare_pip_source_args not properly handle user & pw in repo URLs

### DIFF
--- a/pipenv/utils.py
+++ b/pipenv/utils.py
@@ -265,7 +265,7 @@ def prepare_pip_source_args(sources, pip_args=None):
                     pip_args.extend(
                         [
                             '--trusted-host',
-                            urlparse(source['url']).netloc.split(':')[0],
+                            urlparse(source['url']).hostname,
                         ]
                     )
     return pip_args

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -358,3 +358,38 @@ twine = "*"
         assert not git_reformat.local_file
         # Test regression where VCS uris were being handled as paths rather than VCS entries
         assert git_reformat.vcs == 'git'
+
+    @pytest.mark.utils
+    @pytest.mark.parametrize(
+        'sources, expected_args',
+        [
+            ([{'url': 'https://test.example.com/simple', 'verify_ssl': True}],
+             ['-i', 'https://test.example.com/simple']),
+            ([{'url': 'https://test.example.com/simple', 'verify_ssl': False}],
+             ['-i', 'https://test.example.com/simple',  '--trusted-host', 'test.example.com']),
+
+             ([{'url': "https://pypi.python.org/simple"},
+              {'url': "https://custom.example.com/simple"}],
+             ['-i', 'https://pypi.python.org/simple',
+              '--extra-index-url', 'https://custom.example.com/simple']),
+
+             ([{'url': "https://pypi.python.org/simple"},
+              {'url': "https://custom.example.com/simple",  'verify_ssl': False}],
+             ['-i', 'https://pypi.python.org/simple',
+              '--extra-index-url', 'https://custom.example.com/simple',
+              '--trusted-host', 'custom.example.com']),
+
+           ([{'url': "https://pypi.python.org/simple"},
+             {'url': "https://user:password@custom.example.com/simple",  'verify_ssl': False}],
+            ['-i', 'https://pypi.python.org/simple',
+             '--extra-index-url', 'https://user:password@custom.example.com/simple',
+             '--trusted-host', 'custom.example.com']),
+
+            ([{'url': "https://pypi.python.org/simple"},
+              {'url': "https://user:password@custom.example.com/simple",}],
+             ['-i', 'https://pypi.python.org/simple',
+              '--extra-index-url', 'https://user:password@custom.example.com/simple',]),
+        ],
+    )
+    def test_prepare_pip_source_args(self, sources, expected_args):
+        assert pipenv.utils.prepare_pip_source_args(sources, pip_args=None) == expected_args


### PR DESCRIPTION

When the I use a custom source in the Pipfile that is protected by a user & password. 

The [logic in prepare_pip_source_args](https://github.com/pypa/pipenv/blob/2282e7045f08c0794973d296b11ea174e7fda48a/pipenv/utils.py#L268) tries to manually parse ParseResult.netloc (returned from urlparse) this results in the username being passed as the `--trusted-host` when `verify_ssl` is set to false in the Pipfile.

For example, if one of the sources in the Pipfile is `https://user:password@custom.example.com/simple`  
it will result calling `resolver.py` with the wrong params (passed via the PIPENV_PACKAGES environment variable) and called from venv_resolve_deps
the value of the ` --trusted-host` will be the username instead of the host name.

https://github.com/pypa/pipenv/issues/1773