### PR TITLE
dont ignore compatibility check

### DIFF
--- a/pipenv/patched/notpip/index.py
+++ b/pipenv/patched/notpip/index.py
@@ -642,7 +642,7 @@ class PackageFinder(object):
             logger.debug('Skipping link %s; %s', link, reason)
             self.logged_links.add(link)
 
-    def _link_package_versions(self, link, search, ignore_compatibility=True):
+    def _link_package_versions(self, link, search, ignore_compatibility=False):
         """Return an InstallationCandidate or None"""
         version = None
         if link.egg_fragment:

--- a/tests/integration/test_lock.py
+++ b/tests/integration/test_lock.py
@@ -210,3 +210,27 @@ requests = "*"
         assert c.return_code == 0
         assert '-i https://pypi.python.org/simple' in c.out.strip()
         assert '--extra-index-url https://test.pypi.org/simple' in c.out.strip()
+
+
+@pytest.mark.lock
+@pytest.mark.needs_internet
+def test_lock_with_python_constraints(PipenvInstance):
+    with PipenvInstance() as p:
+        with open(p.pipfile_path, 'w') as f:
+            contents = """
+[[source]]
+url = "https://pypi.python.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[requires]
+python_version = "2.7"
+
+[packages]
+django = "*"
+            """.strip()
+            f.write(contents)
+        c = p.pipenv('lock')
+        assert c.return_code == 0
+        django_version = p.lockfile['default']['django']['version']
+        assert int(django_version[2]) < 2


### PR DESCRIPTION
`_link_package_versions` is only called by `_package_versions`. I guess it's safe to modify the default value here.

Fixes #1901 