### PR TITLE
Fix Python version parser for 2.7.0

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -401,3 +401,23 @@ twine = "*"
     )
     def test_prepare_pip_source_args(self, sources, expected_args):
         assert pipenv.utils.prepare_pip_source_args(sources, pip_args=None) == expected_args
+
+    @pytest.mark.utils
+    def test_parse_python_version(self):
+        ver = pipenv.utils.parse_python_version('Python 3.6.5\n')
+        assert ver == {'major': '3', 'minor': '6', 'micro': '5'}
+
+    @pytest.mark.utils
+    def test_parse_python_version_suffix(self):
+        ver = pipenv.utils.parse_python_version('Python 3.6.5rc1\n')
+        assert ver == {'major': '3', 'minor': '6', 'micro': '5'}
+
+    @pytest.mark.utils
+    def test_parse_python_version_270(self):
+        ver = pipenv.utils.parse_python_version('Python 2.7\n')
+        assert ver == {'major': '2', 'minor': '7', 'micro': '0'}
+
+    @pytest.mark.utils
+    def test_parse_python_version_270_garbage(self):
+        ver = pipenv.utils.parse_python_version('Python 2.7+\n')
+        assert ver == {'major': '2', 'minor': '7', 'micro': '0'}


### PR DESCRIPTION
At this point I think it is better to just parse the whole thing with regex instead. I read some past commits on this part of code and found d00d33be. @eli-b can you help me test if Miniconda’s version output works with this regex pattern?