### PR TITLE
Ensure we're loading .env in UTF-8

### DIFF
--- a/pipenv/envload.py
+++ b/pipenv/envload.py
@@ -1,0 +1,30 @@
+import io
+
+try:
+    import pathlib
+except ImportError:
+    import pathlib2 as pathlib
+
+import dotenv
+
+from .environments import PIPENV_DONT_LOAD_ENV, PIPENV_DOTENV_LOCATION
+
+
+def load_dot_env(project_directory, preload=None):
+    """Loads .env file into sys.environ.
+    """
+    if PIPENV_DONT_LOAD_ENV:
+        return
+    if PIPENV_DOTENV_LOCATION:
+        dotenv_location = pathlib.Path(PIPENV_DOTENV_LOCATION)
+    else:
+        # If the project doesn't exist yet, check current directory.
+        dotenv_location = str(pathlib.Path(project_directory or '.', '.env'))
+    dotenv_path = pathlib.Path(dotenv.find_dotenv(dotenv_location))
+    if not dotenv_path.is_file():
+        return
+    if callable(preload):
+        preload()
+    with dotenv_path.open(encoding='utf-8') as f:
+        stream = io.StringIO(f.read())
+    dotenv.load_dotenv(stream, override=True)

--- a/tests/integration/test_run.py
+++ b/tests/integration/test_run.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+import io
 import os
 
 from pipenv.project import Project
@@ -9,12 +11,19 @@ import pytest
 @pytest.mark.dotenv
 def test_env(PipenvInstance):
     with PipenvInstance(pipfile=False, chdir=True) as p:
-        with open('.env', 'w') as f:
-            f.write('HELLO=WORLD')
+        with io.open('.env', 'w', encoding='utf-8') as f:
+            f.write(u'HELLO=WORLD\n')
+            f.write(u'HI=世界\n')
 
         c = p.pipenv('run python -c "import os; print(os.environ[\'HELLO\'])"')
         assert c.return_code == 0
         assert 'WORLD' in c.out
+
+        c = p.pipenv('run python -c "import os; print(os.environ[\'HI\'])"')
+        assert c.return_code == 0
+        # The output varies too much from platform to platform.
+        # As long as it prints (return code 0) I guess it's fine.
+        # Feel free to contribute a robust assertion if you feel like it.
 
 
 @pytest.mark.run


### PR DESCRIPTION
Since python-dotenv does not provide this capacity, we do the reading part ourselves instead (into a StringIO). It supports this at least, fortunately.

Fix #1963.