### PR TITLE
Pipfile.lock hashes back to determinitic order

### DIFF
--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -1070,7 +1070,7 @@ def do_lock(
             {dep['name']: {'version': '=={0}'.format(dep['version'])}}
         )
         # Add Hashes to lockfile
-        lockfile['develop'][dep['name']]['hashes'] = sorted(dep['hashes'])
+        lockfile['develop'][dep['name']]['hashes'] = dep['hashes']
         # Add index metadata to lockfile.
         if 'index' in dep:
             lockfile['develop'][dep['name']]['index'] = dep['index']
@@ -1126,7 +1126,7 @@ def do_lock(
             {dep['name']: {'version': '=={0}'.format(dep['version'])}}
         )
         # Add Hashes to lockfile
-        lockfile['default'][dep['name']]['hashes'] = sorted(dep['hashes'])
+        lockfile['default'][dep['name']]['hashes'] = dep['hashes']
         # Add index metadata to lockfile.
         if 'index' in dep:
             lockfile['default'][dep['name']]['index'] = dep['index']

--- a/pipenv/utils.py
+++ b/pipenv/utils.py
@@ -496,7 +496,7 @@ def resolve_deps(
             except (ValueError, KeyError, ConnectionError, IndexError):
                 if verbose:
                     print('Error generating hash for {}'.format(name))
-            collected_hashes = list(set(collected_hashes))
+            collected_hashes = sorted(set(collected_hashes))
             d = {'name': name, 'version': version, 'hashes': collected_hashes}
             if index:
                 d.update({'index': index})


### PR DESCRIPTION
The intent has been for hashes to be in a stable order to minimize diff
noise. Commit 1fa3e2a567da779b0c081ac28893aca3353c0674 caused a
regression here by converting to a set and back.

Fixes #1529
Fixes #1664