### PR TITLE
Clean unused sync options

### DIFF
--- a/pipenv/cli.py
+++ b/pipenv/cli.py
@@ -740,6 +740,9 @@ def check(
     default=None,
     help=u"List out–of–date dependencies.",
 )
+@option(
+    '--system', is_flag=True, default=False, help="System pip management."
+)
 @argument('package', default=False)
 @pass_context
 def update(
@@ -794,6 +797,7 @@ def update(
             python=python,
             bare=bare,
             verbose=verbose,
+            system=system,
             sequential=sequential,
         )
     else:
@@ -929,12 +933,16 @@ def run_open(module, three=None, python=None):
     default=False,
     help="Install dependencies one-at-a-time, instead of concurrently.",
 )
+@option(
+    '--system', is_flag=True, default=False, help="System pip management."
+)
 @pass_context
 def sync(
     ctx,
     dev=False,
     three=None,
     python=None,
+    system=False,
     bare=False,
     dry_run=False,
     verbose=False,
@@ -950,6 +958,7 @@ def sync(
         dev=dev,
         three=three,
         python=python,
+        system=system,
         bare=bare,
         verbose=verbose,
         sequential=sequential,

--- a/pipenv/cli.py
+++ b/pipenv/cli.py
@@ -943,7 +943,7 @@ def sync(
     from .core import do_sync, list_mismatching
 
     if dry_run:
-        list_mismatching()
+        list_mismatching(update=False)
 
     do_sync(
         ctx=ctx,

--- a/pipenv/cli.py
+++ b/pipenv/cli.py
@@ -761,7 +761,7 @@ def update(
 ):
     from .core import (
         ensure_project,
-        do_outdated,
+        list_mismatching,
         do_lock,
         do_sync,
         ensure_lockfile,
@@ -773,7 +773,7 @@ def update(
     if not outdated:
         outdated = bool(dry_run)
     if outdated:
-        do_outdated()
+        list_mismatching()
     if not package:
         echo(
             '{0} {1} {2} {3}{4}'.format(
@@ -789,16 +789,11 @@ def update(
         )
         do_sync(
             ctx=ctx,
-            install=install,
             dev=dev,
             three=three,
             python=python,
             bare=bare,
-            dont_upgrade=False,
-            user=False,
             verbose=verbose,
-            clear=clear,
-            unused=False,
             sequential=sequential,
         )
     else:
@@ -923,7 +918,10 @@ def run_open(module, three=None, python=None):
 )
 @option('--bare', is_flag=True, default=False, help="Minimal output.")
 @option(
-    '--clear', is_flag=True, default=False, help="Clear the dependency cache."
+    '--dry-run',
+    is_flag=True,
+    default=False,
+    help="List packages outdated or not installed."
 )
 @option(
     '--sequential',
@@ -938,28 +936,22 @@ def sync(
     three=None,
     python=None,
     bare=False,
-    dont_upgrade=False,
-    user=False,
+    dry_run=False,
     verbose=False,
-    clear=False,
-    unused=False,
-    package_name=None,
     sequential=False,
 ):
-    from .core import do_sync
+    from .core import do_sync, list_mismatching
+
+    if dry_run:
+        list_mismatching()
 
     do_sync(
         ctx=ctx,
-        install=install,
         dev=dev,
         three=three,
         python=python,
         bare=bare,
-        dont_upgrade=dont_upgrade,
-        user=user,
         verbose=verbose,
-        clear=clear,
-        unused=unused,
         sequential=sequential,
     )
 

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -1722,7 +1722,7 @@ def list_mismatching(update=True):
     for result in results:
         packages.update(convert_deps_from_pip(result))
     updated_packages = {}
-    if update or not project.lockfile_exists():
+    if update or not project.lockfile_exists:
         lockfile = do_lock(write=False)
     else:
         lockfile = project.load_lockfile()

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -2538,6 +2538,7 @@ def do_sync(
     dev=False,
     three=None,
     python=None,
+    system=False,
     bare=False,
     verbose=False,
     sequential=False,
@@ -2563,6 +2564,7 @@ def do_sync(
     do_init(
         dev=dev,
         verbose=verbose,
+        system=system,
         concurrent=(not sequential),
         requirements_dir=requirements_dir,
         ignore_pipfile=True,    # Don't check if Pipfile and lock match.

--- a/tests/integration/test_sync.py
+++ b/tests/integration/test_sync.py
@@ -40,3 +40,22 @@ six = "*"
         c = p.pipenv('sync')
         assert c.return_code == 0
         assert lockfile_content == p.lockfile
+
+
+@pytest.mark.sync
+def test_sync_dry_run(PipenvInstance, pypi):
+    with PipenvInstance(pypi=pypi) as p:
+        c = p.pipenv('install requests==2.14.0')
+        assert c.return_code == 0
+
+        with open(p.pipfile_path, 'w') as f:
+            f.write("""
+[packages]
+requests = "*"
+            """.strip())
+
+        c = p.pipenv('lock')
+        assert c.return_code == 0
+        c = p.pipenv('sync --dry-run')
+        assert "Package 'requests' out–of–date" in c.out
+        assert "Package 'chardet==3.0.4' is not installed." in c.out


### PR DESCRIPTION
Closes #2010 

`pipenv update --dry-run` will also output not installed packages, as what's done in non dry-run mode. Here is what it produces:
```bash
$ pipenv sync --dry-run
Package 'requests' out–of–date: '==2.14.0' installed, '==2.18.4' available.
Package 'chardet==3.0.4' is not installed.
Package 'urllib3==1.22' is not installed.
Package 'idna==2.6' is not installed.
Package 'certifi==2018.4.16' is not installed.
```