### PR TITLE
remove --update option from the documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -120,7 +120,6 @@ Fish is the best shell. You should use it.
     Usage: pipenv [OPTIONS] COMMAND [ARGS]...
 
     Options:
-      --update         Update Pipenv & pip to latest.
       --where          Output project home information.
       --venv           Output virtualenv information.
       --py             Output Python interpreter information.


### PR DESCRIPTION
I've removed the --update option from the documentation, as it was recently removed from pipenv.