### PR TITLE
Add tips for Supervisor user

### DIFF
--- a/docs/diagnose.rst
+++ b/docs/diagnose.rst
@@ -119,3 +119,14 @@ instead (not available on Windows).
 No, it does not, intentionally. Pipfile and setup.py serve different purposes,
 and should not consider each other by default. See :ref:`pipfile-vs-setuppy`
 for more information.
+
+☤ Using ``pipenv run`` in Supervisor program
+---------------------------------------------
+
+When you configure a supervisor program's ``command`` with ``pipenv run ...``, you 
+need to set locale enviroment variables properly to make it work. 
+
+Add this line under ``[supervisord]`` section in ``/etc/supervisor/supervisord.conf``::
+    
+    [supervisord]
+    environment=LC_ALL='en_US.UTF-8',LANG='en_US.UTF-8'


### PR DESCRIPTION
When configuring Supervisor program to run with Pipenv, for example:
```ini
[program:bluelog]
command=pipenv run gunicorn -w 4 wsgi:app
directory=/home/greyli/bluelog
user=greyli
```
You will get Click's `RuntimeError` due to the locale issue:
```pytb
supervisor> tail bluelog stderr
n(*args, **kwargs)
  File "/usr/local/lib/python3.5/dist-packages/pipenv/vendor/click/core.py", line 676, in main
    _verify_python3_env()
  File "/usr/local/lib/python3.5/dist-packages/pipenv/vendor/click/_unicodefun.py", line 118, in _verify_python3_env
    'for mitigation steps.' + extra)
RuntimeError: Click will abort further execution because Python 3 was configured to use ASCII as encoding for the environment.  Consult http://click.pocoo.org/python3/for mitigation steps.

This system supports the C.UTF-8 locale which is recommended.
You might be able to resolve your issue by exporting the
following environment variables:

    export LC_ALL=C.UTF-8
    export LANG=C.UTF-8
```

It can be fixed by adding enviroment setting in Supervisor's config file:
```ini
[supervisord]
environment=LC_ALL='en_US.UTF-8',LANG='en_US.UTF-8'
```