### PR TITLE
Add `python_requires` in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -132,7 +132,6 @@ setup(
         'Programming Language :: Python',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',

--- a/setup.py
+++ b/setup.py
@@ -122,6 +122,7 @@ setup(
         "pipenv.patched.notpip._vendor.distlib._backport": ["sysconfig.cfg"],
         "pipenv.patched.notpip._vendor.distlib": ["t32.exe", "t64.exe", "w32.exe", "w64.exe"],
     },
+    python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*',
     install_requires=required,
     extras_require={},
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -122,7 +122,7 @@ setup(
         "pipenv.patched.notpip._vendor.distlib._backport": ["sysconfig.cfg"],
         "pipenv.patched.notpip._vendor.distlib": ["t32.exe", "t64.exe", "w32.exe", "w64.exe"],
     },
-    python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*',
+    python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*',
     install_requires=required,
     extras_require={},
     include_package_data=True,


### PR DESCRIPTION
This argument prevents accident install `pipenv` on not supported python versions.

The syntax for this string you can find in [PEP440](https://www.python.org/dev/peps/pep-0440/).

Note: this feature works with pip 9.0+.