### PR TITLE
Use shell=False when "run" if possible on Windows

### DIFF
--- a/news/2385.feature
+++ b/news/2385.feature
@@ -1,0 +1,1 @@
+``pipenv run`` will now avoid spawning additional ``COMSPEC`` instances to run commands in when possible.``

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -2266,7 +2266,12 @@ def inline_activate_virtualenv():
 
 def do_run_nt(script):
     import subprocess
-    p = subprocess.Popen(script.cmdify(), shell=True, universal_newlines=True)
+    command = system_which(script.command)
+    options = {'universal_newlines': True}
+    if command:     # Try to use CreateProcess directly if possible.
+        p = subprocess.Popen([command] + script.args, **options)
+    else:   # Command not found, maybe this is a shell built-in?
+        p = subprocess.Popen(script.cmdify(), shell=True, **options)
     p.communicate()
     sys.exit(p.returncode)
 


### PR DESCRIPTION
Do a `where` on the command; if it is found, prevent the intermediate `COMSPEC` and use `CreateProcess` directly. Only use `shell=True` if the command is not an executable.

This prevents some unexpected behaviour caused by the intermediate shell process.