### PR TITLE
Serialize prettytoml ArrayElements as lists

### DIFF
--- a/pipenv/project.py
+++ b/pipenv/project.py
@@ -78,8 +78,8 @@ class _LockFileEncoder(json.JSONEncoder):
         )
 
     def default(self, obj):
-        from prettytoml.elements.common import ContainerElement
-        if isinstance(obj, ContainerElement):
+        from prettytoml.elements.common import ContainerElement, TokenElement
+        if isinstance(obj, (ContainerElement, TokenElement)):
             return obj.primitive_value
         return super(_LockFileEncoder, self).default(obj)
 

--- a/pipenv/project.py
+++ b/pipenv/project.py
@@ -64,6 +64,12 @@ def _normalized(p):
 DEFAULT_NEWLINES = u"\n"
 
 
+def encode_toml_elements(obj):
+    if hasattr(obj, 'primitive_value'):
+        return obj.primitive_value
+    raise TypeError(repr(obj) + " is not JSON serializable")
+
+
 def preferred_newlines(f):
     if isinstance(f.newlines, six.text_type):
         return f.newlines
@@ -631,7 +637,8 @@ class Project(object):
         """
         newlines = self._lockfile_newlines
         s = simplejson.dumps(  # Send Unicode in to guarentee Unicode out.
-            content, indent=4, separators=(u",", u": "), sort_keys=True
+            content, indent=4, separators=(u",", u": "), sort_keys=True,
+            default=encode_toml_elements,
         )
         with atomic_open_for_write(self.lockfile_location, newline=newlines) as f:
             f.write(s)

--- a/tests/integration/test_lock.py
+++ b/tests/integration/test_lock.py
@@ -1,6 +1,5 @@
 import pytest
 import os
-import six
 
 from pipenv.utils import temp_environ
 
@@ -344,6 +343,27 @@ requests = {git = "https://github.com/requests/requests.git", ref = "master", ed
         assert 'requests' in p.lockfile['default']
         assert 'idna' in p.lockfile['default']
         assert 'chardet' in p.lockfile['default']
+        c = p.pipenv('install')
+        assert c.return_code == 0
+
+
+@pytest.mark.extras
+@pytest.mark.lock
+@pytest.mark.vcs
+@pytest.mark.needs_internet
+def test_lock_editable_vcs_with_extras_without_install(PipenvInstance, pypi):
+    with PipenvInstance(pypi=pypi, chdir=True) as p:
+        with open(p.pipfile_path, 'w') as f:
+            f.write("""
+[packages]
+requests = {git = "https://github.com/requests/requests.git", editable = true, extras = ["socks"]}
+            """.strip())
+        c = p.pipenv('lock')
+        assert c.return_code == 0
+        assert 'requests' in p.lockfile['default']
+        assert 'idna' in p.lockfile['default']
+        assert 'chardet' in p.lockfile['default']
+        assert "socks" in p.lockfile["default"]["requests"]["extras"]
         c = p.pipenv('install')
         assert c.return_code == 0
 


### PR DESCRIPTION
Applies the fix suggested in https://github.com/pypa/pipenv/issues/2504#issuecomment-402853014

Resolves #2504

I couldn't find a quick/easy way to test this locally before pushing (just saw the Makefile), so using buildkite to test a bit blind. 😅