### PR TITLE
Lint + test fixes

### DIFF
--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -4,7 +4,6 @@ import logging
 import os
 import sys
 import shutil
-import shlex
 import signal
 import time
 import tempfile
@@ -17,10 +16,8 @@ import crayons
 import dotenv
 import delegator
 import pexpect
-import requests
 import pipfile
 import pipdeptree
-import semver
 from pipreqs import pipreqs
 from blindspin import spinner
 
@@ -41,19 +38,15 @@ from .utils import (
     is_vcs,
     python_version,
     find_windows_executable,
-    is_file,
     prepare_pip_source_args,
     temp_environ,
     is_valid_url,
     download_file,
     get_requirement,
-    need_update_check,
-    touch_update_stamp,
     is_pinned,
     is_star,
     TemporaryDirectory,
 )
-from .__version__ import __version__
 from .import pep508checker, progress
 from .environments import (
     PIPENV_COLORBLIND,
@@ -683,8 +676,6 @@ def shorten_path(location, bold=False):
     if bold:
         short[-1] = str(crayons.normal(short[-1], bold=True))
     return os.sep.join(short)
-
-
 
 
 # return short

--- a/pipenv/help.py
+++ b/pipenv/help.py
@@ -1,7 +1,6 @@
 # coding: utf-8
 import os
 import sys
-import crayons
 import pipenv
 
 from pprint import pprint

--- a/pipenv/project.py
+++ b/pipenv/project.py
@@ -36,7 +36,6 @@ from .environments import (
     PIPENV_PIPFILE,
     PIPENV_VENV_IN_PROJECT,
     PIPENV_VIRTUALENV,
-    PIPENV_NO_INHERIT,
     PIPENV_TEST_INDEX,
     PIPENV_PYTHON,
 )
@@ -315,7 +314,6 @@ class Project(object):
             contents = f.read()
 
         return self._parse_pipfile(contents)
-
 
     def clear_pipfile_cache(self):
         """Clear pipfile cache (e.g., so we can mutate parsed pipfile)"""

--- a/pipenv/utils.py
+++ b/pipenv/utils.py
@@ -6,7 +6,6 @@ import tempfile
 import sys
 import shutil
 import logging
-import errno
 import click
 import crayons
 import delegator
@@ -50,7 +49,7 @@ from pip9.index import Link
 from pip9._vendor.requests.exceptions import HTTPError, ConnectionError
 
 from .pep508checker import lookup
-from .environments import SESSION_IS_INTERACTIVE, PIPENV_MAX_ROUNDS, PIPENV_CACHE_DIR
+from .environments import PIPENV_MAX_ROUNDS, PIPENV_CACHE_DIR
 
 if six.PY2:
 
@@ -1025,7 +1024,7 @@ def find_windows_executable(bin_path, exe_name):
     return find_executable(exe_name)
 
 
-def get_converted_relative_path(path, relative_to= os.curdir):
+def get_converted_relative_path(path, relative_to=os.curdir):
     """Given a vague relative path, return the path relative to the given location"""
     return os.path.join('.', os.path.relpath(path, start=relative_to))
 
@@ -1070,8 +1069,6 @@ def find_requirements(max_depth=3):
                     return r
 
     raise RuntimeError('No requirements.txt found!')
-
-
 
 
 # Borrowed from pew to avoid importing pew which imports psutil

--- a/tests/test_pipenv.py
+++ b/tests/test_pipenv.py
@@ -1,14 +1,12 @@
 import os
-from pkg_resources import parse_version
 import re
-import tempfile
 import shutil
 import json
 import pytest
 import warnings
 from pipenv.core import activate_virtualenv
 from pipenv.utils import (
-    temp_environ, get_windows_path, mkdir_p, normalize_drive, rmtree, TemporaryDirectory
+    temp_environ, get_windows_path, mkdir_p, normalize_drive, TemporaryDirectory
 )
 from pipenv.vendor import toml
 from pipenv.vendor import delegator
@@ -374,7 +372,6 @@ tablib = "*"
             assert 'requests' in p.lockfile['develop']
             assert 'flask' in p.lockfile['develop']
 
-
             c = p.pipenv('uninstall --all-dev')
             assert c.return_code == 0
             assert 'requests' not in p.pipfile['dev-packages']
@@ -383,7 +380,6 @@ tablib = "*"
             assert 'pytest' not in p.lockfile['develop']
             assert 'tpfd' in p.pipfile['packages']
             assert 'tpfd' in p.lockfile['default']
-
 
             c = p.pipenv('run python -m requests.help')
             assert c.return_code > 0
@@ -776,7 +772,6 @@ requests = {version = "*"}
                     out, _ = process.communicate()
                     assert any(req.startswith('requests') for req in out.splitlines()) is True
 
-
     @pytest.mark.run
     @pytest.mark.dotenv
     def test_env(self):
@@ -1050,7 +1045,6 @@ requests = "==2.14.0"
             assert c.return_code == 0
             assert all(pkg in p.lockfile['default'] for pkg in ['xlrd', 'xlwt', 'pyyaml', 'odfpy'])
 
-
     @pytest.mark.install
     @pytest.mark.files
     def test_local_zipfiles(self):
@@ -1075,7 +1069,6 @@ requests = "==2.14.0"
 
             assert 'file' in dep or 'path' in dep
 
-
     @pytest.mark.install
     @pytest.mark.files
     @pytest.mark.urls
@@ -1094,7 +1087,6 @@ requests = "==2.14.0"
             # check Pipfile.lock
             assert 'requests' in p.lockfile['default']
             assert 'records' in p.lockfile['default']
-
 
     @pytest.mark.install
     @pytest.mark.files
@@ -1137,12 +1129,12 @@ requests = "==2.14.0"
             c = p.pipenv('clean')
             assert c.return_code == 0
 
-
     @pytest.mark.install
-    def test_environment_variable_value_does_not_change_hash(self, pypi, monkeypatch):
+    def test_environment_variable_value_does_not_change_hash(self, pypi):
         with PipenvInstance(chdir=True, pypi=pypi) as p:
-            with open(p.pipfile_path, 'w') as f:
-                f.write("""
+            with temp_environ():
+                with open(p.pipfile_path, 'w') as f:
+                    f.write("""
 [[source]]
 url = 'https://${PYPI_USERNAME}:${PYPI_PASSWORD}@pypi.python.org/simple'
 verify_ssl = true
@@ -1154,22 +1146,22 @@ python_version = '2.7'
 [packages]
 flask = "==0.12.2"
 """)
-            monkeypatch.setitem(os.environ, 'PYPI_USERNAME', 'whatever')
-            monkeypatch.setitem(os.environ, 'PYPI_PASSWORD', 'pass')
-            assert Project().get_lockfile_hash() is None
-            c = p.pipenv('install')
-            lock_hash = Project().get_lockfile_hash()
-            assert lock_hash is not None
-            assert lock_hash == Project().calculate_pipfile_hash()
-            # sanity check on pytest
-            assert 'PYPI_USERNAME' not in str(pipfile.load(p.pipfile_path))
-            assert c.return_code == 0
-            assert Project().get_lockfile_hash() == Project.calculate_pipfile_hash()
-            monkeypatch.setitem(os.environ, 'PYPI_PASSWORD', 'pass2')
-            assert Project().get_lockfile_hash() == Project.calculate_pipfile_hash()
-            with open(p.pipfile_path, 'a') as f:
-                f.write('requests = "==2.14.0"\n')
-            assert Project().get_lockfile_hash() != Project.calculate_pipfile_hash()
+                os.environ['PYPI_USERNAME'] = 'whatever'
+                os.environ['PYPI_PASSWORD'] = 'pass'
+                assert Project().get_lockfile_hash() is None
+                c = p.pipenv('install')
+                lock_hash = Project().get_lockfile_hash()
+                assert lock_hash is not None
+                assert lock_hash == Project().calculate_pipfile_hash()
+                # sanity check on pytest
+                assert 'PYPI_USERNAME' not in str(pipfile.load(p.pipfile_path))
+                assert c.return_code == 0
+                assert Project().get_lockfile_hash() == Project().calculate_pipfile_hash()
+                os.environ['PYPI_PASSWORD'] = 'pass2'
+                assert Project().get_lockfile_hash() == Project().calculate_pipfile_hash()
+                with open(p.pipfile_path, 'a') as f:
+                    f.write('requests = "==2.14.0"\n')
+                assert Project().get_lockfile_hash() != Project().calculate_pipfile_hash()
 
     @pytest.mark.run
     def test_scripts_basic(self):


### PR DESCRIPTION
1. Fix up a test case that was never passing (but should have) <-- clearly wasn't running in CI (and I missed it as a last minute change right before merging)
2. Remove unused / duplicate imports
3. whitespace fixups

Now when you run flake8, mostly good:

```
$ flake8 tests/*.py pipenv/*.py
tests/test_utils.py:371:14: E131 continuation line unaligned for hanging indent
tests/test_utils.py:382:12: E131 continuation line unaligned for hanging indent
tests/test_utils.py:384:13: E122 continuation line missing indentation or outdented
pipenv/__init__.py:22:1: F401 '.resolver' imported but unused
pipenv/cli.py:15:1: F403 'from .environments import *' used; unable to detect undefined names
pipenv/cli.py:137:12: F405 'PIPENV_SHELL' may be undefined, or defined from star imports: .environments
pipenv/cli.py:140:27: F405 'PIPENV_SHELL' may be undefined, or defined from star imports: .environments
pipenv/cli.py:201:16: F405 'PIPENV_USE_SYSTEM' may be undefined, or defined from star imports: .environments
pipenv/core.py:2177:17: E211 whitespace before '('
```
