### PR TITLE
Avoid double `pip` output if `--verbose` is used an output includes "Ignoring"

### DIFF
--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -730,7 +730,7 @@ def do_install_dependencies(
                 c.block()
             if 'Ignoring' in c.out:
                 click.echo(crayons.yellow(c.out.strip()))
-            if verbose:
+            elif verbose:
                 click.echo(crayons.blue(c.out or c.err))
             # The Installation failed...
             if c.return_code != 0:


### PR DESCRIPTION
If the `pip` output already has been printed due to it containing the string "Ignoring", then avoid printing it again if `--verbose` is enabled.

Ironically, in my simple test of this (`pipenv install --verbose` in a ) the "Ignoring" string is only included in the `pip` output if `--verbose` is supplied.

I've tried to make a screenshot of it here to show the problem, but I had to make it quite small in order to fit it all on screen. You can however see that the yellow and blue output is duplicated:
![screen shot 2018-06-28 at 11 57 32](https://user-images.githubusercontent.com/68696/42030424-a84a6456-7aca-11e8-84bc-04585219abf2.png)