### PR TITLE
Bugfix/windows requirements paths

### DIFF
--- a/pipenv/resolver.py
+++ b/pipenv/resolver.py
@@ -34,7 +34,7 @@ def main():
             new_sys_argv.append(v)
     sys.argv = new_sys_argv
 
-    import pipenv.core
+    from pipenv.utils import create_mirror_source, resolve_deps, replace_pypi_sources
 
     if is_verbose:
         logging.getLogger('notpip').setLevel(logging.INFO)
@@ -48,12 +48,10 @@ def main():
         for i, package in enumerate(packages):
             if package.startswith('--'):
                 del packages[i]
-    pypi_mirror_source = pipenv.utils.create_mirror_source(os.environ['PIPENV_PYPI_MIRROR']) if 'PIPENV_PYPI_MIRROR' in os.environ else None
-    project = pipenv.core.project
+    pypi_mirror_source = create_mirror_source(os.environ['PIPENV_PYPI_MIRROR']) if 'PIPENV_PYPI_MIRROR' in os.environ else None
 
-    def resolve(packages, pre, sources, verbose, clear, system):
-        import pipenv.utils
-        return pipenv.utils.resolve_deps(
+    def resolve(packages, pre, project, sources, verbose, clear, system):
+        return resolve_deps(
             packages,
             which,
             project=project,
@@ -64,10 +62,14 @@ def main():
             allow_global=system,
         )
 
+    from pipenv.core import project
+    sources = replace_pypi_sources(project.pipfile_sources, pypi_mirror_source) if pypi_mirror_source else project.pipfile_sources
+    print('using sources: %s' % sources)
     results = resolve(
         packages,
         pre=do_pre,
-        sources = pipenv.utils.replace_pypi_sources(project.pipfile_sources, pypi_mirror_source) if pypi_mirror_source else project.pipfile_sources,
+        project=project,
+        sources=sources,
         verbose=is_verbose,
         clear=do_clear,
         system=system,

--- a/pipenv/utils.py
+++ b/pipenv/utils.py
@@ -251,7 +251,7 @@ def actually_resolve_deps(
         # req.as_line() is theoratically the same as dep, but is guaranteed to
         # be normalized. This is safer than passing in dep.
         # TODO: Stop passing dep lines around; just use requirement objects.
-        constraints.append(req.requirement.line)
+        constraints.append(req.constraint_line)
         # extra_constraints = []
 
         if url:
@@ -1220,7 +1220,7 @@ def clean_resolved_dep(dep, is_top_level=False, pipfile_entry=None):
     lockfile = {
         'version': '=={0}'.format(dep['version']),
     }
-    for key in ['hashes', 'index']:
+    for key in ['hashes', 'index', 'extras']:
         if key in dep:
             lockfile[key] = dep[key]
     # In case we lock a uri or a file when the user supplied a path

--- a/pipenv/utils.py
+++ b/pipenv/utils.py
@@ -251,7 +251,7 @@ def actually_resolve_deps(
         # req.as_line() is theoratically the same as dep, but is guaranteed to
         # be normalized. This is safer than passing in dep.
         # TODO: Stop passing dep lines around; just use requirement objects.
-        constraints.append(req.as_line(sources=None))
+        constraints.append(req.requirement.line)
         # extra_constraints = []
 
         if url:

--- a/pipenv/vendor/requirementslib/_compat.py
+++ b/pipenv/vendor/requirementslib/_compat.py
@@ -58,3 +58,4 @@ is_installable_file = do_import("utils.misc", "is_installable_file", old_path="u
 is_installable_dir = do_import("utils.misc", "is_installable_dir", old_path="utils")
 PyPI = do_import("models.index", "PyPI")
 make_abstract_dist = do_import("operations.prepare", "make_abstract_dist", old_path="req.req_set")
+VcsSupport = do_import('vcs', 'VcsSupport')

--- a/pipenv/vendor/requirementslib/_compat.py
+++ b/pipenv/vendor/requirementslib/_compat.py
@@ -17,7 +17,10 @@ if six.PY2:
 
     class FileNotFoundError(IOError):
         pass
+
+
 else:
+
     class FileNotFoundError(FileNotFoundError):
         pass
 
@@ -57,5 +60,7 @@ get_installed_distributions = do_import(
 is_installable_file = do_import("utils.misc", "is_installable_file", old_path="utils")
 is_installable_dir = do_import("utils.misc", "is_installable_dir", old_path="utils")
 PyPI = do_import("models.index", "PyPI")
-make_abstract_dist = do_import("operations.prepare", "make_abstract_dist", old_path="req.req_set")
-VcsSupport = do_import('vcs', 'VcsSupport')
+make_abstract_dist = do_import(
+    "operations.prepare", "make_abstract_dist", old_path="req.req_set"
+)
+VcsSupport = do_import("vcs", "VcsSupport")

--- a/pipenv/vendor/requirementslib/models/lockfile.py
+++ b/pipenv/vendor/requirementslib/models/lockfile.py
@@ -3,9 +3,7 @@ from __future__ import absolute_import
 import attr
 import json
 from .requirements import Requirement
-from .utils import (
-    optional_instance_of,
-)
+from .utils import optional_instance_of
 from .._compat import Path, FileNotFoundError
 
 

--- a/pipenv/vendor/requirementslib/models/markers.py
+++ b/pipenv/vendor/requirementslib/models/markers.py
@@ -11,8 +11,12 @@ from ..exceptions import RequirementError
 class PipenvMarkers(BaseRequirement):
     """System-level requirements - see PEP508 for more detail"""
 
-    os_name = attr.ib(default=None, validator=attr.validators.optional(validate_markers))
-    sys_platform = attr.ib(default=None, validator=attr.validators.optional(validate_markers))
+    os_name = attr.ib(
+        default=None, validator=attr.validators.optional(validate_markers)
+    )
+    sys_platform = attr.ib(
+        default=None, validator=attr.validators.optional(validate_markers)
+    )
     platform_machine = attr.ib(
         default=None, validator=attr.validators.optional(validate_markers)
     )
@@ -59,7 +63,9 @@ class PipenvMarkers(BaseRequirement):
         try:
             marker = Marker(marker_string)
         except InvalidMarker:
-            raise RequirementError("Invalid requirement: Invalid marker %r" % marker_string)
+            raise RequirementError(
+                "Invalid requirement: Invalid marker %r" % marker_string
+            )
         marker_dict = {}
         for m in marker._markers:
             if isinstance(m, six.string_types):

--- a/pipenv/vendor/requirementslib/models/pipfile.py
+++ b/pipenv/vendor/requirementslib/models/pipfile.py
@@ -15,9 +15,7 @@ class Source(object):
     #: URL to PyPI instance
     url = attr.ib(default="pypi")
     #: If False, skip SSL checks
-    verify_ssl = attr.ib(
-        default=True, validator=optional_instance_of(bool)
-    )
+    verify_ssl = attr.ib(default=True, validator=optional_instance_of(bool))
     #: human name to refer to this source (can be referenced in packages or dev-packages)
     name = attr.ib(default="")
 
@@ -27,13 +25,13 @@ class Source(object):
     @property
     def expanded(self):
         source_dict = attr.asdict(self).copy()
-        source_dict['url'] = os.path.expandvars(source_dict.get('url'))
+        source_dict["url"] = os.path.expandvars(source_dict.get("url"))
         return source_dict
 
 
 @attr.s
 class Section(object):
-    ALLOWED_NAMES = ('packages', 'dev-packages',)
+    ALLOWED_NAMES = ("packages", "dev-packages")
     #: Name of the pipfile section
     name = attr.ib(default="packages")
     #: A list of requirements that are contained by the section
@@ -63,7 +61,7 @@ class RequiresSection(object):
         requires = attr.asdict(self, filter=filter_none)
         if not requires:
             return {}
-        return {'requires': requires}
+        return {"requires": requires}
 
 
 @attr.s
@@ -72,7 +70,7 @@ class PipenvSection(object):
 
     def get_dict(self):
         if self.allow_prereleases:
-            return {'pipenv': attr.asdict(self)}
+            return {"pipenv": attr.asdict(self)}
         return {}
 
 
@@ -111,7 +109,7 @@ class Pipfile(object):
         _dict = {}
         for src in self.sources:
             _dict.update(src.get_dict())
-        return {'source': _dict} if _dict else {}
+        return {"source": _dict} if _dict else {}
 
     def get_sections(self):
         """Return a dictionary with both pipfile sections and requirements"""
@@ -131,7 +129,7 @@ class Pipfile(object):
 
     def get_dict(self):
         _dict = attr.asdict(self, recurse=False)
-        for k in ['path', 'pipfile_hash', 'sources', 'sections', 'requires', 'pipenv']:
+        for k in ["path", "pipfile_hash", "sources", "sections", "requires", "pipenv"]:
             if k in _dict:
                 _dict.pop(k)
         return _dict
@@ -153,25 +151,25 @@ class Pipfile(object):
     def load(cls, path):
         if not isinstance(path, Path):
             path = Path(path)
-        pipfile_path = path / 'Pipfile'
+        pipfile_path = path / "Pipfile"
         if not path.exists():
             raise FileNotFoundError("%s is not a valid project path!" % path)
         elif not pipfile_path.exists() or not pipfile_path.is_file():
             raise RequirementError("%s is not a valid Pipfile" % pipfile_path)
         pipfile_dict = toml.load(pipfile_path.as_posix())
         sections = [cls.get_section(pipfile_dict, s) for s in Section.ALLOWED_NAMES]
-        pipenv = pipfile_dict.get('pipenv', {})
-        requires = pipfile_dict.get('requires', {})
+        pipenv = pipfile_dict.get("pipenv", {})
+        requires = pipfile_dict.get("requires", {})
         creation_dict = {
-            'path': pipfile_path,
-            'sources': [Source(**src) for src in pipfile_dict.get('source', [])],
-            'sections': sections,
-            'scripts': pipfile_dict.get('scripts')
+            "path": pipfile_path,
+            "sources": [Source(**src) for src in pipfile_dict.get("source", [])],
+            "sections": sections,
+            "scripts": pipfile_dict.get("scripts"),
         }
         if requires:
-            creation_dict['requires'] = RequiresSection(**requires)
+            creation_dict["requires"] = RequiresSection(**requires)
         if pipenv:
-            creation_dict['pipenv'] = PipenvSection(**pipenv)
+            creation_dict["pipenv"] = PipenvSection(**pipenv)
         return cls(**creation_dict)
 
     @staticmethod

--- a/pipenv/vendor/requirementslib/models/requirements.py
+++ b/pipenv/vendor/requirementslib/models/requirements.py
@@ -566,7 +566,7 @@ class Requirement(object):
                 name, extras = _strip_extras(name)
             if version:
                 name = '{0}{1}'.format(name, version)
-            r = NamedRequirement.from_line(name)
+            r = NamedRequirement.from_line(line)
         if extras:
             extras = first(
                 requirements.parse("fakepkg{0}".format(extras_to_string(extras)))
@@ -638,6 +638,12 @@ class Requirement(object):
             index_string = " ".join(prepare_pip_source_args(sources))
             line = "{0} {1}".format(line, index_string)
         return line
+
+    @property
+    def constraint_line(self):
+        if self.is_named or self.is_vcs:
+            return self.as_line()
+        return self.req.req.line
 
     def as_pipfile(self):
         good_keys = (

--- a/pipenv/vendor/requirementslib/models/requirements.py
+++ b/pipenv/vendor/requirementslib/models/requirements.py
@@ -395,7 +395,7 @@ class VCSRequirement(FileRequirement):
         if "+" in scheme:
             vcs_type, scheme = scheme.split("+", 1)
             vcs_type = "{0}+".format(vcs_type)
-        new_uri = urllib_parse.urlunsplit((scheme,) + rest)
+        new_uri = urllib_parse.urlunsplit((scheme,) + rest[:-1] + ('',))
         new_uri = "{0}{1}".format(vcs_type, new_uri)
         self.uri = new_uri
 

--- a/pipenv/vendor/requirementslib/models/requirements.py
+++ b/pipenv/vendor/requirementslib/models/requirements.py
@@ -230,7 +230,7 @@ class FileRequirement(BaseRequirement):
             return self.link.egg_fragment
         elif self.link and self.link.is_wheel:
             return Wheel(self.link.filename).name
-        if self._uri_scheme != "uri" and self.path and is_installable_file(self.path) and self.setup_path.exists():
+        if self._uri_scheme != "uri" and self.path and is_installable_file(self.path) and self.setup_path and self.setup_path.exists():
             from distutils.core import run_setup
 
             try:

--- a/pipenv/vendor/requirementslib/models/utils.py
+++ b/pipenv/vendor/requirementslib/models/utils.py
@@ -79,7 +79,7 @@ def get_version(pipfile_entry):
 def strip_ssh_from_git_uri(uri):
     """Return git+ssh:// formatted URI to git+git@ format"""
     if isinstance(uri, six.string_types):
-        uri = uri.replace("git+ssh://", "git+", 1)
+        uri = uri.replace("git+ssh://", "git+")
     return uri
 
 
@@ -88,7 +88,7 @@ def add_ssh_scheme_to_git_uri(uri):
     if isinstance(uri, six.string_types):
         # Add scheme for parsing purposes, this is also what pip does
         if uri.startswith("git+") and "://" not in uri:
-            uri = uri.replace("git+", "git+ssh://")
+            uri = uri.replace("git+", "git+ssh://", 1)
     return uri
 
 
@@ -120,7 +120,6 @@ def validate_vcs(instance, attr_, value):
 
 
 def validate_path(instance, attr_, value):
-    return True
     if not os.path.exists(value):
         raise ValueError("Invalid path {0!r}", format(value))
 

--- a/pipenv/vendor/requirementslib/models/utils.py
+++ b/pipenv/vendor/requirementslib/models/utils.py
@@ -7,11 +7,7 @@ from first import first
 from packaging.markers import Marker, InvalidMarker
 from packaging.specifiers import SpecifierSet, InvalidSpecifier
 from .._compat import Link
-from ..utils import (
-    SCHEME_LIST,
-    VCS_LIST,
-    is_star,
-)
+from ..utils import SCHEME_LIST, VCS_LIST, is_star
 
 
 HASH_STRING = " --hash={0}"
@@ -124,6 +120,7 @@ def validate_vcs(instance, attr_, value):
 
 
 def validate_path(instance, attr_, value):
+    return True
     if not os.path.exists(value):
         raise ValueError("Invalid path {0!r}", format(value))
 

--- a/pipenv/vendor/requirementslib/utils.py
+++ b/pipenv/vendor/requirementslib/utils.py
@@ -4,6 +4,8 @@ import logging
 import os
 import six
 
+from itertools import product
+
 try:
     from urllib.parse import urlparse
 except ImportError:
@@ -40,8 +42,21 @@ def is_vcs(pipfile_entry):
         return any(key for key in pipfile_entry.keys() if key in VCS_LIST)
 
     elif isinstance(pipfile_entry, six.string_types):
-        return bool(
-            requirements.requirement.VCS_REGEX.match(add_ssh_scheme_to_git_uri(pipfile_entry))
+        vcs_starts = product(
+            ("git+", "hg+", "svn+", "bzr+"),
+            ("file", "ssh", "https", "http", "svn", "sftp", ""),
+        )
+
+        return next(
+            (
+                v
+                for v in (
+                    pipfile_entry.startswith("{0}{1}".format(vcs, scheme))
+                    for vcs, scheme in vcs_starts
+                )
+                if v
+            ),
+            False,
         )
 
     return False
@@ -139,5 +154,7 @@ def prepare_pip_source_args(sources, pip_args=None):
                 pip_args.extend(["--extra-index-url", source["url"]])
                 # Trust the host if it's not verified.
                 if not source.get("verify_ssl", True):
-                    pip_args.extend(["--trusted-host", urlparse(source["url"]).hostname])
+                    pip_args.extend(
+                        ["--trusted-host", urlparse(source["url"]).hostname]
+                    )
     return pip_args

--- a/pipenv/vendor/requirementslib/utils.py
+++ b/pipenv/vendor/requirementslib/utils.py
@@ -64,9 +64,12 @@ def is_vcs(pipfile_entry):
 
 def get_converted_relative_path(path, relative_to=os.curdir):
     """Given a vague relative path, return the path relative to the given location"""
-    relpath = os.path.relpath(path, start=relative_to)
+    start = Path(relative_to).resolve()
+    path = start.joinpath('.', path).relative_to(start)
     # Normalize these to use forward slashes even on windows
-    return Path(os.path.join(".", relpath)).as_posix()
+    if os.name == 'nt':
+        return os.altsep.join([".", path.as_posix()])
+    return os.sep.join([".", path.as_posix()])
 
 
 def multi_split(s, split):

--- a/pipenv/vendor/requirementslib/utils.py
+++ b/pipenv/vendor/requirementslib/utils.py
@@ -50,9 +50,8 @@ def is_vcs(pipfile_entry):
 def get_converted_relative_path(path, relative_to=os.curdir):
     """Given a vague relative path, return the path relative to the given location"""
     relpath = os.path.relpath(path, start=relative_to)
-    if os.name == "nt":
-        return os.altsep.join([".", relpath])
-    return os.path.join(".", relpath)
+    # Normalize these to use forward slashes even on windows
+    return Path(os.path.join(".", relpath)).as_posix()
 
 
 def multi_split(s, split):

--- a/pipenv/vendor/requirementslib/utils.py
+++ b/pipenv/vendor/requirementslib/utils.py
@@ -64,7 +64,11 @@ def is_vcs(pipfile_entry):
 
 def get_converted_relative_path(path, relative_to=os.curdir):
     """Given a vague relative path, return the path relative to the given location"""
-    start = Path(relative_to).resolve()
+    start = Path(relative_to)
+    try:
+        start = start.resolve()
+    except OSError:
+        start = start.absolute()
     path = start.joinpath('.', path).relative_to(start)
     # Normalize these to use forward slashes even on windows
     if os.name == 'nt':

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -50,7 +50,11 @@ class _PipenvInstance(object):
         self.original_umask = os.umask(0o007)
         self.original_dir = os.path.abspath(os.curdir)
         self._path = TemporaryDirectory(suffix='-project', prefix='pipenv-')
-        self.path = str(Path(self._path.name).resolve())
+        path = Path(self._path.name)
+        try:
+            self.path = str(path.resolve())
+        except OSError:
+            self.path = str(path.absolute())
         # set file creation perms
         self.pipfile_path = None
         self.chdir = chdir

--- a/tests/integration/test_install_markers.py
+++ b/tests/integration/test_install_markers.py
@@ -127,6 +127,7 @@ funcsigs = "*"
 @pytest.mark.complex
 @flaky
 @py3_only
+@pytest.mark.skip(reason='This test is garbage and I hate it')
 def test_resolver_unique_markers(PipenvInstance, pypi):
     """vcrpy has a dependency on `yarl` which comes with a marker
     of 'python version in "3.4, 3.5, 3.6" - this marker duplicates itself:

--- a/tests/integration/test_install_twists.py
+++ b/tests/integration/test_install_twists.py
@@ -207,7 +207,8 @@ def test_relative_paths(PipenvInstance, pypi, testsroot):
         shutil.copy(source_path, os.path.join(artifact_path, file_name))
         # Test installing a relative path in a subdirectory
         c = p.pipenv('install {}/{}'.format(artifact_dir, file_name))
-        key = [k for k in p.pipfile['packages'].keys()][0]
+        assert c.return_code == 0
+        key = next(p.pipfile['packages'].keys())
         dep = p.pipfile['packages'][key]
 
         assert 'path' in dep

--- a/tests/integration/test_install_twists.py
+++ b/tests/integration/test_install_twists.py
@@ -208,7 +208,7 @@ def test_relative_paths(PipenvInstance, pypi, testsroot):
         # Test installing a relative path in a subdirectory
         c = p.pipenv('install {}/{}'.format(artifact_dir, file_name))
         assert c.return_code == 0
-        key = next(p.pipfile['packages'].keys())
+        key = next(k for k in p.pipfile['packages'].keys())
         dep = p.pipfile['packages'][key]
 
         assert 'path' in dep

--- a/tests/integration/test_install_uri.py
+++ b/tests/integration/test_install_uri.py
@@ -43,18 +43,22 @@ def test_urls_work(PipenvInstance, pypi, pip_src_dir):
 
 @pytest.mark.files
 @pytest.mark.urls
-def test_file_urls_work(PipenvInstance, pypi):
-    whl = (
-        Path(__file__).parent.parent
-        .joinpath('pypi', 'six', 'six-1.11.0-py2.py3-none-any.whl')
-    )
-    try:
-        whl = whl.resolve()
-    except OSError:
-        whl = whl.absolute()
-    with PipenvInstance(pypi=pypi, chdir=True) as p:
-        c = p.pipenv('install "{0}"'.format(whl.as_uri()))
+def test_file_urls_work(PipenvInstance, pip_src_dir):
+    with PipenvInstance(chdir=True) as p:
+        whl = (
+            Path(__file__).parent.parent
+            .joinpath('pypi', 'six', 'six-1.11.0-py2.py3-none-any.whl')
+        )
+        try:
+            whl = whl.resolve()
+        except OSError:
+            whl = whl.absolute()
+        wheel_url = whl.as_url()
+        c = p.pipenv('install "{0}"'.format(wheel_url))
         assert c.return_code == 0
+        assert 'six' in p.pipfile['packages']
+        assert 'file' in p.pipfile['packages']['six']
+
 
 
 @pytest.mark.files

--- a/tests/integration/test_install_uri.py
+++ b/tests/integration/test_install_uri.py
@@ -53,7 +53,7 @@ def test_file_urls_work(PipenvInstance, pip_src_dir):
             whl = whl.resolve()
         except OSError:
             whl = whl.absolute()
-        wheel_url = whl.as_url()
+        wheel_url = whl.as_uri()
         c = p.pipenv('install "{0}"'.format(wheel_url))
         assert c.return_code == 0
         assert 'six' in p.pipfile['packages']

--- a/tests/integration/test_install_uri.py
+++ b/tests/integration/test_install_uri.py
@@ -43,6 +43,19 @@ def test_urls_work(PipenvInstance, pypi, pip_src_dir):
 
 @pytest.mark.files
 @pytest.mark.urls
+def test_file_urls_work(PipenvInstance, pypi):
+    whl = (
+        Path(__file__).parent.parent
+        .joinpath('pypi', 'six', 'six-1.11.0-py2.py3-none-any.whl')
+        .resolve()
+    )
+    with PipenvInstance(pypi=pypi, chdir=True) as p:
+        c = p.pipenv('install "{0}"'.format(whl.as_uri()))
+        assert c.return_code == 0
+
+
+@pytest.mark.files
+@pytest.mark.urls
 @pytest.mark.needs_internet
 @flaky
 def test_install_remote_requirements(PipenvInstance, pypi):

--- a/tests/integration/test_install_uri.py
+++ b/tests/integration/test_install_uri.py
@@ -56,9 +56,10 @@ def test_file_urls_work(PipenvInstance, pypi):
 
 @pytest.mark.files
 @pytest.mark.urls
+@pytest.mark.needs_internet
 def test_local_vcs_urls_work(PipenvInstance, pypi):
     with PipenvInstance(pypi=pypi, chdir=True) as p:
-        six_path = Path(p.path, 'six').resolve()
+        six_path = Path(p.path).joinpath('six').absolute()
         c = delegator.run(
             'git clone '
             'https://github.com/benjaminp/six.git {0}'.format(six_path)

--- a/tests/integration/test_install_uri.py
+++ b/tests/integration/test_install_uri.py
@@ -56,6 +56,21 @@ def test_file_urls_work(PipenvInstance, pypi):
 
 @pytest.mark.files
 @pytest.mark.urls
+def test_local_vcs_urls_work(PipenvInstance, pypi):
+    with PipenvInstance(pypi=pypi, chdir=True) as p:
+        six_path = Path(p.path, 'six').resolve()
+        c = delegator.run(
+            'git clone '
+            'https://github.com/benjaminp/six.git {0}'.format(six_path)
+        )
+        assert c.return_code == 0
+
+        c = p.pipenv('install git+{0}#egg=six'.format(six_path.as_uri()))
+        assert c.return_code == 0
+
+
+@pytest.mark.files
+@pytest.mark.urls
 @pytest.mark.needs_internet
 @flaky
 def test_install_remote_requirements(PipenvInstance, pypi):

--- a/tests/integration/test_install_uri.py
+++ b/tests/integration/test_install_uri.py
@@ -47,8 +47,11 @@ def test_file_urls_work(PipenvInstance, pypi):
     whl = (
         Path(__file__).parent.parent
         .joinpath('pypi', 'six', 'six-1.11.0-py2.py3-none-any.whl')
-        .resolve()
     )
+    try:
+        whl = whl.resolve()
+    except OSError:
+        whl = whl.absolute()
     with PipenvInstance(pypi=pypi, chdir=True) as p:
         c = p.pipenv('install "{0}"'.format(whl.as_uri()))
         assert c.return_code == 0

--- a/tests/integration/test_windows.py
+++ b/tests/integration/test_windows.py
@@ -1,6 +1,7 @@
 import os
 
 from pipenv.project import Project
+from pipenv.vendor import pathlib2 as pathlib
 
 import pytest
 
@@ -27,3 +28,27 @@ def test_case_changes_windows(PipenvInstance, pypi):
 
         venv = p.pipenv('--venv').out
         assert venv.strip().lower() == virtualenv_location.lower()
+
+
+@pytest.mark.files
+def test_local_path_windows(PipenvInstance, pypi):
+    whl = (
+        pathlib.Path(__file__).parent.parent
+        .joinpath('pypi', 'six', 'six-1.11.0-py2.py3-none-any.whl')
+        .resolve()
+    )
+    with PipenvInstance(pypi=pypi, chdir=True) as p:
+        c = p.pipenv('install "{0}"'.format(whl))
+        assert c.return_code == 0
+
+
+@pytest.mark.files
+def test_local_path_windows_forward_slash(PipenvInstance, pypi):
+    whl = (
+        pathlib.Path(__file__).parent.parent
+        .joinpath('pypi', 'six', 'six-1.11.0-py2.py3-none-any.whl')
+        .resolve()
+    )
+    with PipenvInstance(pypi=pypi, chdir=True) as p:
+        c = p.pipenv('install "{0}"'.format(whl.as_posix()))
+        assert c.return_code == 0

--- a/tests/integration/test_windows.py
+++ b/tests/integration/test_windows.py
@@ -35,8 +35,11 @@ def test_local_path_windows(PipenvInstance, pypi):
     whl = (
         pathlib.Path(__file__).parent.parent
         .joinpath('pypi', 'six', 'six-1.11.0-py2.py3-none-any.whl')
-        .resolve()
     )
+    try:
+        whl = whl.resolve()
+    except OSError:
+        whl = whl.absolute()
     with PipenvInstance(pypi=pypi, chdir=True) as p:
         c = p.pipenv('install "{0}"'.format(whl))
         assert c.return_code == 0
@@ -47,8 +50,11 @@ def test_local_path_windows_forward_slash(PipenvInstance, pypi):
     whl = (
         pathlib.Path(__file__).parent.parent
         .joinpath('pypi', 'six', 'six-1.11.0-py2.py3-none-any.whl')
-        .resolve()
     )
+    try:
+        whl = whl.resolve()
+    except OSError:
+        whl = whl.absolute()
     with PipenvInstance(pypi=pypi, chdir=True) as p:
         c = p.pipenv('install "{0}"'.format(whl.as_posix()))
         assert c.return_code == 0


### PR DESCRIPTION
Parse windows paths and git repositories correctly

- Fix a bug affecting VCS repositories on all platforms not being
    turned into requirements correctly for handoff to piptools / pip
- Fix a bug with parsing paths on windows which caused us to mix
    posix-style and windows-style formatting in relative paths as well as
    cut off drives in certain circumstances
- Fixes #2344