### PR TITLE
Expand env vars in Pipfile

### DIFF
--- a/pipenv/help.py
+++ b/pipenv/help.py
@@ -45,13 +45,13 @@ def main():
     for key in os.environ:
         print('  - `{0}`'.format(key))
     print('')
-    print(u'Pipenv–specific environment variables:')
+    print(u'Pipenv-specific environment variables:')
     print('')
     for key in os.environ:
         if key.startswith('PIPENV'):
             print(' - `{0}`: `{1}`'.format(key, os.environ[key]))
     print('')
-    print(u'Debug–specific environment variables:')
+    print(u'Debug-specific environment variables:')
     print('')
     for key in ('PATH', 'SHELL', 'EDITOR', 'LANG', 'PWD', 'VIRTUAL_ENV'):
         if key in os.environ:

--- a/pipenv/project.py
+++ b/pipenv/project.py
@@ -392,6 +392,12 @@ class Project(object):
         _pipfile_cache.clear()
 
     def _parse_pipfile(self, contents):
+        parsed = self.__parse_pipfile(contents)
+        for source in parsed.get('source', []):
+            source['url'] = os.path.expandvars(source['url'])
+        return parsed
+
+    def __parse_pipfile(self, contents):
         # If any outline tables are present...
         if ('[packages.' in contents) or ('[dev-packages.' in contents):
             data = toml.loads(contents)

--- a/tests/integration/test_run.py
+++ b/tests/integration/test_run.py
@@ -18,6 +18,24 @@ def test_env(PipenvInstance):
 
 
 @pytest.mark.run
+def test_expands_env_variables(PipenvInstance, monkeypatch):
+    with PipenvInstance(chdir=True) as p:
+        with open(p.pipfile_path, 'w') as f:
+            f.write(r"""
+            [[source]]
+            url = "https://${TEST_HOST}/simple"
+            verify_ssl = true
+            name = "pypi"
+            """)
+
+        monkeypatch.setenv('TEST_HOST', 'localhost:8888')
+
+        project = Project()
+        assert len(project.sources) == 1
+        assert project.sources[0]['url'] == 'https://localhost:8888/simple'
+
+
+@pytest.mark.run
 def test_scripts(PipenvInstance):
     with PipenvInstance(chdir=True) as p:
         with open(p.pipfile_path, 'w') as f:


### PR DESCRIPTION
Documentation says it's possible to use environment variables in source urls (https://docs.pipenv.org/advanced/#injecting-credentials-into-pipfiles-via-environment-variables), but it doesn't seem to be the case at the moment. Here's a fix that works for me.
