### PR TITLE
Remove leading dashes in venv names

### DIFF
--- a/pipenv/project.py
+++ b/pipenv/project.py
@@ -260,11 +260,15 @@ class Project(object):
         #      127 : BINPRM_BUF_SIZE - 1
         #       32 : Maximum length of username
         #
+        # Also remove leading dashes to avoid names being interpreted as
+        # arguments to external commands.
+        #
         # References:
         #   https://www.gnu.org/software/bash/manual/html_node/Double-Quotes.html
         #   http://www.tldp.org/LDP/abs/html/special-chars.html#FIELDREF
         #   https://github.com/torvalds/linux/blob/2bfe01ef/include/uapi/linux/binfmts.h#L18
-        return re.sub(r'[ $`!*@"\\\r\n\t]', '_', name)[0:42]
+        sanitized_name = re.sub(r'[ $`!*@"\\\r\n\t]', '_', name).lstrip('-')
+        return sanitized_name[0:42]
 
     def _get_virtualenv_hash(self, name):
         """Get the name of the virtualenv adjusted for windows if needed

--- a/tests/unit/test_project.py
+++ b/tests/unit/test_project.py
@@ -1,0 +1,10 @@
+from pipenv.project import Project
+
+import pytest
+
+
+@pytest.mark.project
+def test_virtualenv_name():
+    project = Project()
+    project._name = '-directory-with-dash'
+    assert not project.virtualenv_name.startswith('-')


### PR DESCRIPTION
This is designed to fix issue #439 without causing a breaking change; it does so by removing only leading slashes, instead of prohibiting slashes anywhere in the virtualenv name, as the original issue proposed.

I slightly changed how `Project._sanitize()` works, but it's not the only potential solution. Another option would be to change how `do_create_virtualenv()` calls `pew`; a double dash could be used to separate options from positional arguments and then even a virtualenv name that started with a dash would work. That change would look something like this:

```diff
--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -914,7 +914,6 @@ def do_create_virtualenv(python=None, site_packages=False):
             '-m',
             'pipenv.pew',
             'new',
-            project.virtualenv_name,
             '-d',
             '-a',
             project.project_directory,
@@ -932,6 +931,10 @@ def do_create_virtualenv(python=None, site_packages=False):
         err=True,
     )
     cmd = cmd + ['-p', python]
+
+    if not project.is_venv_in_project():
+        cmd = cmd + ['--', project.virtualenv_name]
+
     # Actually create the virtualenv.
     with spinner():
         try:
```

However, it seems to me that changing the name sanitizing method is a better choice for the following reasons:

1. It's easier and faster to test
Checking a string in a unit test is a fast and easily understood operation. While admittedly the context for the test could be lost if its broader purpose is not made clear, that seems like a decent tradeoff when considering the other option. Changing how `pew` is invoked in `pipenv` necessitates a slow integration test that relies on calling external code. Furthermore, it would require either extensive changes to the `_PipenvInstance` and `TemporaryDirectory` classes to allow specifying a temp dir with a defined name (think `/tmp/-dir-with-leading-dash`) or a lot of messy one-off setup and teardown logic.
2. It potentially covers other edge cases
Should `virtualenv_name` be passed to other external commands, options and positional args would not need to be separated by the double dash. Given that a bug of this nature would be stubborn and hard to find, this PR has the potential save a lot of time by preventing other issues before they are introduced.