### PR TITLE
Only quote arguments during cmdify if needed

### DIFF
--- a/news/2563.bugfix
+++ b/news/2563.bugfix
@@ -1,0 +1,2 @@
+Improve quoting logic for ``pipenv run`` so it works better with Windows
+built-in commands.

--- a/pipenv/cmdparse.py
+++ b/pipenv/cmdparse.py
@@ -55,11 +55,18 @@ class Script(object):
 
         The result is then quoted into a pair of double quotes to be grouped.
 
+        An argument is intentionally not quoted if it does not contain
+        whitespaces. This is done to be compatible with Windows built-in
+        commands that don't work well with quotes, e.g. everything with `echo`,
+        and DOS-style (forward slash) switches.
+
         The intended use of this function is to pre-process an argument list
         before passing it into ``subprocess.Popen(..., shell=True)``.
 
         See also: https://docs.python.org/3/library/subprocess.html#converting-argument-sequence
         """
         return " ".join(
-            '"{0}"'.format(re.sub(r'(\\*)"', r'\1\1\\"', arg)) for arg in self._parts
+            arg if not next(re.finditer(r'\s', arg), None)
+            else '"{0}"'.format(re.sub(r'(\\*)"', r'\1\1\\"', arg))
+            for arg in self._parts
         )

--- a/tests/unit/test_cmdparse.py
+++ b/tests/unit/test_cmdparse.py
@@ -30,9 +30,9 @@ def test_extend():
 @pytest.mark.run
 @pytest.mark.script
 def test_cmdify():
-    script = Script('python', ['-c', "print('hello')"])
+    script = Script('python', ['-c', "print('hello world')"])
     cmd = script.cmdify()
-    assert cmd == '"python" "-c" "print(\'hello\')"', script
+    assert cmd == 'python -c "print(\'hello world\')"', script
 
 
 @pytest.mark.run
@@ -44,6 +44,6 @@ def test_cmdify_complex():
     ]))
     assert script.cmdify() == ' '.join([
         '"C:\\Program Files\\Python36\\python.exe"',
-        '"-c"',
+        '-c',
         """ "print(\'Double quote: \\\"\')" """.strip(),
     ]), script


### PR DESCRIPTION
Windows built-in commands don't always work well with quotes.

```cmd
rem The path can be interpreted correctly, but not "/w".
dir "/w" "C:\"

rem Outputs "foo" "bar", with quotes!
echo "foo" "bar"
```

The solution (I think) is to be less aggressive. Only quote things if they need to be quoted (i.e. contains whitespaces).