### PR TITLE
Retry pypi.org requests on CI, or if an environment variable is set

### DIFF
--- a/pipenv/environments.py
+++ b/pipenv/environments.py
@@ -23,6 +23,9 @@ PIPENV_COLORBLIND = bool(os.environ.get('PIPENV_COLORBLIND'))
 PIPENV_NOSPIN = bool(os.environ.get('PIPENV_NOSPIN'))
 # Tells Pipenv how many rounds of resolving to do for Pip-Tools.
 PIPENV_MAX_ROUNDS = int(os.environ.get('PIPENV_MAX_ROUNDS', '16'))
+# Specify how many retries Pipenv should attempt for network requests.
+default_retries = '1' if 'CI' in os.environ else '0'
+PIPENV_MAX_RETRIES = int(os.environ.get('PIPENV_MAX_RETRIES', default_retries))
 # Specify a custom Pipfile location.
 PIPENV_PIPFILE = os.environ.get('PIPENV_PIPFILE')
 # Tells Pipenv which Python to default to, when none is provided.

--- a/pipenv/utils.py
+++ b/pipenv/utils.py
@@ -45,7 +45,11 @@ except ImportError:
 from distutils.spawn import find_executable
 from contextlib import contextmanager
 from .pep508checker import lookup
-from .environments import PIPENV_MAX_ROUNDS, PIPENV_CACHE_DIR
+from .environments import (
+    PIPENV_MAX_ROUNDS,
+    PIPENV_CACHE_DIR,
+    PIPENV_MAX_RETRIES
+)
 
 try:
     from collections.abc import Mapping
@@ -72,6 +76,8 @@ def _get_requests_session():
         return requests_session
     import requests
     requests_session = requests.Session()
+    adapter = requests.adapters.HTTPAdapter(max_retries=PIPENV_MAX_RETRIES)
+    requests_session.mount('https://pypi.org/pypi', adapter)
     return requests_session
 
 


### PR DESCRIPTION
Use PIPENV_MAX_RETRIES environment variable to determine how many times to retry requests to pypi.org. Default to 0 retries, unless running on CI, in which case default to 1 retry.

This was the suggested retry setup in the discussion on https://github.com/pypa/pipenv/issues/1110.