### PR TITLE
Feature/2477

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,14 +1,10 @@
 Be sure to check the existing issues (both open and closed!).
 
-Describe the issue briefly here.
-
-Please run `$ python -m pipenv.help`, and paste the results here.
-
-If you're on MacOS, just run the following:
-
-    $ python -m pipenv.help | pbcopy
-
 ------------
+
+##### Issue description
+
+Describe the issue briefly here.
 
 ##### Expected result
 
@@ -21,3 +17,15 @@ When possible, provide the verbose output (`--verbose`), especially for locking 
 ##### Steps to replicate
 
 Provide the steps to replicate (which usually at least includes the commands and the Pipfile).
+
+-------------
+
+Please run `$ pipenv --support`, and paste the results here. Don't put backticks (`` ` ``) around it! The output already contains Markdown formatting.
+
+If you're on macOS, run the following:
+
+    $ pipenv --support | pbcopy
+
+If you're on Windows, run the following:
+
+    > pipenv --support | clip

--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -6,15 +6,11 @@ about: Create a report to help us improve
 
 Be sure to check the existing issues (both open and closed!).
 
-Describe the issue briefly here.
-
-Please run `$ python -m pipenv.help`, and paste the results here.
-
-If you're on MacOS, just run the following:
-
-    $ python -m pipenv.help | pbcopy
-
 ------------
+
+##### Issue description
+
+Describe the issue briefly here.
 
 ##### Expected result
 
@@ -27,3 +23,15 @@ When possible, provide the verbose output (`--verbose`), especially for locking 
 ##### Steps to replicate
 
 Provide the steps to replicate (which usually at least includes the commands and the Pipfile).
+
+-------------
+
+Please run `$ pipenv --support`, and paste the results here. Don't put backticks (`` ` ``) around it! The output already contains Markdown formatting.
+
+If you're on macOS, run the following:
+
+    $ pipenv --support | pbcopy
+
+If you're on Windows, run the following:
+
+    > pipenv --support | clip

--- a/.github/ISSUE_TEMPLATE/Custom.md
+++ b/.github/ISSUE_TEMPLATE/Custom.md
@@ -5,3 +5,18 @@ about: Requests for assistance or general usage guidance.
 ---
 
 Please refer to our [StackOverflow tag](https://stackoverflow.com/questions/tagged/pipenv) for more information.
+
+If Pipenv is not functioning as you would like it to, consider filing either a bug report, or a feature request instead.
+
+
+-------------
+
+Please run `$ pipenv --support`, and paste the results here. Don't put backticks (`` ` ``) around it! The output already contains Markdown formatting.
+
+If you're on macOS, run the following:
+
+    $ pipenv --support | pbcopy
+
+If you're on Windows, run the following:
+
+    > pipenv --support | clip

--- a/.github/ISSUE_TEMPLATE/Feature_request.md
+++ b/.github/ISSUE_TEMPLATE/Feature_request.md
@@ -4,14 +4,20 @@ about: Suggest an idea for this project
 
 ---
 
-**Is your feature request related to a problem? Please describe.**
+Be sure to check the existing issues (both open and closed!).
+
+##### Is your feature request related to a problem? Please describe.
+
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
 
-**Describe the solution you'd like**
+##### Describe the solution you'd like
+
 A clear and concise description of what you want to happen.
 
-**Describe alternatives you've considered**
+##### Describe alternatives you've considered
+
 A clear and concise description of any alternative solutions or features you've considered.
 
-**Additional context**
-Add any other context or screenshots about the feature request here.
+##### Additional context
+
+Add any other context or screenshots about the feature request here. It may be a good idea to mention that platform and Python version you are on.

--- a/news/2477.feature
+++ b/news/2477.feature
@@ -1,0 +1,1 @@
+Added new flag `pipenv --support` to replace the diagnostic command `python -m pipenv.help`.

--- a/news/2477.feature
+++ b/news/2477.feature
@@ -1,1 +1,1 @@
-Added new flag `pipenv --support` to replace the diagnostic command `python -m pipenv.help`.
+Added new flag ``pipenv --support`` to replace the diagnostic command ``python -m pipenv.help``.

--- a/pipenv/cli.py
+++ b/pipenv/cli.py
@@ -152,6 +152,11 @@ def validate_pypi_mirror(ctx, param, value):
     callback=validate_pypi_mirror,
     help="Specify a PyPI mirror.",
 )
+@option(
+    '--support',
+    is_flag=True,
+    help="Output diagnostic information for use in Github issues."
+)
 @version_option(
     prog_name=crayons.normal('pipenv', bold=True), version=__version__
 )
@@ -171,6 +176,7 @@ def cli(
     man=False,
     completion=False,
     pypi_mirror=None,
+    support=None
 ):
     if completion:  # Handle this ASAP to make shell startup fast.
         from . import shells
@@ -229,6 +235,10 @@ def cli(
         elif py:
             do_py()
             sys.exit()
+        elif support:
+            from .help import get_pipenv_diagnostics
+            get_pipenv_diagnostics()
+            sys.exit(0)
         # --venv was passed...
         elif venv:
             # There is no virtualenv yet.

--- a/pipenv/cli.py
+++ b/pipenv/cli.py
@@ -235,6 +235,7 @@ def cli(
         elif py:
             do_py()
             sys.exit()
+        # --support was passed...
         elif support:
             from .help import get_pipenv_diagnostics
             get_pipenv_diagnostics()

--- a/pipenv/help.py
+++ b/pipenv/help.py
@@ -16,8 +16,8 @@ def print_utf(line):
         print(line.encode('utf-8'))
 
 
-def main():
-    print('<details><summary>$ python -m pipenv.help output</summary>')
+def get_pipenv_diagnostics():
+    print('<details><summary>$ pipenv --support</summary>')
     print('')
     print('Pipenv version: `{0!r}`'.format(__version__))
     print('')
@@ -93,5 +93,5 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    get_pipenv_diagnostics()
 

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -32,6 +32,12 @@ def test_pipenv_py(PipenvInstance):
 
 
 @pytest.mark.cli
+def test_pipenv_support(PipenvInstance):
+    with PipenvInstance() as p:
+        assert p.pipenv('--support').out
+
+
+@pytest.mark.cli
 def test_pipenv_rm(PipenvInstance):
     with PipenvInstance() as p:
         p.pipenv('--python python')


### PR DESCRIPTION
Change `python -m pipenv.help` to `pipenv --support`.

Note. `python -m pipenv.help` is still supported but should only be used in cases when it's requested.