### PR TITLE
Allow users to override default PyPI index URLs with PyPI mirror URLs

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -38,6 +38,23 @@ If you'd like a specific package to be installed with a specific package index, 
 
 Very fancy.
 
+☤ Using a PyPI Mirror
+----------------------------
+
+If you'd like to override the default PyPI index urls with the url for a PyPI mirror, you can use the following::
+
+    $ pipenv install --pypi-mirror <mirror_url>
+
+    $ pipenv update --pypi-mirror <mirror_url>
+
+    $ pipenv sync --pypi-mirror <mirror_url>
+
+    $ pipenv lock --pypi-mirror <mirror_url>
+
+    $ pipenv uninstall --pypi-mirror <mirror_url>
+
+Alternatively, you can set the ``PIPENV_PYPI_MIRROR`` environment variable.
+
 ☤ Injecting credentials into Pipfiles via environment variables
 -----------------------------------------------------------------
 

--- a/pipenv/environments.py
+++ b/pipenv/environments.py
@@ -76,3 +76,5 @@ PYENV_INSTALLED = (
 SESSION_IS_INTERACTIVE = bool(os.isatty(sys.stdout.fileno()))
 PIPENV_SHELL = os.environ.get('SHELL') or os.environ.get('PYENV_SHELL')
 PIPENV_CACHE_DIR = os.environ.get('PIPENV_CACHE_DIR', user_cache_dir('pipenv'))
+# Tells pipenv to override PyPI index urls with a mirror.
+PIPENV_PYPI_MIRROR = os.environ.get('PIPENV_PYPI_MIRROR')

--- a/pipenv/resolver.py
+++ b/pipenv/resolver.py
@@ -48,6 +48,7 @@ def main():
         for i, package in enumerate(packages):
             if package.startswith('--'):
                 del packages[i]
+    pypi_mirror_source = pipenv.utils.create_mirror_source(os.environ['PIPENV_PYPI_MIRROR']) if 'PIPENV_PYPI_MIRROR' in os.environ else None
     project = pipenv.core.project
 
     def resolve(packages, pre, sources, verbose, clear, system):
@@ -66,7 +67,7 @@ def main():
     results = resolve(
         packages,
         pre=do_pre,
-        sources=project.pipfile_sources,
+        sources = pipenv.utils.replace_pypi_sources(project.pipfile_sources, pypi_mirror_source) if pypi_mirror_source else project.pipfile_sources,
         verbose=is_verbose,
         clear=do_clear,
         system=system,

--- a/tests/integration/test_sync.py
+++ b/tests/integration/test_sync.py
@@ -1,3 +1,7 @@
+import os
+
+from pipenv.utils import temp_environ
+
 import pytest
 
 
@@ -12,6 +16,23 @@ def test_sync_error_without_lockfile(PipenvInstance, pypi):
         c = p.pipenv('sync')
         assert c.return_code != 0
         assert 'Pipfile.lock is missing!' in c.err
+
+
+@pytest.mark.sync
+@pytest.mark.lock
+def test_mirror_lock_sync(PipenvInstance, pypi):
+    with temp_environ(), PipenvInstance(chdir=True) as p:
+        mirror_url = os.environ.pop('PIPENV_TEST_INDEX', "https://pypi.python.org/simple")
+        assert 'pypi.org' not in mirror_url
+        with open(p.pipfile_path, 'w') as f:
+            f.write("""
+[packages]
+six = "*"
+            """.strip())
+        c = p.pipenv('lock --pypi-mirror {0}'.format(mirror_url))
+        assert c.return_code == 0
+        c = p.pipenv('sync --pypi-mirror {0}'.format(mirror_url))
+        assert c.return_code == 0
 
 
 @pytest.mark.sync

--- a/tests/integration/test_uninstall.py
+++ b/tests/integration/test_uninstall.py
@@ -1,6 +1,8 @@
 import os
 import shutil
 
+from pipenv.utils import temp_environ
+
 import pytest
 
 
@@ -26,6 +28,47 @@ def test_uninstall(PipenvInstance, pypi):
         assert 'idna' not in p.lockfile['develop']
         assert 'urllib3' not in p.lockfile['develop']
         assert 'certifi' not in p.lockfile['develop']
+
+        c = p.pipenv('run python -m requests.help')
+        assert c.return_code > 0
+
+
+@pytest.mark.run
+@pytest.mark.uninstall
+@pytest.mark.install
+def test_mirror_uninstall(PipenvInstance, pypi):
+    with temp_environ(), PipenvInstance(chdir=True) as p:
+
+        mirror_url = os.environ.pop('PIPENV_TEST_INDEX', "https://pypi.python.org/simple")
+        assert 'pypi.org' not in mirror_url
+
+        c = p.pipenv('install requests --pypi-mirror {0}'.format(mirror_url))
+        assert c.return_code == 0
+        assert 'requests' in p.pipfile['packages']
+        assert 'requests' in p.lockfile['default']
+        assert 'chardet' in p.lockfile['default']
+        assert 'idna' in p.lockfile['default']
+        assert 'urllib3' in p.lockfile['default']
+        assert 'certifi' in p.lockfile['default']
+        # Ensure the --pypi-mirror parameter hasn't altered the Pipfile or Pipfile.lock sources
+        assert len(p.pipfile['source']) == 1
+        assert len(p.lockfile["_meta"]["sources"]) == 1
+        assert 'https://pypi.org/simple' == p.pipfile['source'][0]['url']
+        assert 'https://pypi.org/simple' == p.lockfile['_meta']['sources'][0]['url']
+
+        c = p.pipenv('uninstall requests --pypi-mirror {0}'.format(mirror_url))
+        assert c.return_code == 0
+        assert 'requests' not in p.pipfile['dev-packages']
+        assert 'requests' not in p.lockfile['develop']
+        assert 'chardet' not in p.lockfile['develop']
+        assert 'idna' not in p.lockfile['develop']
+        assert 'urllib3' not in p.lockfile['develop']
+        assert 'certifi' not in p.lockfile['develop']
+        # Ensure the --pypi-mirror parameter hasn't altered the Pipfile or Pipfile.lock sources
+        assert len(p.pipfile['source']) == 1
+        assert len(p.lockfile["_meta"]["sources"]) == 1
+        assert 'https://pypi.org/simple' == p.pipfile['source'][0]['url']
+        assert 'https://pypi.org/simple' == p.lockfile['_meta']['sources'][0]['url']
 
         c = p.pipenv('run python -m requests.help')
         assert c.return_code > 0


### PR DESCRIPTION
In response to #2075, allow users to override the default PyPI indices (pypi.org, pypi.python.org) with a mirror specified via CLI parameter or environment variable.