### PR TITLE
Delete "Changing Where Pipenv Stores Virtualenvs"

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -548,11 +548,6 @@ This will tell Pipenv to lock all your ``setup.py``–declared dependencies.
 
 You can force Pipenv to use a different cache location by setting the environment variable ``PIPENV_CACHE_DIR`` to the location you wish. This is useful in the same situations that you would change ``PIP_CACHE_DIR`` to a different directory.
 
-☤ Changing Where Pipenv Stores Virtualenvs
-------------------------------------------
-
-By default, Pipenv stores all of your virtualenvs in a single place.  Usually this isn't a problem, but if you'd like to change it for developer ergonomics, or if it's causing issues on build servers you can set ``PIPENV_VENV_IN_PROJECT`` to create the virtualenv inside the root of your project.
-
 ☤ Changing Default Python Versions
 ----------------------------------
 


### PR DESCRIPTION
It's a partial duplicate of the "Custom Virtual Environment Location" section.