### PR TITLE
Check whether dependency exists in old lockfile during keep-updated lock

### DIFF
--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -1136,11 +1136,12 @@ def do_lock(
             for package_specified in section:
                 norm_name = pep423_name(package_specified)
                 if not is_pinned(section[package_specified]):
-                    lockfile[section_name][norm_name] = cached_lockfile[
-                        section_name
-                    ][
-                        norm_name
-                    ]
+                    if norm_name in cached_lockfile[section_name]:
+                        lockfile[section_name][norm_name] = cached_lockfile[
+                            section_name
+                        ][
+                            norm_name
+                        ]
     # Overwrite any develop packages with default packages.
     for default_package in lockfile['default']:
         if default_package in lockfile['develop']:


### PR DESCRIPTION
Currently, if a new dependency has been added to the `Pipfile` and `pipenv lock --keep-outdated` is run a `KeyError: '<dependency-nam>'` error is raised. Conditioning on whether the dependency is already in the lockfile fixes this.