### PR TITLE
Install git in dockerfile for git dependencies.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:18.04
 
 # -- Install Pipenv:
-RUN apt update && apt install python3-pip -y && pip3 install pipenv
+RUN apt update && apt install python3-pip git -y && pip3 install pipenv
 
 ENV LC_ALL C.UTF-8
 ENV LANG C.UTF-8


### PR DESCRIPTION
In my Pipfile I have the following package, while I'm waiting on the package authors' pypi release of a PR I made.
```
python-nomad = {git = "https://github.com/jrxFive/python-nomad"}
```

However when building my docker image I get the following:
```
Error [Errno 2] No such file or directory: 'git': 'git' while executing command git clone -q https://github.com/jrxFive/python-nomad /tmp/pip-build-yl5dapck/python-nomad
Cannot find command 'git'
```

I tried with the following Dockerfile
```Dockerfile
FROM kennethreitz/pipenv

RUN apt-get update & apt-get install git

COPY . /app

CMD [ "./start_worker.sh" ]
```
Apparently the `ONBUILD` commands in the parent pipenv image run before I get to install via apt.