### PR TITLE
Rename _PipenvInstance.pipfile_path to pipfile_location for consistency

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -47,7 +47,7 @@ class _PipenvInstance(object):
         self._path = TemporaryDirectory(suffix='-project', prefix='pipenv-')
         self.path = self._path.name
         # set file creation perms
-        self.pipfile_path = None
+        self.pipfile_location = None
         self.chdir = chdir
 
         if self.pypi:
@@ -59,7 +59,7 @@ class _PipenvInstance(object):
                 os.utime(p_path, None)
 
             self.chdir = False or chdir
-            self.pipfile_path = p_path
+            self.pipfile_location = p_path
 
     def __enter__(self):
         os.environ['PIPENV_DONT_USE_PYENV'] = '1'
@@ -84,8 +84,8 @@ class _PipenvInstance(object):
             os.umask(self.original_umask)
 
     def pipenv(self, cmd, block=True):
-        if self.pipfile_path:
-            os.environ['PIPENV_PIPFILE'] = self.pipfile_path
+        if self.pipfile_location:
+            os.environ['PIPENV_PIPFILE'] = self.pipfile_location
 
         with TemporaryDirectory(prefix='pipenv-', suffix='-cache') as tempdir:
             os.environ['PIPENV_CACHE_DIR'] = tempdir.name

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -114,7 +114,7 @@ def test_install_parse_error(PipenvInstance, pypi):
 
         # Make sure unparseable packages don't wind up in the pipfile
         # Escape $ for shell input
-        with open(p.pipfile_path, 'w') as f:
+        with open(p.pipfile_location, 'w') as f:
             contents = """
 [packages]
 

--- a/tests/integration/test_install_basic.py
+++ b/tests/integration/test_install_basic.py
@@ -72,7 +72,7 @@ def test_basic_dev_install(PipenvInstance, pypi):
 def test_install_without_dev(PipenvInstance, pypi):
     """Ensure that running `pipenv install` doesn't install dev packages"""
     with PipenvInstance(pypi=pypi, chdir=True) as p:
-        with open(p.pipfile_path, 'w') as f:
+        with open(p.pipfile_location, 'w') as f:
             contents = """
 [packages]
 six = "*"
@@ -97,7 +97,7 @@ pytz = "*"
 @flaky
 def test_install_without_dev_section(PipenvInstance, pypi):
     with PipenvInstance(pypi=pypi) as p:
-        with open(p.pipfile_path, 'w') as f:
+        with open(p.pipfile_location, 'w') as f:
             contents = """
 [packages]
 six = "*"
@@ -135,7 +135,7 @@ def test_extras_install(PipenvInstance, pypi):
 @flaky
 def test_windows_pinned_pipfile(PipenvInstance, pypi):
     with PipenvInstance(pypi=pypi) as p:
-        with open(p.pipfile_path, 'w') as f:
+        with open(p.pipfile_location, 'w') as f:
             contents = """
 [packages]
 tablib = "<0.12"
@@ -153,7 +153,7 @@ tablib = "<0.12"
 @flaky
 def test_backup_resolver(PipenvInstance, pypi):
     with PipenvInstance(pypi=pypi) as p:
-        with open(p.pipfile_path, 'w') as f:
+        with open(p.pipfile_location, 'w') as f:
             contents = """
 [packages]
 "ibm-db-sa-py3" = "==0.3.1-1"
@@ -170,7 +170,7 @@ def test_backup_resolver(PipenvInstance, pypi):
 @flaky
 def test_alternative_version_specifier(PipenvInstance, pypi):
     with PipenvInstance(pypi=pypi) as p:
-        with open(p.pipfile_path, 'w') as f:
+        with open(p.pipfile_location, 'w') as f:
             contents = """
 [packages]
 requests = {version = "*"}

--- a/tests/integration/test_install_markers.py
+++ b/tests/integration/test_install_markers.py
@@ -18,7 +18,7 @@ py3_only = pytest.mark.skipif(sys.version_info < (3, 0), reason="requires Python
 def test_package_environment_markers(PipenvInstance, pypi):
 
     with PipenvInstance(pypi=pypi) as p:
-        with open(p.pipfile_path, 'w') as f:
+        with open(p.pipfile_location, 'w') as f:
             contents = """
 [packages]
 tablib = {version = "*", markers="os_name=='splashwear'"}
@@ -41,7 +41,7 @@ tablib = {version = "*", markers="os_name=='splashwear'"}
 def test_specific_package_environment_markers(PipenvInstance, pypi):
 
     with PipenvInstance(pypi=pypi) as p:
-        with open(p.pipfile_path, 'w') as f:
+        with open(p.pipfile_location, 'w') as f:
             contents = """
 [packages]
 requests = {version = "*", os_name = "== 'splashwear'"}
@@ -64,7 +64,7 @@ def test_top_level_overrides_environment_markers(PipenvInstance, pypi):
     """Top-level environment markers should take precedence.
     """
     with PipenvInstance(pypi=pypi) as p:
-        with open(p.pipfile_path, 'w') as f:
+        with open(p.pipfile_location, 'w') as f:
             contents = """
 [packages]
 apscheduler = "*"
@@ -89,7 +89,7 @@ def test_global_overrides_environment_markers(PipenvInstance, pypi):
     also specified as an unconditional dep, its markers should be empty.
     """
     with PipenvInstance(pypi=pypi) as p:
-        with open(p.pipfile_path, 'w') as f:
+        with open(p.pipfile_location, 'w') as f:
             contents = """
 [packages]
 apscheduler = "*"
@@ -129,7 +129,7 @@ def test_resolver_unique_markers(PipenvInstance, pypi):
 def test_environment_variable_value_does_not_change_hash(PipenvInstance, pypi):
     with PipenvInstance(chdir=True, pypi=pypi) as p:
         with temp_environ():
-            with open(p.pipfile_path, 'w') as f:
+            with open(p.pipfile_location, 'w') as f:
                 f.write("""
 [[source]]
 url = 'https://${PYPI_USERNAME}:${PYPI_PASSWORD}@pypi.python.org/simple'
@@ -152,13 +152,13 @@ flask = "==0.12.2"
             assert lock_hash == project.calculate_pipfile_hash()
 
             # sanity check on pytest
-            assert 'PYPI_USERNAME' not in str(pipfile.load(p.pipfile_path))
+            assert 'PYPI_USERNAME' not in str(pipfile.load(p.pipfile_location))
             assert c.return_code == 0
             assert project.get_lockfile_hash() == project.calculate_pipfile_hash()
 
             os.environ['PYPI_PASSWORD'] = 'pass2'
             assert project.get_lockfile_hash() == project.calculate_pipfile_hash()
 
-            with open(p.pipfile_path, 'a') as f:
+            with open(p.pipfile_location, 'a') as f:
                 f.write('requests = "==2.14.0"\n')
             assert project.get_lockfile_hash() != project.calculate_pipfile_hash()

--- a/tests/integration/test_install_twists.py
+++ b/tests/integration/test_install_twists.py
@@ -70,7 +70,7 @@ def test_multiprocess_bug_and_install(PipenvInstance, pypi):
         os.environ['PIPENV_MAX_SUBPROCESS'] = '2'
 
         with PipenvInstance(pypi=pypi, chdir=True) as p:
-            with open(p.pipfile_path, 'w') as f:
+            with open(p.pipfile_location, 'w') as f:
                 contents = """
 [packages]
 pytz = "*"
@@ -96,7 +96,7 @@ urllib3 = "*"
 def test_sequential_mode(PipenvInstance, pypi):
 
     with PipenvInstance(pypi=pypi, chdir=True) as p:
-        with open(p.pipfile_path, 'w') as f:
+        with open(p.pipfile_location, 'w') as f:
             contents = """
 [packages]
 six = "*"
@@ -120,7 +120,7 @@ pytz = "*"
 @pytest.mark.run
 def test_normalize_name_install(PipenvInstance, pypi):
     with PipenvInstance(pypi=pypi) as p:
-        with open(p.pipfile_path, 'w') as f:
+        with open(p.pipfile_location, 'w') as f:
             contents = """
 # Pre comment
 [packages]
@@ -141,7 +141,7 @@ Requests = "==2.14.0"   # Inline comment
         c = p.pipenv('install python_DateUtil')
         assert c.return_code == 0
         assert 'python-dateutil' in p.pipfile['packages']
-        contents = open(p.pipfile_path).read()
+        contents = open(p.pipfile_location).read()
         assert '# Pre comment' in contents
         assert '# Inline comment' in contents
 

--- a/tests/integration/test_install_uri.py
+++ b/tests/integration/test_install_uri.py
@@ -100,7 +100,7 @@ def test_install_editable_git_tag(PipenvInstance, pip_src_dir, pypi):
 @pytest.mark.needs_internet
 def test_install_named_index_alias(PipenvInstance, pypi):
     with PipenvInstance(pypi=pypi) as p:
-        with open(p.pipfile_path, 'w') as f:
+        with open(p.pipfile_location, 'w') as f:
             contents = """
 [[source]]
 url = "https://pypi.python.org/simple"

--- a/tests/integration/test_lock.py
+++ b/tests/integration/test_lock.py
@@ -9,7 +9,7 @@ def test_lock_handle_eggs(PipenvInstance, pypi):
     """Ensure locking works with packages provoding egg formats.
     """
     with PipenvInstance() as p:
-        with open(p.pipfile_path, 'w') as f:
+        with open(p.pipfile_location, 'w') as f:
             f.write("""
 [packages]
 RandomWords = "*"
@@ -25,7 +25,7 @@ RandomWords = "*"
 def test_lock_requirements_file(PipenvInstance, pypi):
 
     with PipenvInstance(pypi=pypi) as p:
-        with open(p.pipfile_path, 'w') as f:
+        with open(p.pipfile_location, 'w') as f:
             contents = """
 [packages]
 requests = "==2.14.0"
@@ -57,7 +57,7 @@ def test_complex_lock_with_vcs_deps(PipenvInstance, pip_src_dir):
     # This uses the real PyPI since we need Internet to access the Git
     # dependency anyway.
     with PipenvInstance() as p:
-        with open(p.pipfile_path, 'w') as f:
+        with open(p.pipfile_location, 'w') as f:
             contents = """
 [packages]
 click = "==6.7"
@@ -90,7 +90,7 @@ requests = {git = "https://github.com/requests/requests.git"}
 def test_lock_with_prereleases(PipenvInstance, pypi):
 
     with PipenvInstance(pypi=pypi) as p:
-        with open(p.pipfile_path, 'w') as f:
+        with open(p.pipfile_location, 'w') as f:
             contents = """
 [packages]
 sqlalchemy = "==1.2.0b3"
@@ -113,7 +113,7 @@ allow_prereleases = true
 def test_complex_deps_lock_and_install_properly(PipenvInstance, pip_src_dir, pypi):
     # This uses the real PyPI because Maya has too many dependencies...
     with PipenvInstance(chdir=True, pypi=pypi) as p:
-        with open(p.pipfile_path, 'w') as f:
+        with open(p.pipfile_location, 'w') as f:
             contents = """
 [packages]
 maya = "*"
@@ -137,7 +137,7 @@ def test_complex_lock_deep_extras(PipenvInstance, pypi):
     # This uses the real PyPI; Pandas has too many requirements to mock.
 
     with PipenvInstance(pypi=pypi) as p:
-        with open(p.pipfile_path, 'w') as f:
+        with open(p.pipfile_location, 'w') as f:
             contents = """
 [packages]
 records = {extras = ["pandas"], version = "==0.5.2"}
@@ -158,7 +158,7 @@ records = {extras = ["pandas"], version = "==0.5.2"}
 @pytest.mark.install  # private indexes need to be uncached for resolution
 def test_private_index_skip_lock(PipenvInstance):
     with PipenvInstance() as p:
-        with open(p.pipfile_path, 'w') as f:
+        with open(p.pipfile_location, 'w') as f:
             contents = """
 [[source]]
 url = "https://pypi.python.org/simple"
@@ -187,7 +187,7 @@ requests = "*"
 def test_private_index_lock_requirements(PipenvInstance):
     # Don't use the local fake pypi
     with PipenvInstance() as p:
-        with open(p.pipfile_path, 'w') as f:
+        with open(p.pipfile_location, 'w') as f:
             contents = """
 [[source]]
 url = "https://pypi.python.org/simple"

--- a/tests/integration/test_pipenv.py
+++ b/tests/integration/test_pipenv.py
@@ -36,7 +36,7 @@ def test_activate_virtualenv_no_source():
 def test_deploy_works(PipenvInstance, pypi):
 
     with PipenvInstance(pypi=pypi) as p:
-        with open(p.pipfile_path, 'w') as f:
+        with open(p.pipfile_location, 'w') as f:
             contents = """
 [packages]
 requests = "==2.14.0"
@@ -49,7 +49,7 @@ pytest = "==3.1.1"
         assert c.return_code == 0
         c = p.pipenv('lock')
         assert c.return_code == 0
-        with open(p.pipfile_path, 'w') as f:
+        with open(p.pipfile_location, 'w') as f:
             contents = """
 [packages]
 requests = "==2.14.0"

--- a/tests/integration/test_project.py
+++ b/tests/integration/test_project.py
@@ -12,7 +12,7 @@ from pipenv.patched import pipfile
 def test_pipfile_envvar_expansion(PipenvInstance):
     with PipenvInstance(chdir=True) as p:
         with temp_environ():
-            with open(p.pipfile_path, 'w') as f:
+            with open(p.pipfile_location, 'w') as f:
                 f.write("""
 [[source]]
 url = 'https://${TEST_HOST}/simple'
@@ -25,7 +25,7 @@ pytz = "*"
             os.environ['TEST_HOST'] = 'localhost:5000'
             project = Project()
             assert project.sources[0]['url'] == 'https://localhost:5000/simple'
-            assert 'localhost:5000' not in str(pipfile.load(p.pipfile_path))
+            assert 'localhost:5000' not in str(pipfile.load(p.pipfile_location))
 
 
 @pytest.mark.project
@@ -33,7 +33,7 @@ pytz = "*"
 @pytest.mark.parametrize('lock_first', [True, False])
 def test_get_source(PipenvInstance, pypi, lock_first):
     with PipenvInstance(pypi=pypi, chdir=True) as p:
-        with open(p.pipfile_path, 'w') as f:
+        with open(p.pipfile_location, 'w') as f:
             contents = """
 [[source]]
 url = "{0}"

--- a/tests/integration/test_run.py
+++ b/tests/integration/test_run.py
@@ -20,7 +20,7 @@ def test_env(PipenvInstance):
 @pytest.mark.run
 def test_scripts(PipenvInstance):
     with PipenvInstance(chdir=True) as p:
-        with open(p.pipfile_path, 'w') as f:
+        with open(p.pipfile_location, 'w') as f:
             f.write(r"""
 [scripts]
 printfoo = "python -c \"print('foo')\""

--- a/tests/integration/test_uninstall.py
+++ b/tests/integration/test_uninstall.py
@@ -88,7 +88,7 @@ def test_uninstall_all_dev(PipenvInstance, pypi):
 @pytest.mark.run
 def test_normalize_name_uninstall(PipenvInstance, pypi):
     with PipenvInstance(pypi=pypi) as p:
-        with open(p.pipfile_path, 'w') as f:
+        with open(p.pipfile_location, 'w') as f:
             contents = """
 # Pre comment
 [packages]
@@ -103,6 +103,6 @@ python_DateUtil = "*"   # Inline comment
         c = p.pipenv('uninstall python_dateutil')
         assert 'Requests' in p.pipfile['packages']
         assert 'python_DateUtil' not in p.pipfile['packages']
-        contents = open(p.pipfile_path).read()
+        contents = open(p.pipfile_location).read()
         assert '# Pre comment' in contents
         assert '# Inline comment' in contents


### PR DESCRIPTION
The inconsistency was noticed at https://github.com/pypa/pipenv/pull/2069#discussion_r184529995.  The PR that is not accepted first should be updated to avoid the original observation actually being out of place (`self.lockfile_path` -> `self.lockfile_location`).