### PR TITLE
Fix detection of editable packages

### DIFF
--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -1868,7 +1868,7 @@ def do_install(
     if project.pipfile_exists and (
         not project.lockfile_exists or not project.virtualenv_exists
     ):
-        section = project.editable_packages if not dev else project.dev_editable_packages
+        section = project.editable_packages if not dev else project.editable_dev_packages
         for package in section.keys():
             converted = convert_deps_to_pip(
                 {package: section[package]}, project=project, r=False

--- a/pipenv/project.py
+++ b/pipenv/project.py
@@ -19,16 +19,15 @@ from .utils import (
     pep423_name,
     recase_file,
     find_requirements,
+    is_editable,
     is_file,
     is_vcs,
-    python_version,
     cleanup_toml,
     is_installable_file,
     is_valid_url,
     normalize_drive,
     python_version,
     escape_grouped_arguments,
-    VCS_LIST,
 )
 from .environments import (
     PIPENV_MAX_DEPTH,
@@ -420,22 +419,20 @@ class Project(object):
 
     @property
     def editable_packages(self):
-        packages = {}
-        for k, v in self.parsed_pipfile.get('packages', {}).items():
-            if v.get('editable') and any(
-                v.get(key) for key in ('file', 'path') + VCS_LIST
-            ):
-                packages.update({k: v})
+        packages = {
+            k: v
+            for k, v in self.parsed_pipfile.get('packages', {}).items()
+            if is_editable(v)
+        }
         return packages
 
     @property
     def editable_dev_packages(self):
-        packages = {}
-        for k, v in self.parsed_pipfile.get('dev-packages', {}).items():
-            if v.get('editable') and any(
-                v.get(key) for key in ('file', 'path') + VCS_LIST
-            ):
-                packages.update({k: v})
+        packages = {
+            k: v
+            for k, v in self.parsed_pipfile.get('dev-packages', {}).items()
+            if is_editable(v)
+        }
         return packages
 
     @property

--- a/pipenv/utils.py
+++ b/pipenv/utils.py
@@ -751,6 +751,14 @@ def clean_git_uri(uri):
     return uri
 
 
+def is_editable(pipfile_entry):
+    if hasattr(pipfile_entry, 'get'):
+        return pipfile_entry.get('editable', False) and any(
+            pipfile_entry.get(key) for key in ('file', 'path') + VCS_LIST
+        )
+    return False
+
+
 def is_vcs(pipfile_entry):
     import requirements
 

--- a/tests/test_pipenv.py
+++ b/tests/test_pipenv.py
@@ -294,6 +294,24 @@ records = "*"
             c = p.pipenv('run python -c "import tablib"')
             assert c.return_code == 0
 
+    @pytest.mark.cli
+    @pytest.mark.install
+    def test_install_without_dev_section(self, pypi):
+        with PipenvInstance(pypi=pypi) as p:
+            with open(p.pipfile_path, 'w') as f:
+                contents = """
+[packages]
+tablib = "*"
+                """.strip()
+                f.write(contents)
+            c = p.pipenv('install')
+            assert c.return_code == 0
+            assert 'tablib' in p.pipfile['packages']
+            assert p.pipfile.get('dev-packages', {}) == {}
+            assert 'tablib' in p.lockfile['default']
+            assert p.lockfile['develop'] == {}
+            c = p.pipenv('run python -c "import tablib"')
+            assert c.return_code == 0
 
     @pytest.mark.run
     @pytest.mark.uninstall


### PR DESCRIPTION
Introduced in #1812. The values aren’t always dict, but can be strings… Also fix the `editable_dev_packages` call that is probably also wrong.