### PR TITLE
Fix `shlex.split()` call to check for posix first

### DIFF
--- a/pipenv/project.py
+++ b/pipenv/project.py
@@ -369,8 +369,9 @@ class Project(object):
     @property
     def scripts(self):
         scripts = self.parsed_pipfile.get('scripts', {})
+        posix = os.name == 'posix'
         for (k, v) in scripts.items():
-            scripts[k] = shlex.split(v, posix=True)
+            scripts[k] = shlex.split(v, posix=posix)
         return scripts
 
     def update_settings(self, d):

--- a/pipenv/project.py
+++ b/pipenv/project.py
@@ -373,7 +373,7 @@ class Project(object):
         posix = os.name == 'posix'
         _scripts = {}
         for (k, v) in scripts.items():
-            _scripts[k] = shlex.split(six.u(v), posix=posix)
+            _scripts[k] = shlex.split(str(v), posix=posix)
         return _scripts
 
     def update_settings(self, d):

--- a/pipenv/project.py
+++ b/pipenv/project.py
@@ -3,6 +3,7 @@ import codecs
 import json
 import os
 import re
+import six
 import sys
 import shlex
 import base64
@@ -370,9 +371,10 @@ class Project(object):
     def scripts(self):
         scripts = self.parsed_pipfile.get('scripts', {})
         posix = os.name == 'posix'
+        _scripts = {}
         for (k, v) in scripts.items():
-            scripts[k] = shlex.split(v, posix=posix)
-        return scripts
+            _scripts[k] = shlex.split(six.u(v), posix=posix)
+        return _scripts
 
     def update_settings(self, d):
         settings = self.settings

--- a/tests/test_pipenv.py
+++ b/tests/test_pipenv.py
@@ -1170,3 +1170,38 @@ flask = "==0.12.2"
             with open(p.pipfile_path, 'a') as f:
                 f.write('requests = "==2.14.0"\n')
             assert Project().get_lockfile_hash() != Project.calculate_pipfile_hash()
+
+    @pytest.mark.run
+    def test_scripts_basic(self):
+        with PipenvInstance(chdir=True) as p:
+            with open(p.pipfile_path, 'w') as f:
+                f.write("""
+[scripts]
+printfoo = "python -c print('foo')"
+                """)
+
+            c = p.pipenv('install')
+            assert c.return_code == 0
+
+            c = p.pipenv('run printfoo')
+            assert c.return_code == 0
+            assert c.out == 'foo\n'
+            assert c.err == ''
+
+    @pytest.mark.run
+    @pytest.mark.skip(reason='This fails on Windows (not sure about POSIX).')
+    def test_scripts_quoted(self):
+        with PipenvInstance(chdir=True) as p:
+            with open(p.pipfile_path, 'w') as f:
+                f.write("""
+[scripts]
+printfoo = "python -c print('foo')"
+                """)
+
+            c = p.pipenv('install')
+            assert c.return_code == 0
+
+            c = p.pipenv('run printfoo')
+            assert c.return_code == 0
+            assert c.out == 'foo\n'
+            assert c.err == ''


### PR DESCRIPTION
- Currently it assumes posix complience and uses `posix=True`
- This breaks when parsing on windows