### PR TITLE
Fix scripts quoting

### DIFF
--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -2,6 +2,7 @@
  - Resolve editable packages on the local filesystem.
  - Ensure lock hash does not change based on injected env vars.
  - Fix bug in detecting .venv at project root when in subdirectories.
+ - Parse quoting in [scripts] section correctly + clearer run errors.
 11.9.0:
  - Vastly improve markers capabilities.
  - Support for environment variables in Pipfiles.

--- a/tests/test_pipenv.py
+++ b/tests/test_pipenv.py
@@ -1167,11 +1167,10 @@ flask = "==0.12.2"
     def test_scripts_basic(self):
         with PipenvInstance(chdir=True) as p:
             with open(p.pipfile_path, 'w') as f:
-                f.write("""
+                f.write(r"""
 [scripts]
-printfoo = "python -c print('foo')"
+printfoo = "python -c \"print('foo')\""
                 """)
-
             c = p.pipenv('install')
             assert c.return_code == 0
 

--- a/tests/test_pipenv.py
+++ b/tests/test_pipenv.py
@@ -4,7 +4,8 @@ import shutil
 import json
 import pytest
 import warnings
-from pipenv.core import activate_virtualenv
+from pipenv import core
+from pipenv.core import activate_virtualenv, _construct_run_command
 from pipenv.utils import (
     temp_environ, get_windows_path, mkdir_p, normalize_drive, TemporaryDirectory
 )
@@ -1170,6 +1171,9 @@ flask = "==0.12.2"
                 f.write(r"""
 [scripts]
 printfoo = "python -c \"print('foo')\""
+notfoundscript = "randomthingtotally"
+appendscript = "cmd arg1"
+multicommand = "bash -c \"cd docs && make html\""
                 """)
             c = p.pipenv('install')
             assert c.return_code == 0
@@ -1179,20 +1183,15 @@ printfoo = "python -c \"print('foo')\""
             assert c.out == 'foo\n'
             assert c.err == ''
 
-    @pytest.mark.run
-    @pytest.mark.skip(reason='This fails on Windows (not sure about POSIX).')
-    def test_scripts_quoted(self):
-        with PipenvInstance(chdir=True) as p:
-            with open(p.pipfile_path, 'w') as f:
-                f.write("""
-[scripts]
-printfoo = "python -c print('foo')"
-                """)
-
-            c = p.pipenv('install')
-            assert c.return_code == 0
-
-            c = p.pipenv('run printfoo')
-            assert c.return_code == 0
-            assert c.out == 'foo\n'
-            assert c.err == ''
+            if os.name != 'nt':
+                c = p.pipenv('run notfoundscript')
+                assert c.return_code == 1
+                assert c.out == ''
+                assert 'Error' in c.err
+                assert 'randomthingtotally (from notfoundscript)' in c.err
+            executable, argv = _construct_run_command(Project(), 'multicommand', [])
+            assert executable == 'bash'
+            assert argv == ['-c', 'cd docs && make html']
+            executable, argv = _construct_run_command(Project(), 'appendscript', ['a', 'b'])
+            assert executable == 'cmd'
+            assert argv == ['arg1', 'a', 'b']


### PR DESCRIPTION
Better shell quoting

1. Only use split() when we actually come in from CLI (possibly never
   need to do that at all) - e.g. 
```
[scripts]
docs = "bash -c \"cd docs && make html\""
```
now works!

2. Add some additional test cases to cover quoting.
3. Better error message in case of missing executable pulled from a run
script.

E.g.:

```
[scripts]
random = "myexecutable a b c"
myexecutable = "echo 5"
```

```
Error: the command myexecutable (from random) could not be found within PATH.
```

vs. previous, which had a slightly disingenous error message.

```
Error: the command myexecutable could not be found within PATH or Pipfile's [scripts].
```
