### PR TITLE
Don't search for requirements.txt if using pipfile

### DIFF
--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -1779,7 +1779,8 @@ def do_install(
         keep_outdated = True
     more_packages = more_packages or []
     # Don't search for requirements.txt files if the user provides one
-    skip_requirements = True if requirements else False
+    if requirements or package_name or project.pipfile_exists:
+        skip_requirements = True
     concurrent = (not sequential)
     # Ensure that virtualenv is available.
     ensure_project(


### PR DESCRIPTION
- Also don't search for requirements.txt if taking in a package name
- Fixes #2222

Signed-off-by: Dan Ryan <dan@danryan.co>