### PR TITLE
Fix `UnicodeEncodeError` in help.py

### DIFF
--- a/pipenv/help.py
+++ b/pipenv/help.py
@@ -9,6 +9,13 @@ from .core import project, system_which, find_python_in_path, python_version
 from .pep508checker import lookup
 
 
+def print_utf(line):
+    try:
+        print(line)
+    except UnicodeEncodeError:
+        print(line.encode('utf-8'))
+
+
 def main():
     print('<details><summary>$ python -m pipenv.help output</summary>')
     print('')
@@ -45,13 +52,13 @@ def main():
     for key in os.environ:
         print('  - `{0}`'.format(key))
     print('')
-    print(u'Pipenv–specific environment variables:')
+    print_utf(u'Pipenv–specific environment variables:')
     print('')
     for key in os.environ:
         if key.startswith('PIPENV'):
             print(' - `{0}`: `{1}`'.format(key, os.environ[key]))
     print('')
-    print(u'Debug–specific environment variables:')
+    print_utf(u'Debug–specific environment variables:')
     print('')
     for key in ('PATH', 'SHELL', 'EDITOR', 'LANG', 'PWD', 'VIRTUAL_ENV'):
         if key in os.environ:
@@ -61,7 +68,7 @@ def main():
     print('---------------------------')
     print('')
     if project.pipfile_exists:
-        print(
+        print_utf(
             u'Contents of `Pipfile` ({0!r}):'.format(project.pipfile_location)
         )
         print('')
@@ -72,7 +79,7 @@ def main():
         print('')
     if project.lockfile_exists:
         print('')
-        print(
+        print_utf(
             u'Contents of `Pipfile.lock` ({0!r}):'.format(
                 project.lockfile_location
             )
@@ -87,3 +94,4 @@ def main():
 
 if __name__ == '__main__':
     main()
+


### PR DESCRIPTION
I don't know why but on MacOS  when you execute this command `python -m pipenv.help` and redirect output stream to some another file, script fails with exception. 

```bash
$ python -m pipenv.help > test.txt 
Traceback (most recent call last):
  File "/usr/local/Cellar/python@2/2.7.15/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py", line 174, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/usr/local/Cellar/python@2/2.7.15/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/Users/maxkrivich/Projects/pipenv/pipenv/help.py", line 89, in <module>
    main()
  File "/Users/maxkrivich/Projects/pipenv/pipenv/help.py", line 48, in main
    print(u'Pipenv–specific environment variables:')
UnicodeEncodeError: 'ascii' codec can't encode character u'\u2013' in position 6: ordinal not in range(128)
```