### PR TITLE
Still check warehouse API for new pypi.org

### DIFF
--- a/pipenv/utils.py
+++ b/pipenv/utils.py
@@ -462,7 +462,8 @@ def resolve_deps(
             else:
                 markers = markers_lookup.get(result.name)
             collected_hashes = []
-            if 'python.org' in '|'.join([source['url'] for source in sources]):
+            if any('python.org' in source['url'] or 'pypi.org' in source['url']
+                   for source in sources):
                 try:
                     # Grab the hashes from the new warehouse API.
                     r = requests.get(


### PR DESCRIPTION
I think the check for we-should-check-warehouse API needs to be updated to also consider pypi.org.