### PR TITLE
Simplify marker checks in patched resolver

### DIFF
--- a/pipenv/patched/piptools/resolver.py
+++ b/pipenv/patched/piptools/resolver.py
@@ -310,24 +310,28 @@ class Resolver(object):
         for dependency_string in dependency_strings:
 
             try:
-                split_deps = dependency_string.split(';')
-                dependencies, markers = split_deps[0], '; '.join(list(set([marker.strip() for marker in split_deps[1:]])))
-                individual_dependencies = [dep.strip() for dep in dependencies.split(', ')]
+                markers = None
+                if ';' in dependency_string:
+                    # split off markers and remove any duplicates by comparing against deps 
+                    dependencies, markers = dependency_string.rsplit(';', 1)
+                    dependency_string = ';'.join([dep for dep in dependencies.split(';') if dep.strip() != markers.strip()])
+                individual_dependencies = [dep.strip() for dep in dependency_string.split(', ')]
                 cleaned_deps = []
                 for dep in individual_dependencies:
                     tokens = [token.strip() for token in dep.split(';')]
                     cleaned_tokens = []
-                    markers = []
+                    dep_markers = []
                     if len(tokens) == 1:
                         cleaned_deps.append(tokens[0])
                         continue
-                    markers = list(set(tokens[1:]))
+                    dep_markers = list(set(tokens[1:]))
                     cleaned_tokens.append(tokens[0])
-                    if markers:
-                        cleaned_tokens.extend(markers)
+                    if dep_markers:
+                        cleaned_tokens.extend(dep_markers)
                     cleaned_deps.append('; '.join(cleaned_tokens))
                 _dependency_string = ', '.join(set(cleaned_deps))
-                _dependency_string += '; {0}'.format(markers)
+                if markers:
+                    _dependency_string += ';{0}'.format(markers)
 
                 yield InstallRequirement.from_line(_dependency_string, constraint=ireq.constraint)
             except InvalidMarker:


### PR DESCRIPTION
- Fix Overlapping naming checking for inner markers
- Perform a first-pass right-side split of markers and remove other
exact matching markers from the dependency string
- Fixes #1617, #1791, #1805, #1622