### PR TITLE
Resolve editable packages on the local filesystem

### DIFF
--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -1346,7 +1346,7 @@ def do_init(
                     ),
                     err=True,
                 )
-                do_lock(system=system, pre=pre)
+                do_lock(system=system, pre=pre, keep_outdated=keep_outdated)
     # Write out the lockfile if it doesn't exist.
     if not project.lockfile_exists and not skip_lock:
         click.echo(
@@ -1865,8 +1865,20 @@ def do_install(
     # Capture . argument and assign it to nothing
     if package_name == '.':
         package_name = False
+    # Install editable local packages before locking - this givves us acceess to dist-info
+    if project.pipfile_exists and (not project.lockfile_exists or not project.virtualenv_exists):
+        section = project.editable_packages if not dev else project.dev_editable_packages
+        for package in section.keys():
+            converted = convert_deps_to_pip({package: section[package]}, project=project, r=False)
+            if not package_name:
+                if converted:
+                    package_name = converted.pop(0)
+            if converted:
+                more_packages.extend(converted)
+                
     # Allow more than one package to be provided.
     package_names = [package_name] + more_packages
+
     # Install all dependencies, if none was provided.
     if package_name is False:
         # Update project settings with pre preference.
@@ -1899,7 +1911,7 @@ def do_install(
                 ):
                     # Support for VCS dependencies.
                     package_names[i] = convert_deps_to_pip(
-                        {package_name: section[package__name]}, r=False
+                        {package_name: section[package__name]}, project=project, r=False
                     )[
                         0
                     ]

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -169,8 +169,6 @@ def add_to_path(p):
         )
 
 
-
-
 def cleanup_virtualenv(bare=True):
     """Removes the virtualenv directory from the system."""
     if not bare:
@@ -1635,6 +1633,7 @@ def format_pip_output(out, r=None):
     out = '\n'.join([l for l in gen(out)])
     return out
 
+
 def warn_in_virtualenv():
     if PIPENV_USE_SYSTEM:
         # Only warn if pipenv isn't already active.
@@ -1866,19 +1865,21 @@ def do_install(
     if package_name == '.':
         package_name = False
     # Install editable local packages before locking - this givves us acceess to dist-info
-    if project.pipfile_exists and (not project.lockfile_exists or not project.virtualenv_exists):
+    if project.pipfile_exists and (
+        not project.lockfile_exists or not project.virtualenv_exists
+    ):
         section = project.editable_packages if not dev else project.dev_editable_packages
         for package in section.keys():
-            converted = convert_deps_to_pip({package: section[package]}, project=project, r=False)
+            converted = convert_deps_to_pip(
+                {package: section[package]}, project=project, r=False
+            )
             if not package_name:
                 if converted:
                     package_name = converted.pop(0)
             if converted:
                 more_packages.extend(converted)
-                
     # Allow more than one package to be provided.
     package_names = [package_name] + more_packages
-
     # Install all dependencies, if none was provided.
     if package_name is False:
         # Update project settings with pre preference.
@@ -1911,7 +1912,9 @@ def do_install(
                 ):
                     # Support for VCS dependencies.
                     package_names[i] = convert_deps_to_pip(
-                        {package_name: section[package__name]}, project=project, r=False
+                        {package_name: section[package__name]},
+                        project=project,
+                        r=False,
                     )[
                         0
                     ]
@@ -2458,12 +2461,12 @@ def do_clean(
     # Ensure that virtualenv is available.
     ensure_project(three=three, python=python, validate=False)
     ensure_lockfile()
-    installed_packages = filter(None, delegator.run(
-        '{0} freeze'.format(which('pip'))
-    ).out.strip(
-    ).split(
-        '\n'
-    ))
+    installed_packages = filter(
+        None,
+        delegator.run('{0} freeze'.format(which('pip'))).out.strip().split(
+            '\n'
+        ),
+    )
     installed_package_names = []
     for installed in installed_packages:
         r = get_requirement(installed)

--- a/pipenv/project.py
+++ b/pipenv/project.py
@@ -46,8 +46,6 @@ if PIPENV_PIPFILE:
 
     else:
         PIPENV_PIPFILE = normalize_drive(os.path.abspath(PIPENV_PIPFILE))
-
-
 # (path, file contents) => TOMLFile
 # keeps track of pipfiles that we've seen so we do not need to re-parse 'em
 _pipfile_cache = {}
@@ -410,7 +408,9 @@ class Project(object):
     def editable_packages(self):
         packages = {}
         for k, v in self.parsed_pipfile.get('packages', {}).items():
-            if v.get('editable') and any(v.get(key) for key in('file', 'path') + VCS_LIST):
+            if v.get('editable') and any(
+                v.get(key) for key in ('file', 'path') + VCS_LIST
+            ):
                 packages.update({k: v})
         return packages
 
@@ -418,7 +418,9 @@ class Project(object):
     def editable_dev_packages(self):
         packages = {}
         for k, v in self.parsed_pipfile.get('dev-packages', {}).items():
-            if v.get('editable') and any(v.get(key) for key in('file', 'path') + VCS_LIST):
+            if v.get('editable') and any(
+                v.get(key) for key in ('file', 'path') + VCS_LIST
+            ):
                 packages.update({k: v})
         return packages
 

--- a/pipenv/project.py
+++ b/pipenv/project.py
@@ -28,6 +28,7 @@ from .utils import (
     normalize_drive,
     python_version,
     escape_grouped_arguments,
+    VCS_LIST,
 )
 from .environments import (
     PIPENV_MAX_DEPTH,
@@ -404,6 +405,22 @@ class Project(object):
     def lockfile_content(self):
         with open(self.lockfile_location) as lock:
             return json.load(lock)
+
+    @property
+    def editable_packages(self):
+        packages = {}
+        for k, v in self.parsed_pipfile.get('packages', {}).items():
+            if v.get('editable') and any(v.get(key) for key in('file', 'path') + VCS_LIST):
+                packages.update({k: v})
+        return packages
+
+    @property
+    def editable_dev_packages(self):
+        packages = {}
+        for k, v in self.parsed_pipfile.get('dev-packages', {}).items():
+            if v.get('editable') and any(v.get(key) for key in('file', 'path') + VCS_LIST):
+                packages.update({k: v})
+        return packages
 
     @property
     def vcs_packages(self):


### PR DESCRIPTION
- Check for editable pipfile entries when running `pipenv install`
- Check only when lockfile or virtualenv doesnt exist but pipfile does
- If so, first install the editable dependencies, then do resolution
- Required to accommodate `ireq.get_dist()` which we use for setup.py
  parsing
- Fixes #1782