### PR TITLE
Fix venv discovery

### DIFF
--- a/pipenv/project.py
+++ b/pipenv/project.py
@@ -216,8 +216,8 @@ class Project(object):
         return bool(self.requirements_location)
 
     def is_venv_in_project(self):
-        return (
-            PIPENV_VENV_IN_PROJECT or
+        return PIPENV_VENV_IN_PROJECT or (
+            self.project_directory and
             os.path.exists(os.path.join(self.project_directory, '.venv'))
         )
 


### PR DESCRIPTION
If we don't have a project, we don't have an associated environment.

Fix #2202.