### PR TITLE
Remove extraneous is_vcs check

### DIFF
--- a/pipenv/utils.py
+++ b/pipenv/utils.py
@@ -535,8 +535,8 @@ def convert_deps_from_pip(dep):
         # Add --editable if applicable
         if req.editable:
             dependency[req.name].update({'editable': True})
-    # VCS Installs. Extra check for unparsed git over SSH
-    elif req.vcs or is_vcs(req.path):
+    # VCS Installs.
+    elif req.vcs:
         if req.name is None:
             raise ValueError(
                 'pipenv requires an #egg fragment for version controlled '
@@ -544,11 +544,6 @@ def convert_deps_from_pip(dep):
                 'in the form {0}#egg=<package-name>.'.format(req.uri)
             )
 
-        # Set up this requirement as a proper VCS requirement if it was not
-        if not req.vcs and req.path.startswith(VCS_LIST):
-            req.vcs = [vcs for vcs in VCS_LIST if req.path.startswith(vcs)][0]
-            req.uri = '{0}'.format(req.path)
-            req.path = None
         # Crop off the git+, etc part.
         if req.uri.startswith('{0}+'.format(req.vcs)):
             req.uri = req.uri[len(req.vcs) + 1:]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -121,6 +121,14 @@ class TestUtils:
         with pytest.raises(ValueError) as e:
             dep = pipenv.utils.convert_deps_from_pip(dep)
             assert 'pipenv requires an #egg fragment for vcs' in str(e)
+        # vcs dependency that pip does not parse correctly
+        dep = 'git+git@host:user/repo.git#egg=myname'
+        dep = pipenv.utils.convert_deps_from_pip(dep)
+        assert dep == {
+            'myname': {
+                'git': 'git@host:user/repo.git',
+            }
+        }
 
     @pytest.mark.utils
     @pytest.mark.parametrize(


### PR DESCRIPTION
@techalchemy - as we discussed previously - this removes some code that can never be executed.

1. is_vcs requires (req.path or req.uri) to be truthy.
2. (req.path or req.uri) would be true in first if statement

Thus if you have:

```
if (req.uri or req.path or ...) and not req.vcs
elif req.vcs or is_vcs(req.path)
```

if `is_vcs(req.path)` is Truthy, then the first if clause must be
truthy, so it's unnecessary.

Also add a quick test to confirm that originating purpose for that check
is now handled otherwise.