### PR TITLE
better cleanup_toml

### DIFF
--- a/pipenv/utils.py
+++ b/pipenv/utils.py
@@ -165,17 +165,12 @@ def cleanup_toml(tml):
     new_toml = []
     # Add newlines between TOML sections.
     for i, line in enumerate(toml.split('\n')):
-        after = False
         # Skip the first line.
         if line.startswith('['):
             if i > 0:
                 # Insert a newline before the heading.
-                new_toml.append('\n')
-            after = True
+                new_toml.append('')
         new_toml.append(line)
-        # Insert a newline after the heading.
-        if after:
-            new_toml.append('')
     # adding new line at the end of the TOML file
     new_toml.append('')
     toml = '\n'.join(new_toml)


### PR DESCRIPTION
Before this commit Pipfile had a more
than neeeded newlines between sections.

Currently generated Pipfile is
```
[[source]]

url = "https://pypi.python.org/simple"
verify_ssl = true
name = "pypi"


[packages]



[dev-packages]



[requires]

python_version = "3.6"
```
while after this commit it would become
```
[[source]]
url = "https://pypi.python.org/simple"
verify_ssl = true
name = "pypi"

[packages]

[dev-packages]

[requires]
python_version = "3.6"
```