### PR TITLE
Re-add check for vcs pkgs presence in pipfile

### DIFF
--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -1131,6 +1131,11 @@ def do_lock(
     pip_freeze = delegator.run('{0} freeze'.format(escape_grouped_arguments(which_pip(allow_global=system)))).out
     for dep in vcs_deps:
         for line in pip_freeze.strip().split('\n'):
+            # if the line doesn't match a vcs dependency in the Pipfile,
+            # ignore it
+            if not any(dep in line for dep in vcs_deps):
+                continue
+
             try:
                 installed = convert_deps_from_pip(line)
                 name = list(installed.keys())[0]

--- a/tests/integration/test_install_uri.py
+++ b/tests/integration/test_install_uri.py
@@ -132,6 +132,7 @@ def test_install_local_vcs_not_in_lockfile(PipenvInstance, pip_src_dir):
         assert c.return_code == 0
         c = p.pipenv('install -e ./six')
         assert c.return_code == 0
+        six_key = list(p.pipfile['packages'].keys())[0]
         c = p.pipenv('install -e git+https://github.com/requests/requests.git#egg=requests')
         assert c.return_code == 0
         c = p.pipenv('lock')
@@ -139,7 +140,7 @@ def test_install_local_vcs_not_in_lockfile(PipenvInstance, pip_src_dir):
         assert 'requests' in p.pipfile['packages']
         assert 'requests' in p.lockfile['default']
         # This is the hash of ./six
-        assert 'a64df78' in p.pipfile['packages']
-        assert 'a64df78' in p.lockfile['default']
+        assert six_key in p.pipfile['packages']
+        assert six_key in p.lockfile['default']
         # Make sure we didn't put six in the lockfile by accident as a vcs ref
         assert 'six' not in p.lockfile['default']

--- a/tests/integration/test_install_uri.py
+++ b/tests/integration/test_install_uri.py
@@ -1,6 +1,7 @@
 import pytest
 import os
 from flaky import flaky
+import delegator
 
 
 @pytest.mark.vcs
@@ -119,3 +120,26 @@ six = "*"
             f.write(contents)
         c = p.pipenv('install pipenv-test-private-package --index testpypi')
         assert c.return_code == 0
+
+
+@pytest.mark.vcs
+@pytest.mark.install
+@pytest.mark.needs_internet
+def test_install_local_vcs_not_in_lockfile(PipenvInstance, pip_src_dir):
+    with PipenvInstance(chdir=True) as p:
+        six_path = os.path.join(p.path, 'six')
+        c = delegator.run('git clone https://github.com/benjaminp/six.git {0}'.format(six_path))
+        assert c.return_code == 0
+        c = p.pipenv('install -e ./six')
+        assert c.return_code == 0
+        c = p.pipenv('install -e git+https://github.com/requests/requests.git#egg=requests')
+        assert c.return_code == 0
+        c = p.pipenv('lock')
+        assert c.return_code == 0
+        assert 'requests' in p.pipfile['packages']
+        assert 'requests' in p.lockfile['default']
+        # This is the hash of ./six
+        assert 'a64df78' in p.pipfile['packages']
+        assert 'a64df78' in p.lockfile['default']
+        # Make sure we didn't put six in the lockfile by accident as a vcs ref
+        assert 'six' not in p.lockfile['default']


### PR DESCRIPTION
- This was removed in a refactor for no discernable reason
- The logic is still present in dev-packages
- Fixes #1130

Signed-off-by: Dan Ryan <dan@danryan.co>