### PR TITLE
Only use `-e` for install when `editable=True`

### DIFF
--- a/pipenv/utils.py
+++ b/pipenv/utils.py
@@ -717,7 +717,7 @@ def convert_deps_to_pip(deps, project=None, r=True, include_index=False):
         vcs = maybe_vcs[0] if maybe_vcs else None
         if not any(key in deps[dep] for key in ['path', 'vcs', 'file']):
             extra += extras
-        if not isinstance(deps[dep], Mapping):
+        if isinstance(deps[dep], Mapping):
             editable = bool(deps[dep].get('editable', False))
         # Support for files.
         if 'file' in deps[dep]:

--- a/pipenv/utils.py
+++ b/pipenv/utils.py
@@ -564,6 +564,10 @@ def multi_split(s, split):
 
 def convert_deps_from_pip(dep):
     """"Converts a pip-formatted dependency to a Pipfile-formatted one."""
+    try:
+        from collections.abc import Mapping
+    except ImportError:
+        from collections import Mapping
     dependency = {}
     req = get_requirement(dep)
     extras = {'extras': req.extras}
@@ -713,8 +717,8 @@ def convert_deps_to_pip(deps, project=None, r=True, include_index=False):
         vcs = maybe_vcs[0] if maybe_vcs else None
         if not any(key in deps[dep] for key in ['path', 'vcs', 'file']):
             extra += extras
-        if not isinstance(deps[dep], six.string_types):
-            editable = str(deps[dep].get('editable', '')).lower() == 'true'
+        if not isinstance(deps[dep], Mapping):
+            editable = bool(deps[dep].get('editable', False))
         # Support for files.
         if 'file' in deps[dep]:
             dep_file = deps[dep]['file']

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -56,7 +56,7 @@ DEP_PIP_PAIRS = [
         {'requests': {
             'git': 'https://github.com/requests/requests.git',
             'ref': 'master', 'extras': ['security'],
-            'editable': 'false'
+            'editable': False
         }},
         'git+https://github.com/requests/requests.git@master#egg=requests[security]',
     ),

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -2,7 +2,7 @@
 import os
 import pytest
 from mock import patch, Mock
-
+from first import first
 import pipenv.utils
 
 
@@ -110,8 +110,9 @@ def test_convert_deps_to_pip_unicode():
 @pytest.mark.parametrize('expected, requirement', DEP_PIP_PAIRS)
 def test_convert_from_pip(expected, requirement):
     # We don't build requirements back up with the editable key, so lets drop it out
-    if 'requests' in expected and expected['requests'].get('editable', '') == 'false':
-        del expected['requests']['editable']
+    package = first(expected.keys())
+    if hasattr(expected[package], 'keys') and expected[package].get('editable') is False:
+        del expected[package]['editable']
     assert pipenv.utils.convert_deps_from_pip(requirement) == expected
 
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -56,6 +56,7 @@ DEP_PIP_PAIRS = [
         {'requests': {
             'git': 'https://github.com/requests/requests.git',
             'ref': 'master', 'extras': ['security'],
+            'editable': 'false'
         }},
         'git+https://github.com/requests/requests.git@master#egg=requests[security]',
     ),
@@ -108,6 +109,9 @@ def test_convert_deps_to_pip_unicode():
 @pytest.mark.utils
 @pytest.mark.parametrize('expected, requirement', DEP_PIP_PAIRS)
 def test_convert_from_pip(expected, requirement):
+    # We don't build requirements back up with the editable key, so lets drop it out
+    if 'requests' in expected and expected['requests'].get('editable', '') == 'false':
+        del expected['requests']['editable']
     assert pipenv.utils.convert_deps_from_pip(requirement) == expected
 
 


### PR DESCRIPTION
- Fixes #2121
- Add tests for regressions

Signed-off-by: Dan Ryan <dan@danryan.co>