### PR TITLE
Shell completion on Bash for Windows

### DIFF
--- a/pipenv/vendor/click_completion.py
+++ b/pipenv/vendor/click_completion.py
@@ -390,7 +390,7 @@ def get_code(shell=None, prog_name=None, env_name=None, extra_env=None):
     extra_env = extra_env if extra_env else {}
     if shell == 'fish':
         return Template(FISH_TEMPLATE).render(prog_name=prog_name, complete_var=env_name, extra_env=extra_env)
-    elif shell == 'bash':
+    elif shell in ['bash', 'bash.exe']:
         return Template(BASH_COMPLETION_SCRIPT).render(prog_name=prog_name, complete_var=env_name, extra_env=extra_env)
     elif shell == 'zsh':
         return Template(ZSH_TEMPLATE).render(prog_name=prog_name, complete_var=env_name, extra_env=extra_env)


### PR DESCRIPTION
Currently, shell completion is not supported on Bash for Windows.

If we try `pipenv --completion` we get a message saying "bash.exe is not supported"

I've patched pipenv/vendor/click_completion.py to support Bash completion. 

All that was needed was enabling the generation of the bash script on bash.exe. The generated script already worked.

