### PR TITLE
Install Jinja2 templates for click_completion

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -116,6 +116,7 @@ setup(
         '': ['LICENSE', 'NOTICES'],
         "pipenv.vendor.requests": ["*.pem"],
         "pipenv.vendor.certifi": ["*.pem"],
+        "pipenv.vendor.click_completion": ["*.j2"],
         "pipenv.patched.notpip._vendor.certifi": ["*.pem"],
         "pipenv.patched.notpip._vendor.requests": ["*.pem"],
         "pipenv.patched.notpip._vendor.distlib._backport": ["sysconfig.cfg"],


### PR DESCRIPTION
The new version of click_completion requires its Jinja2 templates to be installed along with the package in order to work. If not, any invocation of `pipenv --completion` results in a `jinja2.exceptions.TemplateNotFound` for the template in question.

I’ve just trivially added the pattern to `setup.py`, and tested that it works.