### PR TITLE
Change "Github Pull Pipenv" to "Github Pull Requests" in contributing.rst

### DIFF
--- a/docs/dev/contributing.rst
+++ b/docs/dev/contributing.rst
@@ -76,7 +76,7 @@ When contributing code, you'll want to follow this checklist:
 5. Run the entire test suite again, confirming that all tests pass *including
    the ones you just added*.
 6. Send a GitHub Pull Request to the main repository's ``master`` branch.
-   GitHub Pull Pipenv are the expected method of code collaboration on this
+   GitHub Pull Requests are the expected method of code collaboration on this
    project.
 
 The following sub-sections go into more detail on some of the points above.


### PR DESCRIPTION
Pretty straight forward change. This seemed like a typo to me. I'm assuming this file is used to generate https://docs.pipenv.org/dev/contributing/ as well.