### PR TITLE
Add vendoring documentation

### DIFF
--- a/pipenv/vendor/README.md
+++ b/pipenv/vendor/README.md
@@ -10,6 +10,8 @@ Requires:
 
 - [invoke](https://pypi.org/project/invoke/)
 
+- [pip](https://pypi.org/project/pip/)
+
 Modify the pip requirements file `vendor.txt`. Reference the [pip
 documenation](https://pip.pypa.io/en/stable/user_guide/#requirements-files).
 Execute the vendoring update script:

--- a/pipenv/vendor/README.md
+++ b/pipenv/vendor/README.md
@@ -4,8 +4,18 @@ These packages are copied as-is from upstream to reduce Pipenv dependencies.
 They should always be kept synced with upstream. DO NOT MODIFY DIRECTLY! If
 you need to patch anything, move the package to `patched`.
 
-Known vendored versions:
+## Updatating Vendored Packages
+
+Requires:
+
+- [invoke](https://pypi.org/project/invoke/)
+
+Modify the pip requirements file `vendor.txt`. Reference the [pip
+documenation](https://pip.pypa.io/en/stable/user_guide/#requirements-files).
+Execute the vendoring update script:
+
+```$ invoke vendoring.update```
+
+## Known vendored versions:
 
 - python-dotenv: 0.8.2
-
-When updating, update the corresponding LICENSE files as well.


### PR DESCRIPTION
Added a simple workflow for updating vendored packages to `pipenv/vendor/README.md`.

Removed the line about updating license files, because the vendoring scripts do this automagically.