### PR TITLE
Add tests for environment marker precedence logic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ python:
 env:
   - TEST_SUITE='dotvenv or check or unused or requirements'
   - TEST_SUITE='complex'
-  - TEST_SUITE='run or project or utils'
+  - TEST_SUITE='markers or run or project or utils'
 
 # command to install dependencies
 install:

--- a/tests/test_pipenv.py
+++ b/tests/test_pipenv.py
@@ -602,6 +602,49 @@ requests = {version = "*", os_name = "== 'splashwear'"}
             c = p.pipenv('run python -c "import requests;"')
             assert c.return_code == 1
 
+    @pytest.mark.markers
+    @pytest.mark.install
+    def test_top_level_overrides_environment_markers(self):
+        """Top-level environment markers should take precedence.
+        """
+        with PipenvInstance() as p:
+            with open(p.pipfile_path, 'w') as f:
+                contents = """
+[packages]
+apscheduler = "*"
+funcsigs = {version = "*", os_name = "== 'splashwear'"}
+                """.strip()
+                f.write(contents)
+
+            c = p.pipenv('install')
+            assert c.return_code == 0
+
+            assert p.lockfile['default']['funcsigs']['markers'] == "os_name == 'splashwear'"
+
+    @pytest.mark.markers
+    @pytest.mark.install
+    def test_global_overrides_environment_markers(self):
+        """Empty (unconditional) dependency should take precedence.
+
+        If a dependency is specified without environment markers, it should
+        override dependencies with environment markers. In this example,
+        APScheduler requires funcsigs only on Python 2, but since funcsigs is
+        also specified as an unconditional dep, its markers should be empty.
+        """
+        with PipenvInstance() as p:
+            with open(p.pipfile_path, 'w') as f:
+                contents = """
+[packages]
+apscheduler = "*"
+funcsigs = "*"
+                """.strip()
+                f.write(contents)
+
+            c = p.pipenv('install')
+            assert c.return_code == 0
+
+            assert p.lockfile['default']['funcsigs'].get('markers', '') == ''
+
     @pytest.mark.install
     @pytest.mark.vcs
     @pytest.mark.tablib


### PR DESCRIPTION
This confirms #1757 is fixed. There is one potential discussion here, however.

Currently if your dependencies specify conflicting environment markers, Pipenv will only choose one of them, as demonstrated in the `test_specific_package_environment_markers` test case. I would instead argue Pipenv should try to aggregate the conditions, i.e. with two markers `sys_plarform=='win32'` and `os_name=='splashwear'`, the lockfile should contain something like

```
"markers": "sys_plarform=='win32' or os_name=='splashwear'"
```