### PR TITLE
test_complex_lock is not passing if python interpreter is not 2.7

### DIFF
--- a/tests/test_pipenv.py
+++ b/tests/test_pipenv.py
@@ -249,8 +249,10 @@ class TestPipenv:
             c = p.pipenv('install apscheduler')
             assert c.return_code == 0
             assert 'apscheduler' in p.pipfile['packages']
-            assert 'funcsigs' in p.lockfile[u'default']
-            assert 'futures' in p.lockfile[u'default']
+
+            if p.pipfile['requires']['python_version'] == "2.7":
+                assert 'funcsigs' in p.lockfile[u'default']
+                assert 'futures' in p.lockfile[u'default']
 
     @pytest.mark.dev
     @pytest.mark.run


### PR DESCRIPTION
When I run tests I have a problem with `test_complex_lock`. The reason is `apscheduler` package which for python 3> doesn't need `funcsigs` and `futures` dependency. 
All other tests are working with python 3>