### PR TITLE
Fix env calculation with hashes

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -38,6 +38,23 @@ If you'd like a specific package to be installed with a specific package index, 
 
 Very fancy.
 
+☤ Injecting credentials into Pipfiles via environment variables
+-----------------------------------------------------------------
+
+
+Pipenv will expand environment variables (if defined) in your Pipfile. Quite
+useful if you need to authenticate to a private PyPI::
+
+    [[source]]
+    url = "https://$USERNAME:${PASSWORD}@mypypi.example.com/simple"
+    verify_ssl = true
+    name = "pypi"
+
+Luckily - pipenv will hash your Pipfile *before* expanding environment
+variables (and, helpfully, will substitute the environment variables again when
+you install from the lock file - so no need to commit any secrets! Woo!)
+
+
 ☤ Specifying Basically Anything
 -------------------------------
 

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -1311,14 +1311,14 @@ def do_init(
         )
     # Write out the lockfile if it doesn't exist, but not if the Pipfile is being ignored
     if (project.lockfile_exists and not ignore_pipfile) and not skip_lock:
-        changed_hash = project.pipfile_hash_changed()
-        if changed_hash:
-            old_hash, new_hash = changed_hash
+        old_hash = project.get_lockfile_hash()
+        new_hash = project.calculate_pipfile_hash()
+        if new_hash != old_hash:
             if deploy:
                 click.echo(
                     crayons.red(
                         'Your Pipfile.lock ({0}) is out of date. Expected: ({1}).'.format(
-                            old_hash, new_hash
+                            old_hash[-6:], new_hash[-6:]
                         )
                     )
                 )
@@ -1331,7 +1331,7 @@ def do_init(
                 click.echo(
                     crayons.red(
                         u'Pipfile.lock ({0}) out of date, updating to ({1})…'.format(
-                            old_hash, new_hash
+                            old_hash[-6:], new_hash[-6:]
                         ),
                         bold=True,
                     ),
@@ -1648,13 +1648,13 @@ def ensure_lockfile(keep_outdated=False):
         keep_outdated = project.settings.get('keep_outdated')
     # Write out the lockfile if it doesn't exist, but not if the Pipfile is being ignored
     if project.lockfile_exists:
-        changed_hash = project.pipfile_hash_changed()
-        if changed_hash:
-            old_hash, new_hash = changed_hash
+        old_hash = project.get_lockfile_hash()
+        new_hash = project.calculate_pipfile_hash()
+        if new_hash != old_hash:
             click.echo(
                 crayons.red(
                     u'Pipfile.lock ({0}) out of date, updating to ({1})…'.format(
-                        old_hash, new_hash
+                        old_hash[-6:], new_hash[-6:]
                     ),
                     bold=True,
                 ),

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -1316,7 +1316,7 @@ def do_init(
         with codecs.open(project.lockfile_location, 'r') as f:
             lockfile = simplejson.load(f)
         # Update the lockfile if it is out-of-date.
-        p = pipfile.load(project.pipfile_location)
+        p = pipfile.load(project.pipfile_location, inject_env=False)
         # Check that the hash of the Lockfile matches the lockfile's hash.
         if not lockfile['_meta'].get('hash', {}).get('sha256') == p.hash:
             old_hash = lockfile['_meta'].get('hash', {}).get('sha256')[-6:]
@@ -1659,7 +1659,7 @@ def ensure_lockfile(keep_outdated=False):
         with codecs.open(project.lockfile_location, 'r') as f:
             lockfile = simplejson.load(f)
         # Update the lockfile if it is out-of-date.
-        p = pipfile.load(project.pipfile_location)
+        p = pipfile.load(project.pipfile_location, inject_env=False)
         # Check that the hash of the Lockfile matches the lockfile's hash.
         if not lockfile['_meta'].get('hash', {}).get('sha256') == p.hash:
             old_hash = lockfile['_meta'].get('hash', {}).get('sha256')[-6:]

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import contextlib
-import codecs
 import logging
 import os
 import sys
@@ -1312,15 +1311,9 @@ def do_init(
         )
     # Write out the lockfile if it doesn't exist, but not if the Pipfile is being ignored
     if (project.lockfile_exists and not ignore_pipfile) and not skip_lock:
-        # Open the lockfile.
-        with codecs.open(project.lockfile_location, 'r') as f:
-            lockfile = simplejson.load(f)
-        # Update the lockfile if it is out-of-date.
-        p = pipfile.load(project.pipfile_location, inject_env=False)
-        # Check that the hash of the Lockfile matches the lockfile's hash.
-        if not lockfile['_meta'].get('hash', {}).get('sha256') == p.hash:
-            old_hash = lockfile['_meta'].get('hash', {}).get('sha256')[-6:]
-            new_hash = p.hash[-6:]
+        changed_hash = project.pipfile_hash_changed()
+        if changed_hash:
+            old_hash, new_hash = changed_hash
             if deploy:
                 click.echo(
                     crayons.red(
@@ -1655,15 +1648,9 @@ def ensure_lockfile(keep_outdated=False):
         keep_outdated = project.settings.get('keep_outdated')
     # Write out the lockfile if it doesn't exist, but not if the Pipfile is being ignored
     if project.lockfile_exists:
-        # Open the lockfile.
-        with codecs.open(project.lockfile_location, 'r') as f:
-            lockfile = simplejson.load(f)
-        # Update the lockfile if it is out-of-date.
-        p = pipfile.load(project.pipfile_location, inject_env=False)
-        # Check that the hash of the Lockfile matches the lockfile's hash.
-        if not lockfile['_meta'].get('hash', {}).get('sha256') == p.hash:
-            old_hash = lockfile['_meta'].get('hash', {}).get('sha256')[-6:]
-            new_hash = p.hash[-6:]
+        changed_hash = project.pipfile_hash_changed()
+        if changed_hash:
+            old_hash, new_hash = changed_hash
             click.echo(
                 crayons.red(
                     u'Pipfile.lock ({0}) out of date, updating to ({1})…'.format(

--- a/pipenv/project.py
+++ b/pipenv/project.py
@@ -642,18 +642,15 @@ class Project(object):
     def recase_pipfile(self):
         self.write_toml(recase_file(self._pipfile))
 
-    def pipfile_hash_changed(self):
-        """Check if hashes differ between lockfile and Pipfile.
-
-        Returns: (old_hash, new_hash) if hash has changed
-        """
+    def get_lockfile_hash(self):
+        if not os.path.exists(self.lockfile_location):
+            return
         # Open the lockfile.
         with codecs.open(self.lockfile_location, 'r') as f:
             lockfile = json.load(f)
+        return lockfile['_meta'].get('hash', {}).get('sha256')
+
+    def calculate_pipfile_hash(self):
         # Update the lockfile if it is out-of-date.
         p = pipfile.load(self.pipfile_location, inject_env=False)
-        # Check that the hash of the Lockfile matches the lockfile's hash.
-        if not lockfile['_meta'].get('hash', {}).get('sha256') == p.hash:
-            old_hash = lockfile['_meta'].get('hash', {}).get('sha256')[-6:]
-            new_hash = p.hash[-6:]
-            return old_hash, new_hash
+        return p.hash

--- a/pipenv/project.py
+++ b/pipenv/project.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import codecs
 import json
 import os
 import re
@@ -640,3 +641,19 @@ class Project(object):
 
     def recase_pipfile(self):
         self.write_toml(recase_file(self._pipfile))
+
+    def pipfile_hash_changed(self):
+        """Check if hashes differ between lockfile and Pipfile.
+
+        Returns: (old_hash, new_hash) if hash has changed
+        """
+        # Open the lockfile.
+        with codecs.open(self.lockfile_location, 'r') as f:
+            lockfile = json.load(f)
+        # Update the lockfile if it is out-of-date.
+        p = pipfile.load(self.pipfile_location, inject_env=False)
+        # Check that the hash of the Lockfile matches the lockfile's hash.
+        if not lockfile['_meta'].get('hash', {}).get('sha256') == p.hash:
+            old_hash = lockfile['_meta'].get('hash', {}).get('sha256')[-6:]
+            new_hash = p.hash[-6:]
+            return old_hash, new_hash

--- a/tests/test_pipenv.py
+++ b/tests/test_pipenv.py
@@ -1139,13 +1139,17 @@ flask = "==0.12.2"
 """)
             monkeypatch.setitem(os.environ, 'PYPI_USERNAME', 'whatever')
             monkeypatch.setitem(os.environ, 'PYPI_PASSWORD', 'pass')
+            assert Project().get_lockfile_hash() is None
             c = p.pipenv('install')
+            lock_hash = Project().get_lockfile_hash()
+            assert lock_hash is not None
+            assert lock_hash == Project().calculate_pipfile_hash()
             # sanity check on pytest
             assert 'PYPI_USERNAME' not in str(pipfile.load(p.pipfile_path))
             assert c.return_code == 0
-            assert not Project().pipfile_hash_changed()
+            assert Project().get_lockfile_hash() == Project.calculate_pipfile_hash()
             monkeypatch.setitem(os.environ, 'PYPI_PASSWORD', 'pass2')
-            assert not Project().pipfile_hash_changed()
+            assert Project().get_lockfile_hash() == Project.calculate_pipfile_hash()
             with open(p.pipfile_path, 'a') as f:
                 f.write('requests = "==2.14.0"\n')
-            assert Project().pipfile_hash_changed()
+            assert Project().get_lockfile_hash() != Project.calculate_pipfile_hash()


### PR DESCRIPTION
Fixes #1833.  @frostming - kinda was already there by the time I saw your note - heh.

First commit just fixes both locations where environment variables were injected before hash calculation.

Second commit DRYs up the pipfile hash checking a bit and adds a test case.  I know the API is a little goofy (returning a tuple only when truthy), but it felt like an easier to read way to do the API.

Perhaps longer term it'd be better to move this into pipfile directly.

In particularly, I think this would be a good idea:

```
>>> p = pipfile.load(inject_env=True)
>>> p.hash
AssertionError: cannot calculate hash on pipfile with already-substituted env vars
```