### PR TITLE
Ensure environs are strings on Python 2 + Windows

### DIFF
--- a/news/2386.bugfix
+++ b/news/2386.bugfix
@@ -1,0 +1,1 @@
+Patched ``python-dotenv`` to ensure that environment variables always get encoded to the filesystem encoding.

--- a/news/2386.vendor
+++ b/news/2386.vendor
@@ -1,0 +1,1 @@
+Patched ``python-dotenv`` to ensure that environment variables always get encoded to the filesystem encoding.

--- a/pipenv/vendor/dotenv/main.py
+++ b/pipenv/vendor/dotenv/main.py
@@ -94,6 +94,13 @@ class DotEnv():
         for k, v in self.dict().items():
             if k in os.environ and not override:
                 continue
+            # With Python 2 on Windows, ensuree environment variables are
+            # system strings to avoid "TypeError: environment can only contain
+            # strings" in Python's subprocess module.
+            if sys.version_info.major < 3 and sys.platform == 'win32':
+                from pipenv.utils import fs_str
+                k = fs_str(k)
+                v = fs_str(v)
             os.environ[k] = v
 
         return True

--- a/tasks/vendoring/patches/vendor/dotenv-windows-unicode.patch
+++ b/tasks/vendoring/patches/vendor/dotenv-windows-unicode.patch
@@ -1,0 +1,18 @@
+diff --git a/pipenv/vendor/dotenv/main.py b/pipenv/vendor/dotenv/main.py
+index 3d1bd72f..75f49c4a 100644
+--- a/pipenv/vendor/dotenv/main.py
++++ b/pipenv/vendor/dotenv/main.py
+@@ -94,6 +94,13 @@ class DotEnv():
+         for k, v in self.dict().items():
+             if k in os.environ and not override:
+                 continue
++            # With Python 2 on Windows, ensuree environment variables are
++            # system strings to avoid "TypeError: environment can only contain
++            # strings" in Python's subprocess module.
++            if sys.version_info.major < 3 and sys.platform == 'win32':
++                from pipenv.utils import fs_str
++                k = fs_str(k)
++                v = fs_str(v)
+             os.environ[k] = v
+
+         return True


### PR DESCRIPTION
Patch based on theskumar/python-dotenv#101 by @greyli.