### PR TITLE
Allow passing options of commands via environment variables

### DIFF
--- a/pipenv/cli.py
+++ b/pipenv/cli.py
@@ -286,6 +286,9 @@ def cli(
         # Display help to user, if no commands were passed.
         echo(format_help(ctx.get_help()))
 
+    # Allow passing options of commands via environment variables.
+    ctx.auto_envvar_prefix = 'PIPENV'
+
 
 @command(
     short_help="Installs provided packages and adds them to Pipfile, or (if none is given), installs all packages.",


### PR DESCRIPTION
We would like to provide a way to automatically submit options during builds via environment variables. This is not a standard way how to enable click's `auto_envvar_prefix`, but it works with `console_scripts` entrypoint.