### PR TITLE
Fall back to toml for parsing errors in contoml

### DIFF
--- a/pipenv/project.py
+++ b/pipenv/project.py
@@ -11,6 +11,7 @@ from first import first
 import pipfile
 import pipfile.api
 import toml
+import prettytoml
 
 try:
     import pathlib
@@ -408,7 +409,7 @@ class Project(object):
             try:
                 return contoml.loads(toml.dumps(data, preserve=True))
 
-            except RuntimeError:
+            except (RuntimeError, prettytoml.parser.errors.ParsingError):
                 return toml.loads(toml.dumps(data, preserve=True))
 
         else:


### PR DESCRIPTION
Doesn't fix https://github.com/pypa/pipenv/issues/2062 (it turns out that `toml` can't handle this case in the currently vendored version), but may fix other TOML parsing issues. 

I also tried this using `master` from `toml`, which required a few other changes to get working. Using the `master` branch *does* fix https://github.com/pypa/pipenv/issues/2062, so hopefully it will be released soon. 