### PR TITLE
Fix typo in HISTORY.txt: reqeuests -> requests

### DIFF
--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -51,7 +51,7 @@
  - Bugfix for allow_global with new resolver fixes.
  - Locally cache hashes for performance gains.
  - Lock prereleases correctly.
- - Add reqeuests.pem back to package.
+ - Add requests.pem back to package.
  - Auto-toggle PIPENV_VENV_IN_PROJECT when .venv is present.
  - Fix bug with pipfile casing.
  - Enable environment variable interpolation in pipfiles.


### PR DESCRIPTION
Quick, before the author of `requests` notices! 🙀