### PR TITLE
Fix environment variable expansion with extras

### DIFF
--- a/pipenv/vendor/pipfile/api.py
+++ b/pipenv/vendor/pipfile/api.py
@@ -4,6 +4,7 @@ import codecs
 import json
 import hashlib
 import platform
+import six
 import sys
 import os
 
@@ -69,9 +70,10 @@ class PipfileParser(object):
 
         if not d:
             return d
-
+        if isinstance(d, six.string_types):
+            return os.path.expandvars(d)
         for k, v in d.items():
-            if isinstance(v, str):
+            if isinstance(v, six.string_types):
                 d[k] = os.path.expandvars(v)
             elif isinstance(v, dict):
                 d[k] = self.inject_environment_variables(v)


### PR DESCRIPTION
Current master tests are failing because of small bug in environment variable expansion.

I.e., this fails:

```
$ pipenv install 'requests[socks]'
# long traceback ending with
  File "/Users/jtratner/pipenv/pipenv/vendor/pipfile/api.py", line 103, in parse
    parsed_toml = self.inject_environment_variables(toml.loads(content))
  File "/Users/jtratner/pipenv/pipenv/vendor/pipfile/api.py", line 79, in inject_environment_variables
    d[k] = self.inject_environment_variables(v)
  File "/Users/jtratner/pipenv/pipenv/vendor/pipfile/api.py", line 79, in inject_environment_variables
    d[k] = self.inject_environment_variables(v)
  File "/Users/jtratner/pipenv/pipenv/vendor/pipfile/api.py", line 81, in inject_environment_variables
    d[k] = [self.inject_environment_variables(e) for e in v]
  File "/Users/jtratner/pipenv/pipenv/vendor/pipfile/api.py", line 75, in inject_environment_variables
    for k, v in d.items():
AttributeError: 'unicode' object has no attribute 'items'
```

but this PR gets it to work again - woo!

I will open up an additional PR against the pipfile repo sometime later, just figured it'd be good to unbreak the build :) (I also need to fully grok how extras get converted into a dictionary format)

cc @dvf