### PR TITLE
Enable installation using `-i indexname`

### DIFF
--- a/pipenv/project.py
+++ b/pipenv/project.py
@@ -597,6 +597,10 @@ class Project(object):
                     return source
         raise SourceNotFound(name or url)
 
+    def lookup_source(self, index):
+        pf = self.parsed_pipfile
+        return [s for s in pf.get('source') if s['name'] == index]
+
     def destroy_lockfile(self):
         """Deletes the lockfile."""
         try:


### PR DESCRIPTION
- Recognizes index names in pipfile
- Falls back to assuming index is a url and uses it as such
- Actually uses the index when passed at `pipenv install`
- Fixes #1852

Signed-off-by: Dan Ryan <dan@danryan.co>