### PR TITLE
Only consider supported ext when fetching metadata

### DIFF
--- a/pipenv/patched/notpip/req/req_install.py
+++ b/pipenv/patched/notpip/req/req_install.py
@@ -261,7 +261,7 @@ class InstallRequirement(object):
         return '<%s object: %s editable=%r>' % (
             self.__class__.__name__, str(self), self.editable)
 
-    def populate_link(self, finder, upgrade, require_hashes):
+    def populate_link(self, finder, upgrade, require_hashes, only_supported_ext=False):
         """Ensure that if a link can be found for this, that it is found.
 
         Note that self.link may still be None - if Upgrade is False and the
@@ -274,7 +274,7 @@ class InstallRequirement(object):
         to file modification times.
         """
         if self.link is None:
-            self.link = finder.find_requirement(self, upgrade)
+            self.link = finder.find_requirement(self, upgrade, only_supported_ext=only_supported_ext)
         if self._wheel_cache is not None and not require_hashes:
             old_link = self.link
             self.link = self._wheel_cache.cached_wheel(self.link, self.name)

--- a/pipenv/patched/notpip/req/req_set.py
+++ b/pipenv/patched/notpip/req/req_set.py
@@ -561,7 +561,8 @@ class RequirementSet(object):
                 req_to_install.populate_link(
                     finder,
                     self._is_upgrade_allowed(req_to_install),
-                    require_hashes
+                    require_hashes,
+                    only_supported_ext=True
                 )
                 # We can't hit this spot and have populate_link return None.
                 # req_to_install.satisfied_by is None here (because we're

--- a/tests/test_pipenv.py
+++ b/tests/test_pipenv.py
@@ -880,11 +880,17 @@ import records
 
     @pytest.mark.lock
     def test_lock_ignore_eggs(self, pypi):
-        with PipenvInstance(pypi=pypi) as p:
+        """Ensure locking works with packages provoding egg formats.
+
+        See https://github.com/pypa/pipenv/issues/1849.
+        TODO: This hits the real PyPI. What happens if RandomWords somehow
+        changes its uploads? Need a better way to test this.
+        """
+        with PipenvInstance() as p:
             with open(p.pipfile_path, 'w') as f:
                 f.write("""
 [packages]
-RandomWords = "*"
+RandomWords = "==0.2.1"
                 """)
             c = p.pipenv('lock --verbose')
             assert c.return_code == 0

--- a/tests/test_pipenv.py
+++ b/tests/test_pipenv.py
@@ -879,6 +879,17 @@ import records
         assert command == '{0}/bin/activate'.format(venv)
 
     @pytest.mark.lock
+    def test_lock_ignore_eggs(self, pypi):
+        with PipenvInstance(pypi=pypi) as p:
+            with open(p.pipfile_path, 'w') as f:
+                f.write("""
+[packages]
+RandomWords = "*"
+                """)
+            c = p.pipenv('lock --verbose')
+            assert c.return_code == 0
+
+    @pytest.mark.lock
     @pytest.mark.requirements
     def test_lock_requirements_file(self, pypi):
 


### PR DESCRIPTION
I don’t dare messing with pip internals, so I chose the least disruptive route. When trying to look for a package to resolve, pip (notpip, actually) should only look for package formats that it can actually handle. An extra flag is passed to signal this need.