### PR TITLE
WIP: Added pyinstaller docker for pipenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,11 @@ Otherwise, just use pip:
 
     $ pip install pipenv
 
+Or, to make a single file binary executable in `dist`:
+
+    $ docker-compose build
+    $ docker-compose run -e USERID=$(id -u) -e GROUPID=$(id -g) pipenv-dist
+
 ✨🍰✨
 
 ☤ User Testimonials

--- a/dist.Dockerfile
+++ b/dist.Dockerfile
@@ -1,0 +1,24 @@
+FROM python:3.6.6-slim-stretch
+
+SHELL ["/usr/bin/env", "bash", "-euxvc"]
+
+RUN apt-get update; \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends binutils wget; \
+    wget https://github.com/tianon/gosu/releases/download/1.10/gosu-amd64 -O /usr/local/bin/gosu; \
+    chmod 755 /usr/local/bin/gosu; \
+    DEBIAN_FRONTEND=noninteractive apt-get purge --auto-remove -y wget; \
+    rm -rf /var/lib/apt/lists/*
+
+RUN pip install pyinstaller six
+
+
+RUN chmod 755 /usr/local/bin/gosu; \
+    echo "from pipenv import cli; cli()" > /usr/local/bin/pipenv
+
+CMD groupadd -g ${GROUPID-1000} user; \
+    useradd -u ${USERID-1000} -g user user; \
+    cd /pipenv; \
+    gosu user pyinstaller -p ./pipenv/patched/ \
+                -p ./pipenv/vendor/ \
+                --onefile \
+                /usr/local/bin/pipenv

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,3 +5,11 @@ services:
     command: bash /pipenv/run-tests.sh
     volumes:
       - .:/pipenv
+
+  pipenv-dist:
+    build:
+      context: .
+      dockerfile: dist.Dockerfile
+    image: pipenv-dist
+    volumes:
+      - .:/pipenv


### PR DESCRIPTION
Here's a PR for a docker image so that you can make a single file Linux executable, in case you want this.

This makes installing pipenv into an OS/user environment a lot easier with no dependencies or virtual env needed.

