### PR TITLE
Print out what gets passed to resolver.

### DIFF
--- a/pipenv/environments.py
+++ b/pipenv/environments.py
@@ -78,3 +78,4 @@ PYENV_INSTALLED = (
 SESSION_IS_INTERACTIVE = bool(os.isatty(sys.stdout.fileno()))
 PIPENV_SHELL = os.environ.get('SHELL') or os.environ.get('PYENV_SHELL')
 PIPENV_CACHE_DIR = os.environ.get('PIPENV_CACHE_DIR', user_cache_dir('pipenv'))
+PIPENV_DEBUG = bool(os.environ.get('PIPENV_DEBUG'))

--- a/pipenv/utils.py
+++ b/pipenv/utils.py
@@ -50,7 +50,7 @@ from pip9.index import Link
 from pip9._vendor.requests.exceptions import HTTPError, ConnectionError
 
 from .pep508checker import lookup
-from .environments import SESSION_IS_INTERACTIVE, PIPENV_MAX_ROUNDS, PIPENV_CACHE_DIR
+from .environments import SESSION_IS_INTERACTIVE, PIPENV_MAX_ROUNDS, PIPENV_CACHE_DIR, PIPENV_DEBUG
 
 if six.PY2:
 
@@ -372,6 +372,9 @@ def venv_resolve_deps(
         '--clear' if clear else '',
     )
     os.environ['PIPENV_PACKAGES'] = '\n'.join(deps)
+    if PIPENV_DEBUG:
+        click.echo("export PIPENV_PACKAGES='{}'".format(os.environ['PIPENV_PACKAGES']))
+        click.echo(cmd)
     c = delegator.run(cmd, block=True)
     del os.environ['PIPENV_PACKAGES']
     try:


### PR DESCRIPTION
For dev purposes, it's really helpful to be able to copy/paste a few lines that let you generate exactly what was passed to the resolver. But this can really clutter up verbose output in general, so I was thinking we could add an extra env var to dump development-related output.

Only 50% sure anybody else will even want this - so nbd if you just want to close it :)


```
$ export PIPENV_DEBUG=1
$ pipenv lock
Locking [dev-packages] dependencies…
export PIPENV_PACKAGES='-e ./tests/pytest-pypi
twine -i https://pypi.python.org/simple
stdeb; sys_platform == 'linux' -i https://pypi.python.org/simple
sphinx<=1.5.5 -i https://pypi.python.org/simple
-e .
pytest-tap -i https://pypi.python.org/simple
pytest -i https://pypi.python.org/simple
sphinx-click -i https://pypi.python.org/simple
pytest-xdist -i https://pypi.python.org/simple
white; python_version >= '3.6' -i https://pypi.python.org/simple
click -i https://pypi.python.org/simple
mock -i https://pypi.python.org/simple
flake8>=3.3.0,<4 -i https://pypi.python.org/simple'
"/Users/jtratner/.virtualenvs/pipenv-Cfb3XqC0/bin/python" "/Users/jtratner/pipenv/pipenv/resolver.py"
```