### PR TITLE
Adds a way to adds new index from the cli

### DIFF
--- a/pipenv/cli.py
+++ b/pipenv/cli.py
@@ -1061,6 +1061,60 @@ def clean(
     )
 
 
+@command(
+    short_help="Adds a new index of packages in Pipfile."
+)
+@argument('url', default=False)
+@argument('name', default="")
+@option(
+    '--three/--two',
+    is_flag=True,
+    default=None,
+    help="Use Python 3/2 when creating virtualenv.",
+)
+@option(
+    '--python',
+    default=False,
+    nargs=1,
+    callback=validate_python_path,
+    help="Specify which version of Python virtualenv should use.",
+)
+@option(
+    '--dry-run',
+    is_flag=True,
+    default=False,
+    help="Just output unneeded packages.",
+)
+@option(
+    '--pypi-mirror',
+    default=PIPENV_PYPI_MIRROR,
+    nargs=1,
+    callback=validate_pypi_mirror,
+    help="Specify a PyPI mirror.",
+)
+@pass_context
+def index(
+    ctx,
+    url,
+    name=False,
+    three=False,
+    python=False,
+    dry_run=False,
+    pypi_mirror=None,
+):
+    from .core import do_add_index
+
+    do_add_index(
+        ctx,
+        url,
+        name=name,
+        three=three,
+        python=python,
+        dry_run=dry_run,
+        pypi_mirror=pypi_mirror,
+    )
+
+
 # Install click commands.
 cli.add_command(graph)
 cli.add_command(install)
@@ -1073,6 +1127,7 @@ cli.add_command(shell)
 cli.add_command(run)
 cli.add_command(update)
 cli.add_command(run_open)
+cli.add_command(index)
 # Only invoke the "did you mean" when an argument wasn't passed (it breaks those).
 if '-' not in ''.join(sys.argv) and len(sys.argv) > 1:
     cli = DYMCommandCollection(sources=[cli])

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -2619,3 +2619,41 @@ def do_clean(
             if c.return_code != 0:
                 failure = True
     sys.exit(int(failure))
+
+
+def do_add_index(ctx, url, name=None, three=None, python=None, dry_run=False, pypi_mirror=None):
+    # Ensure that virtualenv is available.
+    ensure_project(three=three, python=python, validate=False)
+    ensure_lockfile(pypi_mirror=pypi_mirror)
+    source = None
+
+    try:
+        source = project.get_source(url=url)
+    except SourceNotFound:
+        pass
+
+    if name:
+        try:
+            source = project.get_source(name=name)
+        except SourceNotFound:
+            pass
+
+    if source:
+        click.echo(
+            crayons.normal(
+                'Index {0} already existed.'.format(url)
+            )
+        )
+        sys.exit(0)
+
+    click.echo(
+        crayons.normal(
+            'Adding new index {0}.'.format(url),
+            bold=True
+        )
+    )
+
+    if not dry_run:
+        project.add_index_to_pipfile(url, name=name)
+
+    click.echo(crayons.green('Index has been updated!'))

--- a/pipenv/project.py
+++ b/pipenv/project.py
@@ -750,11 +750,13 @@ class Project(object):
         # Write Pipfile.
         self.write_toml(p)
 
-    def add_index_to_pipfile(self, index):
+    def add_index_to_pipfile(self, index, name=None):
         """Adds a given index to the Pipfile."""
         # Read and append Pipfile.
         p = self.parsed_pipfile
         source = {'url': index, 'verify_ssl': True}
+        if name:
+            source['name'] = name
         # Add the package to the group.
         if 'source' not in p:
             p['source'] = [source]

--- a/tests/integration/test_index.py
+++ b/tests/integration/test_index.py
@@ -1,0 +1,84 @@
+import os
+import shutil
+
+from pipenv.utils import temp_environ
+
+import pytest
+
+
+@pytest.mark.index
+def test_add_new_index(PipenvInstance):
+    with temp_environ(), PipenvInstance(chdir=True) as p:
+        mirror_url = "https://pypi.python.org/simple2"
+
+        c = p.pipenv('index {0} pypi2'.format(mirror_url))
+
+        assert c.return_code == 0
+
+        assert p.pipfile['source'] == [{
+            'url': 'https://pypi.org/simple',
+            'verify_ssl': True,
+            'name': 'pypi'
+        }, {
+            'url': 'https://pypi.python.org/simple2',
+            'verify_ssl': True,
+            'name': 'pypi2'
+        }]
+
+
+@pytest.mark.index
+def test_add_new_index_without_name(PipenvInstance):
+    with temp_environ(), PipenvInstance(chdir=True) as p:
+        mirror_url = "https://pypi.python.org/simple2"
+
+        c = p.pipenv('index {0}'.format(mirror_url))
+
+        assert c.return_code == 0
+        assert p.pipfile['source'] == [{
+            'url': 'https://pypi.org/simple',
+            'verify_ssl': True,
+            'name': 'pypi'
+        }, {
+            'url': mirror_url,
+            'verify_ssl': True,
+        }]
+
+
+@pytest.mark.index
+def test_existing_index_name(PipenvInstance):
+    with temp_environ(), PipenvInstance(chdir=True) as p:
+        c = p.pipenv('index https://pypi.python.org/simple2 pypi')
+
+        assert c.return_code == 0
+
+        assert p.pipfile['source'] == [{
+            'url': 'https://pypi.org/simple',
+            'verify_ssl': True,
+            'name': 'pypi'
+        }]
+
+
+@pytest.mark.index
+def test_existing_index_url(PipenvInstance):
+    with temp_environ(), PipenvInstance(chdir=True) as p:
+        c = p.pipenv('index https://pypi.org/simple pypi3')
+
+        assert c.return_code == 0
+        assert p.pipfile['source'] == [{
+            'url': 'https://pypi.org/simple',
+            'verify_ssl': True,
+            'name': 'pypi'
+        }]
+
+
+@pytest.mark.index
+def test_dry_run(PipenvInstance):
+    with temp_environ(), PipenvInstance(chdir=True) as p:
+        c = p.pipenv('index https://pypi.org/simple2 pypi2 --dry-run')
+
+        assert c.return_code == 0
+        assert p.pipfile['source'] == [{
+            'url': 'https://pypi.org/simple',
+            'verify_ssl': True,
+            'name': 'pypi'
+        }]

--- a/tests/integration/test_index.py
+++ b/tests/integration/test_index.py
@@ -7,8 +7,8 @@ import pytest
 
 
 @pytest.mark.index
-def test_add_new_index(PipenvInstance):
-    with temp_environ(), PipenvInstance(chdir=True) as p:
+def test_add_new_index(PipenvInstance, pypi):
+    with temp_environ(), PipenvInstance(pypi=pypi) as p:
         mirror_url = "https://pypi.python.org/simple2"
 
         c = p.pipenv('index {0} pypi2'.format(mirror_url))
@@ -16,9 +16,9 @@ def test_add_new_index(PipenvInstance):
         assert c.return_code == 0
 
         assert p.pipfile['source'] == [{
-            'url': 'https://pypi.org/simple',
+            'url': "{0}/simple".format(pypi.url),
             'verify_ssl': True,
-            'name': 'pypi'
+            'name': 'custom'
         }, {
             'url': 'https://pypi.python.org/simple2',
             'verify_ssl': True,
@@ -27,17 +27,17 @@ def test_add_new_index(PipenvInstance):
 
 
 @pytest.mark.index
-def test_add_new_index_without_name(PipenvInstance):
-    with temp_environ(), PipenvInstance(chdir=True) as p:
+def test_add_new_index_without_name(PipenvInstance, pypi):
+    with temp_environ(), PipenvInstance(pypi=pypi) as p:
         mirror_url = "https://pypi.python.org/simple2"
 
         c = p.pipenv('index {0}'.format(mirror_url))
 
         assert c.return_code == 0
         assert p.pipfile['source'] == [{
-            'url': 'https://pypi.org/simple',
+            'url': "{0}/simple".format(pypi.url),
             'verify_ssl': True,
-            'name': 'pypi'
+            'name': 'custom'
         }, {
             'url': mirror_url,
             'verify_ssl': True,
@@ -45,40 +45,41 @@ def test_add_new_index_without_name(PipenvInstance):
 
 
 @pytest.mark.index
-def test_existing_index_name(PipenvInstance):
-    with temp_environ(), PipenvInstance(chdir=True) as p:
-        c = p.pipenv('index https://pypi.python.org/simple2 pypi')
+def test_existing_index_name(PipenvInstance, pypi):
+    with temp_environ(), PipenvInstance(pypi=pypi) as p:
+        c = p.pipenv('index https://pypi.python.org/simple2 custom')
 
         assert c.return_code == 0
 
         assert p.pipfile['source'] == [{
-            'url': 'https://pypi.org/simple',
+            'url': "{0}/simple".format(pypi.url),
             'verify_ssl': True,
-            'name': 'pypi'
+            'name': 'custom'
         }]
 
 
 @pytest.mark.index
-def test_existing_index_url(PipenvInstance):
-    with temp_environ(), PipenvInstance(chdir=True) as p:
-        c = p.pipenv('index https://pypi.org/simple pypi3')
+def test_existing_index_url(PipenvInstance, pypi):
+    with temp_environ(), PipenvInstance(pypi=pypi) as p:
+        mirror_url = "{0}/simple".format(pypi.url)
+        c = p.pipenv('index {0} pypi3'.format(mirror_url))
 
         assert c.return_code == 0
         assert p.pipfile['source'] == [{
-            'url': 'https://pypi.org/simple',
+            'url': mirror_url,
             'verify_ssl': True,
-            'name': 'pypi'
+            'name': 'custom'
         }]
 
 
 @pytest.mark.index
-def test_dry_run(PipenvInstance):
-    with temp_environ(), PipenvInstance(chdir=True) as p:
+def test_dry_run(PipenvInstance, pypi):
+    with temp_environ(), PipenvInstance(pypi=pypi) as p:
         c = p.pipenv('index https://pypi.org/simple2 pypi2 --dry-run')
 
         assert c.return_code == 0
         assert p.pipfile['source'] == [{
-            'url': 'https://pypi.org/simple',
+            'url': "{0}/simple".format(pypi.url),
             'verify_ssl': True,
-            'name': 'pypi'
+            'name': 'custom'
         }]


### PR DESCRIPTION
__What__

In the same way as we we can add package to the `Pipfile` from the command line that would be convenient to be able to add a new source index.

__How__

This PR is proposing to add a new option called `index` to the command line to let people adds a new index from the cli interface.

It would be used like that:
```bash
$ pipenv index <name> <url>
```

By default if ever the `<name>` or the `<url>` already exists we just considered that the index already existed and just do nothing.

__Improvement__

We could possibly improve the clarity of the command by adding a verb to this new option: something like `add-index` would make sense.