### PR TITLE
Detect .venv at project root when in subdirectory

### DIFF
--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -1,7 +1,7 @@
-latest:
- - Fix bug in detecting .venv at project root when in subdirectories.
 11.9.1:
  - Resolve editable packages on the local filesystem.
+ - Ensure lock hash does not change based on injected env vars.
+ - Fix bug in detecting .venv at project root when in subdirectories.
 11.9.0:
  - Vastly improve markers capabilities.
  - Support for environment variables in Pipfiles.

--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -1,3 +1,5 @@
+latest:
+ - Fix bug in detecting .venv at project root when in subdirectories.
 11.9.1:
  - Resolve editable packages on the local filesystem.
 11.9.0:

--- a/pipenv/environments.py
+++ b/pipenv/environments.py
@@ -14,8 +14,6 @@ PIPENV_PYTHON = os.environ.get('PIPENV_PYTHON')
 # Create the virtualenv in the project, instead of with pew.
 PIPENV_VENV_IN_PROJECT = bool(
     os.environ.get('PIPENV_VENV_IN_PROJECT')
-) or os.path.isdir(
-    '.venv'
 )
 # Overwrite all index funcitonality.
 PIPENV_TEST_INDEX = os.environ.get('PIPENV_TEST_INDEX')
@@ -55,9 +53,6 @@ PIPENV_USE_HASHES = True
 PIPENV_SKIP_VALIDATION = True
 # Tells Pipenv where to load .env from.
 PIPENV_DOTENV_LOCATION = os.environ.get('PIPENV_DOTENV_LOCATION')
-# Use shell compatibility mode when using venv in project mode.
-if PIPENV_VENV_IN_PROJECT:
-    PIPENV_SHELL_COMPAT = True
 # Disable spinner on Windows.
 if os.name == 'nt':
     PIPENV_NOSPIN = True

--- a/pipenv/project.py
+++ b/pipenv/project.py
@@ -214,9 +214,11 @@ class Project(object):
         # Use cached version, if available.
         if self._virtualenv_location:
             return self._virtualenv_location
+        venv_in_project = PIPENV_VENV_IN_PROJECT or \
+            os.path.exists(os.path.join(self.project_directory, '.venv'))
 
-        # The user wants the virtualenv in the project.
-        if not PIPENV_VENV_IN_PROJECT:
+        # Default mode.
+        if not venv_in_project:
             c = delegator.run(
                 '{0} -m pipenv.pew dir "{1}"'.format(
                     escape_grouped_arguments(sys.executable),
@@ -224,7 +226,7 @@ class Project(object):
                 )
             )
             loc = c.out.strip()
-        # Default mode.
+        # The user wants the virtualenv in the project.
         else:
             loc = os.sep.join(
                 self.pipfile_location.split(os.sep)[:-1] + ['.venv']


### PR DESCRIPTION
Also remove `PIPENV_SHELL_COMPAT` which appears to be no longer used.

(confirmed test case fails without this change and passes with it).

Before:

```
$ PIPENV_VENV_IN_PROJECT=1 pipenv install
$ pipenv --venv
/Users/jtratner/example7/.venv
$ mkdir subdir
$ cd subdir
$ pipenv --venv # :(
No virtualenv has been created for this project yet!
```

After:

```
$ pipenv --venv
/Users/jtratner/example7/.venv
$ mkdir subdir
$ cd subdir
$ pipenv --venv
/Users/jtratner/example7/.venv
```

The full test suite doesn't pass locally for me right now so I can't tell if I've broken anything else.