### PR TITLE
Allow pyenv installs in non-interactive sessions in PIPENV_YES is set

### DIFF
--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -461,7 +461,7 @@ def ensure_python(three=None, python=None):
         if not PYENV_INSTALLED:
             abort()
         else:
-            if (not PIPENV_DONT_USE_PYENV) and (SESSION_IS_INTERACTIVE):
+            if (not PIPENV_DONT_USE_PYENV) and (SESSION_IS_INTERACTIVE or PIPENV_YES):
                 version_map = {
                     # TODO: Keep this up to date!
                     # These versions appear incompatible with pew:


### PR DESCRIPTION
I'd like to be able to use the pyenv auto-installs from within a non-interactive session to allow Dependabot to honour the Python version specified in a Pipfile.

If `PIPENV_YES` is set, it seems like a relatively strong indicator that `SESSION_IS_INTERACTIVE` logic should be ignored, so I don't think there's any need for an additional environment variable. Happy to add an explicit one if you would prefer, though.