### PR TITLE
Switch all update workflows to `pipenv lock/sync`

### DIFF
--- a/pipenv/cli.py
+++ b/pipenv/cli.py
@@ -840,7 +840,6 @@ def update(
     )
     do_sync(
         ctx=ctx,
-        install=install,
         dev=dev,
         three=three,
         python=python,
@@ -977,7 +976,6 @@ def sync(
 
     do_sync(
         ctx=ctx,
-        install=install,
         dev=dev,
         three=three,
         python=python,

--- a/pipenv/cli.py
+++ b/pipenv/cli.py
@@ -823,24 +823,6 @@ def update(
                 crayons.white('.', bold=True),
             )
         )
-        do_lock(
-            verbose=verbose, clear=clear, pre=pre, keep_outdated=keep_outdated, pypi_mirror=pypi_mirror
-        )
-        do_sync(
-            ctx=ctx,
-            install=install,
-            dev=dev,
-            three=three,
-            python=python,
-            bare=bare,
-            dont_upgrade=False,
-            user=False,
-            verbose=verbose,
-            clear=clear,
-            unused=False,
-            sequential=sequential,
-            pypi_mirror=pypi_mirror,
-        )
     else:
         for package in ([package] + list(more_packages) or []):
             if package not in project.all_packages:
@@ -853,28 +835,24 @@ def update(
                     err=True,
                 )
                 sys.exit(1)
-        ensure_lockfile(keep_outdated=project.lockfile_exists, pypi_mirror=pypi_mirror)
-        # Install the dependencies.
-        do_install(
-            package_name=package,
-            more_packages=more_packages,
-            dev=dev,
-            three=three,
-            python=python,
-            pypi_mirror=pypi_mirror,
-            system=system,
-            lock=True,
-            ignore_pipfile=False,
-            skip_lock=False,
-            verbose=verbose,
-            requirements=False,
-            sequential=sequential,
-            pre=pre,
-            code=False,
-            deploy=False,
-            keep_outdated=True,
-            selective_upgrade=True,
-        )
+    do_lock(
+        verbose=verbose, clear=clear, pre=pre, keep_outdated=keep_outdated, pypi_mirror=pypi_mirror
+    )
+    do_sync(
+        ctx=ctx,
+        install=install,
+        dev=dev,
+        three=three,
+        python=python,
+        bare=bare,
+        dont_upgrade=False,
+        user=False,
+        verbose=verbose,
+        clear=clear,
+        unused=False,
+        sequential=sequential,
+        pypi_mirror=pypi_mirror,
+    )
 
 
 @command(

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -2535,11 +2535,9 @@ def do_graph(bare=False, json=False, json_tree=False, reverse=False):
 
 def do_sync(
     ctx,
-    install,
     dev=False,
     three=None,
     python=None,
-    dry_run=False,
     bare=False,
     dont_upgrade=False,
     user=False,


### PR DESCRIPTION
- `pipenv update` currently doesn't actually run `pipenv lock`
- Semantics around this changed but it doesn't look like the code did
- `pipenv update` should operate similarly for all operations by running
`lock` followed by `sync`
- Fixes #2179