### PR TITLE
Fix pipenv graph

### DIFF
--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -2495,6 +2495,14 @@ def do_graph(bare=False, json=False, json_tree=False, reverse=False):
                     click.echo(crayons.normal(line, bold=False))
     else:
         click.echo(c.out)
+    if c.return_code != 0:
+        click.echo(
+            '{0} {1}'.format(
+                crayons.red('ERROR: ', bold=True),
+                crayons.white('{0}'.format(c.err, bold=True)),
+            ),
+            err=True
+        )
     # Return its return code.
     sys.exit(c.return_code)
 

--- a/pipenv/vendor/pipdeptree.py
+++ b/pipenv/vendor/pipdeptree.py
@@ -237,7 +237,7 @@ class ReqPackage(Package):
 
     @property
     def version_spec(self):
-        specs = self._obj.specs
+        specs = sorted(self._obj.specs, reverse=True)  # `reverse` makes '>' prior to '<'
         return ','.join([''.join(sp) for sp in specs]) if specs else None
 
     @property
@@ -280,8 +280,8 @@ class ReqPackage(Package):
                 'required_version': self.version_spec}
 
 
-def render_tree(tree, list_all=True, show_only=None, frozen=False):
-    """Convert to tree to string representation
+def render_tree(tree, list_all=True, show_only=None, frozen=False, exclude=None):
+    """Convert tree to string representation
 
     :param dict tree: the package tree
     :param bool list_all: whether to list all the pgks at the root
@@ -291,6 +291,8 @@ def render_tree(tree, list_all=True, show_only=None, frozen=False):
                           output. This is optional arg, default: None.
     :param bool frozen: whether or not show the names of the pkgs in
                         the output that's favourable to pip --freeze
+    :param set exclude: set of select packages to be excluded from the
+                          output. This is optional arg, default: None.
     :returns: string representation of the tree
     :rtype: str
 
@@ -310,6 +312,8 @@ def render_tree(tree, list_all=True, show_only=None, frozen=False):
         nodes = [p for p in nodes if p.key not in branch_keys]
 
     def aux(node, parent=None, indent=0, chain=None):
+        if exclude and (node.key in exclude or node.project_name in exclude):
+            return []
         if chain is None:
             chain = [node.project_name]
         node_str = node.render(parent, frozen)
@@ -527,6 +531,11 @@ def get_parser():
                             'Comma separated list of select packages to show '
                             'in the output. If set, --all will be ignored.'
                         ))
+    parser.add_argument('-e', '--exclude',
+                        help=(
+                            'Comma separated list of select packages to exclude '
+                            'from the output. If set, --all will be ignored.'
+                        ), metavar='PACKAGES')
     parser.add_argument('-j', '--json', action='store_true', default=False,
                         help=(
                             'Display dependency tree as json. This will yield '
@@ -548,10 +557,13 @@ def get_parser():
     return parser
 
 
-def main():
+def _get_args():
     parser = get_parser()
-    args = parser.parse_args()
+    return parser.parse_args()
 
+
+def main():
+    args = _get_args()
     pkgs = get_installed_distributions(local_only=args.local_only,
                                            user_only=args.user_only)
 
@@ -600,10 +612,15 @@ def main():
             return_code = 1
 
     show_only = set(args.packages.split(',')) if args.packages else None
+    exclude = set(args.exclude.split(',')) if args.exclude else None
+
+    if show_only and exclude and (show_only & exclude):
+        print('Conflicting packages found in --packages and --exclude lists.', file=sys.stderr)
+        sys.exit(1)
 
     tree = render_tree(tree if not args.reverse else reverse_tree(tree),
                        list_all=args.all, show_only=show_only,
-                       frozen=args.freeze)
+                       frozen=args.freeze, exclude=exclude)
     print(tree)
     return return_code
 

--- a/pipenv/vendor/pipdeptree.py
+++ b/pipenv/vendor/pipdeptree.py
@@ -14,10 +14,10 @@ except ImportError:
     from ordereddict import OrderedDict
 
 try:
-    from pipenv.patched.notpip._internal import get_installed_distributions
-    from pipenv.patched.notpip._internal.operations.freeze import FrozenRequirement
+    from pip._internal import get_installed_distributions
+    from pip._internal.operations.freeze import FrozenRequirement
 except ImportError:
-    from pipenv.patched.notpip import get_installed_distributions, FrozenRequirement
+    from pip import get_installed_distributions, FrozenRequirement
 
 import pkg_resources
 # inline:

--- a/pipenv/vendor/vendor.txt
+++ b/pipenv/vendor/vendor.txt
@@ -19,7 +19,7 @@ packaging
 parse==1.8.0
 pathlib2==2.1.0
 pexpect==4.5.0
-git+https://github.com/naiquevin/pipdeptree.git@2e9e5119160184f359131ea99993f0158a20cd31#egg=pipdeptree
+git+https://github.com/naiquevin/pipdeptree.git@ee5eaf86ed0f49ea97601475e048d81e5b381902#egg=pipdeptree
 pipreqs==0.4.9
 ptyprocess==0.5.2
 pyparsing>=2.0.2

--- a/tasks/vendoring/patches/vendor/pipdeptree-local-pip.patch
+++ b/tasks/vendoring/patches/vendor/pipdeptree-local-pip.patch
@@ -1,0 +1,18 @@
+diff --git a/pipenv/vendor/pipdeptree.py b/pipenv/vendor/pipdeptree.py
+index a62badf7..a2ea83fd 100644
+--- a/pipenv/vendor/pipdeptree.py
++++ b/pipenv/vendor/pipdeptree.py
+@@ -14,10 +14,10 @@ except ImportError:
+     from ordereddict import OrderedDict
+ 
+ try:
+-    from pipenv.patched.notpip._internal import get_installed_distributions
+-    from pipenv.patched.notpip._internal.operations.freeze import FrozenRequirement
++    from pip._internal import get_installed_distributions
++    from pip._internal.operations.freeze import FrozenRequirement
+ except ImportError:
+-    from pipenv.patched.notpip import get_installed_distributions, FrozenRequirement
++    from pip import get_installed_distributions, FrozenRequirement
+ 
+ import pkg_resources
+ # inline:


### PR DESCRIPTION
Fix `pipenv graph` so that it uses local system pip instead of trying to use patched pip (since this runs in the virtualenv this won't ever work)
    
 - Fixes #2258
 - Add patch to prevent import rewrites from catching this again
 - Add useful debugging line to print errors to stderr
