### PR TITLE
Hash cache

### DIFF
--- a/pipenv/patched/piptools/repositories/pypi.py
+++ b/pipenv/patched/piptools/repositories/pypi.py
@@ -55,9 +55,10 @@ class HashCache(SafeFileCache):
             hash_value = self.get(location.url)
         if not hash_value:
             hash_value = self._get_file_hash(location)
+            hash_value = hash_value.encode('utf8')
         if can_hash:
             self.set(location.url, hash_value)
-        return hash_value
+        return hash_value.decode('utf8')
 
     def _get_file_hash(self, location):
         h = hashlib.new(FAVORITE_HASH)


### PR DESCRIPTION
Re-use pip's safe file cache to store hash values for packages.

Set up is:

1. only hash if the remote provides a checksum/hash in URL (e.g. `https://pypi.python.org/mypkg/whatever-path.whl#md5=....`)
2. Store hash in a path including the checksum/hash in the URL (again, only if valid)
3. always return a hash

I will remove print statements before merging.

Gotta think about how to test this too...