### PR TITLE
Fix pipenv crashes 

### DIFF
--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -1889,6 +1889,8 @@ def do_install(
     # Capture -e argument and assign it to following package_name.
     more_packages = list(more_packages)
     if package_name == '-e':
+        if not more_packages:
+            raise click.BadArgumentUsage('Please provide path to setup.py')
         package_name = ' '.join([package_name, more_packages.pop(0)])
     # capture indexes and extra indexes
     line = [package_name] + more_packages

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -1890,7 +1890,7 @@ def do_install(
     more_packages = list(more_packages)
     if package_name == '-e':
         if not more_packages:
-            raise click.BadArgumentUsage('Please provide path to setup.py')
+            raise click.BadArgumentUsage('Please provide path to editable package')
         package_name = ' '.join([package_name, more_packages.pop(0)])
     # capture indexes and extra indexes
     line = [package_name] + more_packages

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -1897,6 +1897,8 @@ def do_install(
     index_indicators = ['-i', '--index', '--extra-index-url']
     index, extra_indexes = None, None
     if more_packages and any(more_packages[0].startswith(s) for s in index_indicators):
+        if len(more_packages) < 2:
+            raise click.BadArgumentUsage('Please provide index value')
         line, index = split_argument(' '.join(line), short='i', long_='index', num=1)
         line, extra_indexes = split_argument(line, long_='extra-index-url')
         package_names = line.split()

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -1893,7 +1893,8 @@ def do_install(
             raise click.BadArgumentUsage('Please provide path to editable package')
         package_name = ' '.join([package_name, more_packages.pop(0)])
     # capture indexes and extra indexes
-    line = ' '.join([package_name] + more_packages).strip()
+    line = [package_name] + more_packages
+    line = ' '.join(str(s) for s in line).strip()
     index_indicators = ['-i', '--index', '--extra-index-url']
     index, extra_indexes = None, None
     if any(line.endswith(s) for s in index_indicators):

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -1893,13 +1893,14 @@ def do_install(
             raise click.BadArgumentUsage('Please provide path to editable package')
         package_name = ' '.join([package_name, more_packages.pop(0)])
     # capture indexes and extra indexes
-    line = [package_name] + more_packages
+    line = ' '.join([package_name] + more_packages).strip()
     index_indicators = ['-i', '--index', '--extra-index-url']
     index, extra_indexes = None, None
-    if more_packages and any(more_packages[0].startswith(s) for s in index_indicators):
-        if len(more_packages) < 2:
-            raise click.BadArgumentUsage('Please provide index value')
-        line, index = split_argument(' '.join(line), short='i', long_='index', num=1)
+    if any(line.endswith(s) for s in index_indicators):
+        # check if cli option is not end of command
+        raise click.BadArgumentUsage('Please provide index value')
+    if any(s in line for s in index_indicators):
+        line, index = split_argument(line, short='i', long_='index', num=1)
         line, extra_indexes = split_argument(line, long_='extra-index-url')
         package_names = line.split()
         package_name = package_names[0]


### PR DESCRIPTION
Add extra checks for CLI params for preventing unexpected crashes and add the more informal message for that exceptions. 

To reproduce those bugs type following command in the terminal.
```bash
$ pipenv install -e
Traceback (most recent call last):
  File "/usr/local/bin/pipenv", line 11, in <module>
    load_entry_point('pipenv', 'console_scripts', 'pipenv')()
  File "/Users/maxkrivich/Projects/pipenv/pipenv/vendor/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/Users/maxkrivich/Projects/pipenv/pipenv/vendor/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/Users/maxkrivich/Projects/pipenv/pipenv/vendor/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/maxkrivich/Projects/pipenv/pipenv/vendor/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/maxkrivich/Projects/pipenv/pipenv/vendor/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/Users/maxkrivich/Projects/pipenv/pipenv/cli.py", line 416, in install
    selective_upgrade=selective_upgrade,
  File "/Users/maxkrivich/Projects/pipenv/pipenv/core.py", line 1892, in do_install
    package_name = ' '.join([package_name, more_packages.pop(0)])
IndexError: pop from empty list

$ pipenv install <some_module> -i
/Users/maxkrivich/Projects/pipenv/pipenv/vendor/requirements/parser.py:44: UserWarning: Private repos not supported. Skipping.
  warnings.warn('Private repos not supported. Skipping.')
Traceback (most recent call last):
  File "/usr/local/bin/pipenv", line 11, in <module>
    load_entry_point('pipenv', 'console_scripts', 'pipenv')()
  File "/Users/maxkrivich/Projects/pipenv/pipenv/vendor/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/Users/maxkrivich/Projects/pipenv/pipenv/vendor/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/Users/maxkrivich/Projects/pipenv/pipenv/vendor/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/maxkrivich/Projects/pipenv/pipenv/vendor/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/maxkrivich/Projects/pipenv/pipenv/vendor/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/Users/maxkrivich/Projects/pipenv/pipenv/cli.py", line 416, in install
    selective_upgrade=selective_upgrade,
  File "/Users/maxkrivich/Projects/pipenv/pipenv/core.py", line 1987, in do_install
    pypi_mirror=pypi_mirror,
  File "/Users/maxkrivich/Projects/pipenv/pipenv/core.py", line 1408, in pip_install
    package_name.split('--hash')[0].split('--trusted-host')[0]
  File "/Users/maxkrivich/Projects/pipenv/pipenv/vendor/requirementslib/models/requirements.py", line 717, in from_line
    r = NamedRequirement.from_line(line)
  File "/Users/maxkrivich/Projects/pipenv/pipenv/vendor/requirementslib/models/requirements.py", line 75, in from_line
    if req.specifier:
AttributeError: 'NoneType' object has no attribute 'specifier'
```