### PR TITLE
prettytoml: Catch StopIteration in AbstractTable._enumerate_items

### DIFF
--- a/news/2426.vendor
+++ b/news/2426.vendor
@@ -1,0 +1,1 @@
+Add patch to ``prettytoml`` to support Python 3.7.

--- a/tasks/vendoring/patches/patched/_post-pip-update-pep425tags.patch
+++ b/tasks/vendoring/patches/patched/_post-pip-update-pep425tags.patch
@@ -18,7 +18,7 @@ index c9804ab5..89c95c45 100644
          pass
  
      # Check glibc version. CentOS 5 uses glibc 2.5.
--    return pipenv.patched.notpip._internal.utils.glibc.have_compatible_glibc(2, 5)
+-    return pip._internal.utils.glibc.have_compatible_glibc(2, 5)
 +    return pipenv.patched.notpip._internal.utils.glibc.have_compatible_glibc(2, 5)
  
  

--- a/tasks/vendoring/patches/patched/prettytoml-python37.patch
+++ b/tasks/vendoring/patches/patched/prettytoml-python37.patch
@@ -1,0 +1,32 @@
+From c44f2126fb5c75a5f5afd9d320c9f6cfc4ce3384 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Miro=20Hron=C4=8Dok?= <miro@hroncok.cz>
+Date: Tue, 26 Jun 2018 21:02:45 +0200
+Subject: [PATCH] Catch StopIteration in AbstractTable._enumerate_items
+
+This makes PEP 479 enabled Pythons (such as 3.7) work again.
+
+Otherwise you get:
+
+    RuntimeError: generator raised StopIteration
+
+Fixes https://github.com/pypa/pipenv/issues/2426
+---
+ pipenv/patched/prettytoml/elements/abstracttable.py | 5 ++++-
+ 1 file changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/pipenv/patched/prettytoml/elements/abstracttable.py b/pipenv/patched/prettytoml/elements/abstracttable.py
+index 59fd574..627da0e 100644
+--- a/pipenv/patched/prettytoml/elements/abstracttable.py
++++ b/pipenv/patched/prettytoml/elements/abstracttable.py
+@@ -19,7 +19,10 @@ def _enumerate_items(self):
+         """
+         non_metadata = self._enumerate_non_metadata_sub_elements()
+         while True:
+-            yield next(non_metadata), next(non_metadata)
++            try:
++                yield next(non_metadata), next(non_metadata)
++            except StopIteration:
++                return
+ 
+     def items(self):
+         for (key_i, key), (value_i, value) in self._enumerate_items():


### PR DESCRIPTION
This makes PEP 479 enabled Pythons (such as 3.7) work again.

Otherwise you get:

    RuntimeError: generator raised StopIteration

Fixes https://github.com/pypa/pipenv/issues/2426

------


Untested. The vendoring script fails with unrelated problem.