### PR TITLE
Feature/better resolver

### DIFF
--- a/pipenv/_compat.py
+++ b/pipenv/_compat.py
@@ -29,6 +29,11 @@ except ImportError:
                 _types.add(type(arg))
         return _types.pop()
 
+try:
+    from pathlib import Path
+except ImportError:
+    from pathlib2 import Path
+
 
 try:
     from weakref import finalize
@@ -50,8 +55,6 @@ if six.PY2:
 
     class ResourceWarning(Warning):
         pass
-
-# -*- coding=utf-8 -*-
 
 
 def pip_import(module_path, subimport=None, old_path=None):

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -46,10 +46,12 @@ from .utils import (
     rmtree,
     split_argument,
     extract_uri_from_vcs_dep,
+    fs_str,
 )
 from ._compat import (
     TemporaryDirectory,
-    vcs
+    vcs,
+    Path
 )
 from .import pep508checker, progress
 from .environments import (
@@ -1495,20 +1497,22 @@ def pip_install(
     )
     if verbose:
         click.echo('$ {0}'.format(pip_command), err=True)
+    cache_dir = Path(PIPENV_CACHE_DIR)
     pip_config = {
-        'PIP_CACHE_DIR': PIPENV_CACHE_DIR,
-        'PIP_WHEEL_DIR': os.path.join(PIPENV_CACHE_DIR, 'wheels'),
-        'PIP_DESTINATION_DIR': os.path.join(PIPENV_CACHE_DIR, 'pkgs'),
+        'PIP_CACHE_DIR': fs_str(cache_dir.as_posix()),
+        'PIP_WHEEL_DIR': fs_str(cache_dir.joinpath('wheels').as_posix()),
+        'PIP_DESTINATION_DIR': fs_str(cache_dir.joinpath('pkgs').as_posix()),
     }
     c = delegator.run(pip_command, block=block, env=pip_config)
     return c
 
 
 def pip_download(package_name):
+    cache_dir = Path(PIPENV_CACHE_DIR)    
     pip_config = {
-        'PIP_CACHE_DIR': PIPENV_CACHE_DIR,
-        'PIP_WHEEL_DIR': os.path.join(PIPENV_CACHE_DIR, 'wheels'),
-        'PIP_DESTINATION_DIR': os.path.join(PIPENV_CACHE_DIR, 'pkgs'),
+        'PIP_CACHE_DIR': fs_str(cache_dir.as_posix()),
+        'PIP_WHEEL_DIR': fs_str(cache_dir.joinpath('wheels').as_posix()),
+        'PIP_DESTINATION_DIR': fs_str(cache_dir.joinpath('pkgs').as_posix()),
     }
     for source in project.sources:
         cmd = '{0} download "{1}" -i {2} -d {3}'.format(

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -1505,6 +1505,11 @@ def pip_install(
 
 
 def pip_download(package_name):
+    pip_config = {
+        'PIP_CACHE_DIR': PIPENV_CACHE_DIR,
+        'PIP_WHEEL_DIR': os.path.join(PIPENV_CACHE_DIR, 'wheels'),
+        'PIP_DESTINATION_DIR': os.path.join(PIPENV_CACHE_DIR, 'pkgs'),
+    }
     for source in project.sources:
         cmd = '{0} download "{1}" -i {2} -d {3}'.format(
             escape_grouped_arguments(which_pip()),
@@ -1512,7 +1517,7 @@ def pip_download(package_name):
             source['url'],
             project.download_location,
         )
-        c = delegator.run(cmd, env={'PIP_CACHE_DIR': PIPENV_CACHE_DIR})
+        c = delegator.run(cmd, env=pip_config)
         if c.return_code == 0:
             break
 

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -1482,7 +1482,7 @@ def pip_install(
     pre = '--pre' if pre else ''
     quoted_pip = which_pip(allow_global=allow_global)
     quoted_pip = escape_grouped_arguments(quoted_pip)
-    upgrade_strategy = '--upgrade --upgrade-strategy=only-if-needed' if selective_upgrade else ''
+    upgrade_strategy = '--upgrade --upgrade-strategy=to-satisfy-only' if selective_upgrade else ''
     pip_command = '{0} install {4} {5} {6} {7} {3} {1} {2} --exists-action w'.format(
         quoted_pip,
         install_reqs,
@@ -1495,7 +1495,12 @@ def pip_install(
     )
     if verbose:
         click.echo('$ {0}'.format(pip_command), err=True)
-    c = delegator.run(pip_command, block=block, env={'PIP_CACHE_DIR': PIPENV_CACHE_DIR})
+    pip_config = {
+        'PIP_CACHE_DIR': PIPENV_CACHE_DIR,
+        'PIP_WHEEL_DIR': os.path.join(PIPENV_CACHE_DIR, 'wheels'),
+        'PIP_DESTINATION_DIR': os.path.join(PIPENV_CACHE_DIR, 'pkgs'),
+    }
+    c = delegator.run(pip_command, block=block, env=pip_config)
     return c
 
 

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -73,6 +73,7 @@ from .environments import (
     PIPENV_SHELL,
     PIPENV_PYTHON,
     PIPENV_VIRTUALENV,
+    PIPENV_CACHE_DIR,
 )
 
 # Backport required for earlier versions of Python.
@@ -1494,7 +1495,7 @@ def pip_install(
     )
     if verbose:
         click.echo('$ {0}'.format(pip_command), err=True)
-    c = delegator.run(pip_command, block=block)
+    c = delegator.run(pip_command, block=block, env={'PIP_CACHE_DIR': PIPENV_CACHE_DIR})
     return c
 
 
@@ -1506,7 +1507,7 @@ def pip_download(package_name):
             source['url'],
             project.download_location,
         )
-        c = delegator.run(cmd)
+        c = delegator.run(cmd, env={'PIP_CACHE_DIR': PIPENV_CACHE_DIR})
         if c.return_code == 0:
             break
 

--- a/pipenv/patched/piptools/repositories/pypi.py
+++ b/pipenv/patched/piptools/repositories/pypi.py
@@ -266,6 +266,9 @@ class PyPIRepository(BaseRepository):
                     setup_requires = self.finder.get_extras_links(
                         dist.get_metadata_lines('requires.txt')
                     )
+                # HACK: Sometimes the InstallRequirement doesn't properly get
+                # these values set on it during the resolution process. It's
+                # difficult to pin down what is going wrong. This fixes things.
                 ireq.version = dist.version
                 ireq.project_name = dist.project_name
                 ireq.req = dist.as_requirement()

--- a/pipenv/patched/piptools/repositories/pypi.py
+++ b/pipenv/patched/piptools/repositories/pypi.py
@@ -164,10 +164,12 @@ class PyPIRepository(BaseRepository):
             return ireq  # return itself as the best match
 
         py_version = parse_version(os.environ.get('PIP_PYTHON_VERSION', str(sys.version_info[:3])))
-        all_candidates = [
-            c for c in self.find_all_candidates(ireq.name)
-            if SpecifierSet(c.requires_python).contains(py_version)
-        ]
+        all_candidates = []
+        for c in self.find_all_candidates(ireq.name):
+            python_specifier = SpecifierSet(c.requires_python)
+            if not python_specifier.contains(py_version):
+                continue
+            all_candidates.append(c)
 
         candidates_by_version = lookup_table(all_candidates, key=lambda c: c.version, unique=True)
         try:

--- a/pipenv/patched/piptools/repositories/pypi.py
+++ b/pipenv/patched/piptools/repositories/pypi.py
@@ -166,8 +166,7 @@ class PyPIRepository(BaseRepository):
         py_version = parse_version(os.environ.get('PIP_PYTHON_VERSION', str(sys.version_info[:3])))
         all_candidates = []
         for c in self.find_all_candidates(ireq.name):
-            python_specifier = SpecifierSet(c.requires_python)
-            if c.requires_python and not python_specifier.contains(py_version):
+            if c.requires_python and not SpecifierSet(c.requires_python).contains(py_version):
                 continue
             all_candidates.append(c)
 

--- a/pipenv/patched/piptools/repositories/pypi.py
+++ b/pipenv/patched/piptools/repositories/pypi.py
@@ -167,7 +167,7 @@ class PyPIRepository(BaseRepository):
         all_candidates = []
         for c in self.find_all_candidates(ireq.name):
             python_specifier = SpecifierSet(c.requires_python)
-            if not python_specifier.contains(py_version):
+            if c.requires_python and not python_specifier.contains(py_version):
                 continue
             all_candidates.append(c)
 

--- a/pipenv/project.py
+++ b/pipenv/project.py
@@ -20,7 +20,7 @@ except ImportError:
     from pathlib2 import Path
 
 from .cmdparse import Script
-from .vendor.requirementslib import Requirement
+from .vendor.requirementslib.requirements import Requirement
 from .utils import (
     atomic_open_for_write,
     mkdir_p,
@@ -728,8 +728,8 @@ class Project(object):
         # Read and append Pipfile.
         p = self.parsed_pipfile
         # Don't re-capitalize file URLs or VCSs.
-        package = Requirement.from_line(package_name)
-        converted = first(package.as_pipfile().values())
+        package = Requirement.from_line(package_name.strip())
+        _, converted = package.pipfile_entry
         key = 'dev-packages' if dev else 'packages'
         # Set empty group if it doesn't exist yet.
         if key not in p:

--- a/pipenv/utils.py
+++ b/pipenv/utils.py
@@ -253,7 +253,7 @@ def actually_resolve_reps(
             if url:
                 index_lookup[req.name] = project.get_source(url=url).get('name')
             if req.markers:
-                markers_lookup[req.name] = req.markers_as_pip
+                markers_lookup[req.name] = req.markers.replace('"', "'")
     constraints_file = None
     pip_command = get_pip_command()
     pip_args = []

--- a/pipenv/utils.py
+++ b/pipenv/utils.py
@@ -264,6 +264,7 @@ def actually_resolve_reps(
         constraints_file = f.name
     if verbose:
         print('Using pip: {0}'.format(' '.join(pip_args)))
+    pip_args = pip_args.extend(['--cache-dir', PIPENV_CACHE_DIR])
     pip_options, _ = pip_command.parse_args(pip_args)
     session = pip_command._build_session(pip_options)
     pypi = PyPIRepository(

--- a/pipenv/utils.py
+++ b/pipenv/utils.py
@@ -1189,10 +1189,9 @@ def get_vcs_deps(
             lockfiles.append({pipfile_name: installed.pipfile_entry[1]})
         pipfile_srcdir = escape_grouped_arguments((src_dir / pipfile_name).as_posix())
         lockfile_srcdir = escape_grouped_arguments(
-            (src_dir / installed.normalized_name).as_posix()
-        )
+            (src_dir / installed.normalized_name))
         lines.append(line)
-        if pipfile_srcdir.exists():
+        if os.path.exists(pipfile_srcdir):
             lockfiles.extend(
                 venv_resolve_deps(
                     ["-e {0}".format(pipfile_srcdir)],
@@ -1217,3 +1216,17 @@ def get_vcs_deps(
                 )
             )
     return lines, lockfiles
+
+
+def fs_str(string):
+    """Encodes a string into the proper filesystem encoding
+
+    Borrowed from pip-tools
+    """
+    if isinstance(string, str):
+        return string
+    assert not isinstance(string, bytes)
+    return string.encode(_fs_encoding)
+
+
+_fs_encoding = sys.getfilesystemencoding() or sys.getdefaultencoding()

--- a/pipenv/utils.py
+++ b/pipenv/utils.py
@@ -261,7 +261,7 @@ def actually_resolve_reps(
     with NamedTemporaryFile(mode='w', prefix='pipenv-', suffix='-constraints.txt', dir=req_dir.name, delete=False) as f:
         if sources:
             requirementstxt_sources = ' '.join(pip_args).replace(' --', '\n--')
-            f.write('{0}\n'.format(requirementstxt_sources))
+            f.write(u'{0}\n'.format(requirementstxt_sources))
         f.write(u'\n'.join([_constraint for _constraint in constraints]))
         constraints_file = f.name
     if verbose:

--- a/pipenv/utils.py
+++ b/pipenv/utils.py
@@ -247,8 +247,13 @@ def actually_resolve_reps(
         if ' -i ' in dep:
             dep, url = dep.split(' -i ')
         req = Requirement.from_line(dep)
+
+        # req.as_line() is theoratically the same as dep, but is guarenteed to
+        # be normalized. This is safer than passing in dep.
+        # TODO: Stop passing dep lines around; just use requirement objects.
         constraints.append(req.as_line())
         # extra_constraints = []
+
         if url:
             index_lookup[req.name] = project.get_source(url=url).get('name')
         if req.markers:

--- a/pipenv/utils.py
+++ b/pipenv/utils.py
@@ -260,6 +260,9 @@ def actually_resolve_reps(
     if sources:
         pip_args = prepare_pip_source_args(sources, pip_args)
     with NamedTemporaryFile(mode='w', prefix='pipenv-', suffix='-constraints.txt', dir=req_dir.name, delete=False) as f:
+        if sources:
+            requirementstxt_sources = ' '.join(pip_args).replace(' --', '\n--')
+            f.write('{0}\n'.format(requirementstxt_sources))
         f.write(u'\n'.join([_constraint for _constraint in constraints]))
         constraints_file = f.name
     if verbose:

--- a/pipenv/utils.py
+++ b/pipenv/utils.py
@@ -1187,10 +1187,8 @@ def get_vcs_deps(
         if installed.is_vcs:
             installed.req.ref = locked_rev
             lockfiles.append({pipfile_name: installed.pipfile_entry[1]})
-        pipfile_srcdir = escape_grouped_arguments((src_dir / pipfile_name).as_posix())
-        lockfile_srcdir = escape_grouped_arguments(
-            (src_dir / installed.normalized_name).as_posix()
-        )
+        pipfile_srcdir = (src_dir / pipfile_name).as_posix()
+        lockfile_srcdir = (src_dir / installed.normalized_name).as_posix()
         lines.append(line)
         if os.path.exists(pipfile_srcdir):
             lockfiles.extend(

--- a/pipenv/utils.py
+++ b/pipenv/utils.py
@@ -1189,7 +1189,8 @@ def get_vcs_deps(
             lockfiles.append({pipfile_name: installed.pipfile_entry[1]})
         pipfile_srcdir = escape_grouped_arguments((src_dir / pipfile_name).as_posix())
         lockfile_srcdir = escape_grouped_arguments(
-            (src_dir / installed.normalized_name))
+            (src_dir / installed.normalized_name).as_posix()
+        )
         lines.append(line)
         if os.path.exists(pipfile_srcdir):
             lockfiles.extend(

--- a/tasks/vendoring/__init__.py
+++ b/tasks/vendoring/__init__.py
@@ -468,7 +468,10 @@ def generate_patch(ctx, package_path, patch_description, base='HEAD'):
     pkg = Path(package_path)
     if len(pkg.parts) != 2 or pkg.parts[0] not in ('vendor', 'patched'):
         raise ValueError('example usage: generate-patch patched/pew some-description')
-    patch_fn = '{0}-{1}.patch'.format(pkg.parts[1], patch_description)
+    if patch_description:
+        patch_fn = '{0}-{1}.patch'.format(pkg.parts[1], patch_description)
+    else:
+        patch_fn = '{0}.patch'.format(pkg.parts[1])
     command = 'git diff {base} -p {root} > {out}'.format(
         base=base,
         root=Path('pipenv').joinpath(pkg),

--- a/tasks/vendoring/patches/patched/piptools.patch
+++ b/tasks/vendoring/patches/patched/piptools.patch
@@ -19,10 +19,18 @@ index 4e6174c..75f9b49 100644
  # NOTE
  # We used to store the cache dir under ~/.pip-tools, which is not the
 diff --git a/pipenv/patched/piptools/repositories/pypi.py b/pipenv/patched/piptools/repositories/pypi.py
-index 1c4b943..8320e14 100644
+index 1c4b943..858d697 100644
 --- a/pipenv/patched/piptools/repositories/pypi.py
 +++ b/pipenv/patched/piptools/repositories/pypi.py
-@@ -15,10 +15,16 @@ from .._compat import (
+@@ -4,6 +4,7 @@ from __future__ import (absolute_import, division, print_function,
+ 
+ import hashlib
+ import os
++import sys
+ from contextlib import contextmanager
+ from shutil import rmtree
+ 
+@@ -15,13 +16,22 @@ from .._compat import (
      Wheel,
      FAVORITE_HASH,
      TemporaryDirectory,
@@ -32,15 +40,23 @@ index 1c4b943..8320e14 100644
 +    SafeFileCache,
  )
  
-+from pip._vendor.packaging.requirements import InvalidRequirement
++from pip._vendor.packaging.requirements import InvalidRequirement, Requirement
++from pip._vendor.packaging.version import Version, InvalidVersion, parse as parse_version
++from pip._vendor.packaging.specifiers import SpecifierSet
 +from pip._vendor.pyparsing import ParseException
 +
  from ..cache import CACHE_DIR
 +from pipenv.environments import PIPENV_CACHE_DIR
  from ..exceptions import NoCandidateFound
- from ..utils import (fs_str, is_pinned_requirement, lookup_table,
-                      make_install_requirement)
-@@ -37,6 +43,40 @@ except ImportError:
+-from ..utils import (fs_str, is_pinned_requirement, lookup_table,
+-                     make_install_requirement)
++from ..utils import (fs_str, is_pinned_requirement, lookup_table, as_tuple, key_from_req,
++                     make_install_requirement, format_requirement, dedup)
++
+ from .base import BaseRepository
+ 
+ 
+@@ -37,6 +47,40 @@ except ImportError:
      from pip.wheel import WheelCache
  
  
@@ -81,7 +97,7 @@ index 1c4b943..8320e14 100644
  class PyPIRepository(BaseRepository):
      DEFAULT_INDEX_URL = PyPI.simple_url
  
-@@ -46,10 +86,11 @@ class PyPIRepository(BaseRepository):
+@@ -46,10 +90,11 @@ class PyPIRepository(BaseRepository):
      config), but any other PyPI mirror can be used if index_urls is
      changed/configured on the Finder.
      """
@@ -95,7 +111,7 @@ index 1c4b943..8320e14 100644
  
          index_urls = [pip_options.index_url] + pip_options.extra_index_urls
          if pip_options.no_index:
-@@ -74,11 +115,15 @@ class PyPIRepository(BaseRepository):
+@@ -74,11 +119,15 @@ class PyPIRepository(BaseRepository):
          # of all secondary dependencies for the given requirement, so we
          # only have to go to disk once for each requirement
          self._dependencies_cache = {}
@@ -113,9 +129,20 @@ index 1c4b943..8320e14 100644
  
      def freshen_build_caches(self):
          """
-@@ -116,8 +161,11 @@ class PyPIRepository(BaseRepository):
+@@ -114,10 +163,21 @@ class PyPIRepository(BaseRepository):
+         if ireq.editable:
+             return ireq  # return itself as the best match
  
-         all_candidates = self.find_all_candidates(ireq.name)
+-        all_candidates = self.find_all_candidates(ireq.name)
++        _all_candidates = self.find_all_candidates(ireq.name)
++        all_candidates = []
++        py_version = parse_version(os.environ.get('PIP_PYTHON_VERSION', str(sys.version_info[:3])))
++        for c in _all_candidates:
++            if c.requires_python:
++                python_specifier = SpecifierSet(c.requires_python)
++                if not python_specifier.contains(py_version):
++                    continue
++            all_candidates.append(c)
          candidates_by_version = lookup_table(all_candidates, key=lambda c: c.version, unique=True)
 -        matching_versions = ireq.specifier.filter((candidate.version for candidate in all_candidates),
 +        try:
@@ -126,7 +153,7 @@ index 1c4b943..8320e14 100644
  
          # Reuses pip's internal candidate sort key to sort
          matching_candidates = [candidates_by_version[ver] for ver in matching_versions]
-@@ -126,11 +174,60 @@ class PyPIRepository(BaseRepository):
+@@ -126,11 +186,61 @@ class PyPIRepository(BaseRepository):
          best_candidate = max(matching_candidates, key=self.finder._candidate_sort_key)
  
          # Turn the candidate into a pinned InstallRequirement
@@ -153,11 +180,12 @@ index 1c4b943..8320e14 100644
 +                r = self.session.get(url)
 +
 +                # TODO: Latest isn't always latest.
-+                latest = list(r.json()['releases'].keys())[-1]
-+                if str(ireq.req.specifier) == '=={0}'.format(latest):
-+                    latest_url = 'https://pypi.org/pypi/{0}/{1}/json'.format(ireq.req.name, latest)
-+                    latest_requires = self.session.get(latest_url)
-+                    for requires in latest_requires.json().get('info', {}).get('requires_dist', {}):
++                releases = list(r.json()['releases'].keys())
++                match = [r for r in releases if '=={0}'.format(r) == str(ireq.req.specifier)]
++                if match:
++                    release_url = 'https://pypi.org/pypi/{0}/{1}/json'.format(ireq.req.name, match[0])
++                    release_requires = self.session.get(release_url)
++                    for requires in release_requires.json().get('info', {}).get('requires_dist', {}):
 +                        i = InstallRequirement.from_line(requires)
 +
 +                        if 'extra' not in repr(i.markers):
@@ -190,7 +218,7 @@ index 1c4b943..8320e14 100644
          """
          Given a pinned or an editable InstallRequirement, returns a set of
          dependencies (also InstallRequirements, but not necessarily pinned).
-@@ -139,6 +236,18 @@ class PyPIRepository(BaseRepository):
+@@ -139,6 +249,21 @@ class PyPIRepository(BaseRepository):
          if not (ireq.editable or is_pinned_requirement(ireq)):
              raise TypeError('Expected pinned or editable InstallRequirement, got {}'.format(ireq))
  
@@ -203,13 +231,16 @@ index 1c4b943..8320e14 100644
 +                    setup_requires = self.finder.get_extras_links(
 +                        dist.get_metadata_lines('requires.txt')
 +                    )
-+            except TypeError:
++                ireq.version = dist.version
++                ireq.project_name = dist.project_name
++                ireq.req = dist.as_requirement()
++            except (TypeError, ValueError):
 +                pass
 +
          if ireq not in self._dependencies_cache:
              if ireq.editable and (ireq.source_dir and os.path.exists(ireq.source_dir)):
                  # No download_dir for locally available editable requirements.
-@@ -164,11 +273,14 @@ class PyPIRepository(BaseRepository):
+@@ -164,11 +289,14 @@ class PyPIRepository(BaseRepository):
                      download_dir=download_dir,
                      wheel_download_dir=self._wheel_download_dir,
                      session=self.session,
@@ -226,7 +257,7 @@ index 1c4b943..8320e14 100644
                  )
              except TypeError:
                  # Pip >= 10 (new resolver!)
-@@ -190,14 +302,44 @@ class PyPIRepository(BaseRepository):
+@@ -190,14 +318,44 @@ class PyPIRepository(BaseRepository):
                      upgrade_strategy="to-satisfy-only",
                      force_reinstall=False,
                      ignore_dependencies=False,
@@ -273,7 +304,7 @@ index 1c4b943..8320e14 100644
              reqset.cleanup_files()
          return set(self._dependencies_cache[ireq])
  
-@@ -224,17 +366,10 @@ class PyPIRepository(BaseRepository):
+@@ -224,17 +382,10 @@ class PyPIRepository(BaseRepository):
          matching_candidates = candidates_by_version[matching_versions[0]]
  
          return {

--- a/tasks/vendoring/patches/patched/piptools.patch
+++ b/tasks/vendoring/patches/patched/piptools.patch
@@ -19,7 +19,7 @@ index 4e6174c..75f9b49 100644
  # NOTE
  # We used to store the cache dir under ~/.pip-tools, which is not the
 diff --git a/pipenv/patched/piptools/repositories/pypi.py b/pipenv/patched/piptools/repositories/pypi.py
-index 1c4b943..1ffbf1d 100644
+index 1c4b943..a15c23b 100644
 --- a/pipenv/patched/piptools/repositories/pypi.py
 +++ b/pipenv/patched/piptools/repositories/pypi.py
 @@ -4,6 +4,7 @@ from __future__ import (absolute_import, division, print_function,
@@ -129,16 +129,18 @@ index 1c4b943..1ffbf1d 100644
  
      def freshen_build_caches(self):
          """
-@@ -114,10 +163,18 @@ class PyPIRepository(BaseRepository):
+@@ -114,10 +163,20 @@ class PyPIRepository(BaseRepository):
          if ireq.editable:
              return ireq  # return itself as the best match
  
 -        all_candidates = self.find_all_candidates(ireq.name)
 +        py_version = parse_version(os.environ.get('PIP_PYTHON_VERSION', str(sys.version_info[:3])))
-+        all_candidates = [
-+            c for c in self.find_all_candidates(ireq.name)
-+            if SpecifierSet(c.requires_python).contains(py_version)
-+        ]
++        all_candidates = []
++        for c in self.find_all_candidates(ireq.name):
++            python_specifier = SpecifierSet(c.requires_python)
++            if not python_specifier.contains(py_version):
++                continue
++            all_candidates.append(c)
 +
          candidates_by_version = lookup_table(all_candidates, key=lambda c: c.version, unique=True)
 -        matching_versions = ireq.specifier.filter((candidate.version for candidate in all_candidates),
@@ -150,7 +152,7 @@ index 1c4b943..1ffbf1d 100644
  
          # Reuses pip's internal candidate sort key to sort
          matching_candidates = [candidates_by_version[ver] for ver in matching_versions]
-@@ -126,11 +183,71 @@ class PyPIRepository(BaseRepository):
+@@ -126,11 +185,71 @@ class PyPIRepository(BaseRepository):
          best_candidate = max(matching_candidates, key=self.finder._candidate_sort_key)
  
          # Turn the candidate into a pinned InstallRequirement
@@ -225,7 +227,7 @@ index 1c4b943..1ffbf1d 100644
          """
          Given a pinned or an editable InstallRequirement, returns a set of
          dependencies (also InstallRequirements, but not necessarily pinned).
-@@ -139,6 +256,21 @@ class PyPIRepository(BaseRepository):
+@@ -139,6 +258,21 @@ class PyPIRepository(BaseRepository):
          if not (ireq.editable or is_pinned_requirement(ireq)):
              raise TypeError('Expected pinned or editable InstallRequirement, got {}'.format(ireq))
  
@@ -247,7 +249,7 @@ index 1c4b943..1ffbf1d 100644
          if ireq not in self._dependencies_cache:
              if ireq.editable and (ireq.source_dir and os.path.exists(ireq.source_dir)):
                  # No download_dir for locally available editable requirements.
-@@ -164,11 +296,14 @@ class PyPIRepository(BaseRepository):
+@@ -164,11 +298,14 @@ class PyPIRepository(BaseRepository):
                      download_dir=download_dir,
                      wheel_download_dir=self._wheel_download_dir,
                      session=self.session,
@@ -264,7 +266,7 @@ index 1c4b943..1ffbf1d 100644
                  )
              except TypeError:
                  # Pip >= 10 (new resolver!)
-@@ -190,14 +325,44 @@ class PyPIRepository(BaseRepository):
+@@ -190,14 +327,44 @@ class PyPIRepository(BaseRepository):
                      upgrade_strategy="to-satisfy-only",
                      force_reinstall=False,
                      ignore_dependencies=False,
@@ -311,7 +313,7 @@ index 1c4b943..1ffbf1d 100644
              reqset.cleanup_files()
          return set(self._dependencies_cache[ireq])
  
-@@ -224,17 +389,10 @@ class PyPIRepository(BaseRepository):
+@@ -224,17 +391,10 @@ class PyPIRepository(BaseRepository):
          matching_candidates = candidates_by_version[matching_versions[0]]
  
          return {

--- a/tasks/vendoring/patches/patched/piptools.patch
+++ b/tasks/vendoring/patches/patched/piptools.patch
@@ -19,7 +19,7 @@ index 4e6174c..75f9b49 100644
  # NOTE
  # We used to store the cache dir under ~/.pip-tools, which is not the
 diff --git a/pipenv/patched/piptools/repositories/pypi.py b/pipenv/patched/piptools/repositories/pypi.py
-index 1c4b943..a15c23b 100644
+index 1c4b943..29e771e 100644
 --- a/pipenv/patched/piptools/repositories/pypi.py
 +++ b/pipenv/patched/piptools/repositories/pypi.py
 @@ -4,6 +4,7 @@ from __future__ import (absolute_import, division, print_function,
@@ -129,7 +129,7 @@ index 1c4b943..a15c23b 100644
  
      def freshen_build_caches(self):
          """
-@@ -114,10 +163,20 @@ class PyPIRepository(BaseRepository):
+@@ -114,10 +163,19 @@ class PyPIRepository(BaseRepository):
          if ireq.editable:
              return ireq  # return itself as the best match
  
@@ -137,8 +137,7 @@ index 1c4b943..a15c23b 100644
 +        py_version = parse_version(os.environ.get('PIP_PYTHON_VERSION', str(sys.version_info[:3])))
 +        all_candidates = []
 +        for c in self.find_all_candidates(ireq.name):
-+            python_specifier = SpecifierSet(c.requires_python)
-+            if c.requires_python and not python_specifier.contains(py_version):
++            if c.requires_python and not SpecifierSet(c.requires_python).contains(py_version):
 +                continue
 +            all_candidates.append(c)
 +
@@ -152,7 +151,7 @@ index 1c4b943..a15c23b 100644
  
          # Reuses pip's internal candidate sort key to sort
          matching_candidates = [candidates_by_version[ver] for ver in matching_versions]
-@@ -126,11 +185,71 @@ class PyPIRepository(BaseRepository):
+@@ -126,11 +184,71 @@ class PyPIRepository(BaseRepository):
          best_candidate = max(matching_candidates, key=self.finder._candidate_sort_key)
  
          # Turn the candidate into a pinned InstallRequirement
@@ -227,7 +226,7 @@ index 1c4b943..a15c23b 100644
          """
          Given a pinned or an editable InstallRequirement, returns a set of
          dependencies (also InstallRequirements, but not necessarily pinned).
-@@ -139,6 +258,21 @@ class PyPIRepository(BaseRepository):
+@@ -139,6 +257,21 @@ class PyPIRepository(BaseRepository):
          if not (ireq.editable or is_pinned_requirement(ireq)):
              raise TypeError('Expected pinned or editable InstallRequirement, got {}'.format(ireq))
  
@@ -249,7 +248,7 @@ index 1c4b943..a15c23b 100644
          if ireq not in self._dependencies_cache:
              if ireq.editable and (ireq.source_dir and os.path.exists(ireq.source_dir)):
                  # No download_dir for locally available editable requirements.
-@@ -164,11 +298,14 @@ class PyPIRepository(BaseRepository):
+@@ -164,11 +297,14 @@ class PyPIRepository(BaseRepository):
                      download_dir=download_dir,
                      wheel_download_dir=self._wheel_download_dir,
                      session=self.session,
@@ -266,7 +265,7 @@ index 1c4b943..a15c23b 100644
                  )
              except TypeError:
                  # Pip >= 10 (new resolver!)
-@@ -190,14 +327,44 @@ class PyPIRepository(BaseRepository):
+@@ -190,14 +326,44 @@ class PyPIRepository(BaseRepository):
                      upgrade_strategy="to-satisfy-only",
                      force_reinstall=False,
                      ignore_dependencies=False,
@@ -313,7 +312,7 @@ index 1c4b943..a15c23b 100644
              reqset.cleanup_files()
          return set(self._dependencies_cache[ireq])
  
-@@ -224,17 +391,10 @@ class PyPIRepository(BaseRepository):
+@@ -224,17 +390,10 @@ class PyPIRepository(BaseRepository):
          matching_candidates = candidates_by_version[matching_versions[0]]
  
          return {

--- a/tasks/vendoring/patches/patched/piptools.patch
+++ b/tasks/vendoring/patches/patched/piptools.patch
@@ -138,7 +138,7 @@ index 1c4b943..a15c23b 100644
 +        all_candidates = []
 +        for c in self.find_all_candidates(ireq.name):
 +            python_specifier = SpecifierSet(c.requires_python)
-+            if not python_specifier.contains(py_version):
++            if c.requires_python and not python_specifier.contains(py_version):
 +                continue
 +            all_candidates.append(c)
 +

--- a/tasks/vendoring/patches/patched/piptools.patch
+++ b/tasks/vendoring/patches/patched/piptools.patch
@@ -19,7 +19,7 @@ index 4e6174c..75f9b49 100644
  # NOTE
  # We used to store the cache dir under ~/.pip-tools, which is not the
 diff --git a/pipenv/patched/piptools/repositories/pypi.py b/pipenv/patched/piptools/repositories/pypi.py
-index 1c4b943..29e771e 100644
+index 1c4b943..aae0122 100644
 --- a/pipenv/patched/piptools/repositories/pypi.py
 +++ b/pipenv/patched/piptools/repositories/pypi.py
 @@ -4,6 +4,7 @@ from __future__ import (absolute_import, division, print_function,
@@ -226,7 +226,7 @@ index 1c4b943..29e771e 100644
          """
          Given a pinned or an editable InstallRequirement, returns a set of
          dependencies (also InstallRequirements, but not necessarily pinned).
-@@ -139,6 +257,21 @@ class PyPIRepository(BaseRepository):
+@@ -139,6 +257,24 @@ class PyPIRepository(BaseRepository):
          if not (ireq.editable or is_pinned_requirement(ireq)):
              raise TypeError('Expected pinned or editable InstallRequirement, got {}'.format(ireq))
  
@@ -239,6 +239,9 @@ index 1c4b943..29e771e 100644
 +                    setup_requires = self.finder.get_extras_links(
 +                        dist.get_metadata_lines('requires.txt')
 +                    )
++                # HACK: Sometimes the InstallRequirement doesn't properly get
++                # these values set on it during the resolution process. It's
++                # difficult to pin down what is going wrong. This fixes things.
 +                ireq.version = dist.version
 +                ireq.project_name = dist.project_name
 +                ireq.req = dist.as_requirement()
@@ -248,7 +251,7 @@ index 1c4b943..29e771e 100644
          if ireq not in self._dependencies_cache:
              if ireq.editable and (ireq.source_dir and os.path.exists(ireq.source_dir)):
                  # No download_dir for locally available editable requirements.
-@@ -164,11 +297,14 @@ class PyPIRepository(BaseRepository):
+@@ -164,11 +300,14 @@ class PyPIRepository(BaseRepository):
                      download_dir=download_dir,
                      wheel_download_dir=self._wheel_download_dir,
                      session=self.session,
@@ -265,7 +268,7 @@ index 1c4b943..29e771e 100644
                  )
              except TypeError:
                  # Pip >= 10 (new resolver!)
-@@ -190,14 +326,44 @@ class PyPIRepository(BaseRepository):
+@@ -190,14 +329,44 @@ class PyPIRepository(BaseRepository):
                      upgrade_strategy="to-satisfy-only",
                      force_reinstall=False,
                      ignore_dependencies=False,
@@ -312,7 +315,7 @@ index 1c4b943..29e771e 100644
              reqset.cleanup_files()
          return set(self._dependencies_cache[ireq])
  
-@@ -224,17 +390,10 @@ class PyPIRepository(BaseRepository):
+@@ -224,17 +393,10 @@ class PyPIRepository(BaseRepository):
          matching_candidates = candidates_by_version[matching_versions[0]]
  
          return {

--- a/tasks/vendoring/patches/patched/piptools.patch
+++ b/tasks/vendoring/patches/patched/piptools.patch
@@ -19,7 +19,7 @@ index 4e6174c..75f9b49 100644
  # NOTE
  # We used to store the cache dir under ~/.pip-tools, which is not the
 diff --git a/pipenv/patched/piptools/repositories/pypi.py b/pipenv/patched/piptools/repositories/pypi.py
-index 1c4b943..858d697 100644
+index 1c4b943..1ffbf1d 100644
 --- a/pipenv/patched/piptools/repositories/pypi.py
 +++ b/pipenv/patched/piptools/repositories/pypi.py
 @@ -4,6 +4,7 @@ from __future__ import (absolute_import, division, print_function,
@@ -129,20 +129,17 @@ index 1c4b943..858d697 100644
  
      def freshen_build_caches(self):
          """
-@@ -114,10 +163,21 @@ class PyPIRepository(BaseRepository):
+@@ -114,10 +163,18 @@ class PyPIRepository(BaseRepository):
          if ireq.editable:
              return ireq  # return itself as the best match
  
 -        all_candidates = self.find_all_candidates(ireq.name)
-+        _all_candidates = self.find_all_candidates(ireq.name)
-+        all_candidates = []
 +        py_version = parse_version(os.environ.get('PIP_PYTHON_VERSION', str(sys.version_info[:3])))
-+        for c in _all_candidates:
-+            if c.requires_python:
-+                python_specifier = SpecifierSet(c.requires_python)
-+                if not python_specifier.contains(py_version):
-+                    continue
-+            all_candidates.append(c)
++        all_candidates = [
++            c for c in self.find_all_candidates(ireq.name)
++            if SpecifierSet(c.requires_python).contains(py_version)
++        ]
++
          candidates_by_version = lookup_table(all_candidates, key=lambda c: c.version, unique=True)
 -        matching_versions = ireq.specifier.filter((candidate.version for candidate in all_candidates),
 +        try:
@@ -153,7 +150,7 @@ index 1c4b943..858d697 100644
  
          # Reuses pip's internal candidate sort key to sort
          matching_candidates = [candidates_by_version[ver] for ver in matching_versions]
-@@ -126,11 +186,61 @@ class PyPIRepository(BaseRepository):
+@@ -126,11 +183,71 @@ class PyPIRepository(BaseRepository):
          best_candidate = max(matching_candidates, key=self.finder._candidate_sort_key)
  
          # Turn the candidate into a pinned InstallRequirement
@@ -174,22 +171,33 @@ index 1c4b943..858d697 100644
 +            raise TypeError('Expected pinned InstallRequirement, got {}'.format(ireq))
 +
 +        def gen(ireq):
-+            if self.DEFAULT_INDEX_URL in self.finder.index_urls:
++            if self.DEFAULT_INDEX_URL not in self.finder.index_urls:
++                return
 +
-+                url = 'https://pypi.org/pypi/{0}/json'.format(ireq.req.name)
-+                r = self.session.get(url)
++            url = 'https://pypi.org/pypi/{0}/json'.format(ireq.req.name)
++            releases = self.session.get(url).json()['releases']
 +
-+                # TODO: Latest isn't always latest.
-+                releases = list(r.json()['releases'].keys())
-+                match = [r for r in releases if '=={0}'.format(r) == str(ireq.req.specifier)]
-+                if match:
-+                    release_url = 'https://pypi.org/pypi/{0}/{1}/json'.format(ireq.req.name, match[0])
-+                    release_requires = self.session.get(release_url)
-+                    for requires in release_requires.json().get('info', {}).get('requires_dist', {}):
-+                        i = InstallRequirement.from_line(requires)
++            matches = [
++                r for r in releases
++                if '=={0}'.format(r) == str(ireq.req.specifier)
++            ]
++            if not matches:
++                return
 +
-+                        if 'extra' not in repr(i.markers):
-+                            yield i
++            release_requires = self.session.get(
++                'https://pypi.org/pypi/{0}/{1}/json'.format(
++                    ireq.req.name, matches[0],
++                ),
++            ).json()
++            try:
++                requires_dist = release_requires['info']['requires_dist']
++            except KeyError:
++                return
++
++            for requires in requires_dist:
++                i = InstallRequirement.from_line(requires)
++                if 'extra' not in repr(i.markers):
++                    yield i
 +
 +        try:
 +            if ireq not in self._json_dep_cache:
@@ -213,12 +221,11 @@ index 1c4b943..858d697 100644
 +
 +        return json_results
 +
-+
 +    def get_legacy_dependencies(self, ireq):
          """
          Given a pinned or an editable InstallRequirement, returns a set of
          dependencies (also InstallRequirements, but not necessarily pinned).
-@@ -139,6 +249,21 @@ class PyPIRepository(BaseRepository):
+@@ -139,6 +256,21 @@ class PyPIRepository(BaseRepository):
          if not (ireq.editable or is_pinned_requirement(ireq)):
              raise TypeError('Expected pinned or editable InstallRequirement, got {}'.format(ireq))
  
@@ -240,7 +247,7 @@ index 1c4b943..858d697 100644
          if ireq not in self._dependencies_cache:
              if ireq.editable and (ireq.source_dir and os.path.exists(ireq.source_dir)):
                  # No download_dir for locally available editable requirements.
-@@ -164,11 +289,14 @@ class PyPIRepository(BaseRepository):
+@@ -164,11 +296,14 @@ class PyPIRepository(BaseRepository):
                      download_dir=download_dir,
                      wheel_download_dir=self._wheel_download_dir,
                      session=self.session,
@@ -257,7 +264,7 @@ index 1c4b943..858d697 100644
                  )
              except TypeError:
                  # Pip >= 10 (new resolver!)
-@@ -190,14 +318,44 @@ class PyPIRepository(BaseRepository):
+@@ -190,14 +325,44 @@ class PyPIRepository(BaseRepository):
                      upgrade_strategy="to-satisfy-only",
                      force_reinstall=False,
                      ignore_dependencies=False,
@@ -304,7 +311,7 @@ index 1c4b943..858d697 100644
              reqset.cleanup_files()
          return set(self._dependencies_cache[ireq])
  
-@@ -224,17 +382,10 @@ class PyPIRepository(BaseRepository):
+@@ -224,17 +389,10 @@ class PyPIRepository(BaseRepository):
          matching_candidates = candidates_by_version[matching_versions[0]]
  
          return {


### PR DESCRIPTION
Patch piptools to use current environment python

 - Fixes #2088, #2234, and #1901
 - Fully leverage piptools' compile functionality by using constraints
    in the same `RequirementSet` during resolution
 - Use `PIP_PYTHON_PATH` for compatibility check to filter out
    `requires_python` markers
 - Fix vcs resolution
 - Update JSON API endpoints
 - Enhance resolution for editable dependencies
 - Minor fix for adding packages to pipfiles
