### PR TITLE
fix bug: DotEnv._get_stream raise IOError when ".env" is a directory rather than a file

### DIFF
--- a/pipenv/vendor/dotenv/main.py
+++ b/pipenv/vendor/dotenv/main.py
@@ -243,7 +243,7 @@ def find_dotenv(filename='.env', raise_error_if_not_found=False, usecwd=False):
 
     for dirname in _walk_to_root(path):
         check_path = os.path.join(dirname, filename)
-        if os.path.exists(check_path):
+        if os.path.isfile(check_path):
             return check_path
 
     if raise_error_if_not_found:


### PR DESCRIPTION
## How this bug happened ?

this bug happened when I run `pipenv run python`, exception traceback information is below:

```
Traceback (most recent call last):
  File "/var/www/django_demo/.env/bin/pipenv", line 11, in <module>
    sys.exit(cli())
  File "/var/www/django_demo/.env/lib/python2.7/site-packages/pipenv/vendor/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/var/www/django_demo/.env/lib/python2.7/site-packages/pipenv/vendor/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/var/www/django_demo/.env/lib/python2.7/site-packages/pipenv/vendor/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/var/www/django_demo/.env/lib/python2.7/site-packages/pipenv/vendor/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/var/www/django_demo/.env/lib/python2.7/site-packages/pipenv/vendor/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/var/www/django_demo/.env/local/lib/python2.7/site-packages/pipenv/cli.py", line 701, in run
    do_run(command=command, args=args, three=three, python=python, pypi_mirror=pypi_mirror)
  File "/var/www/django_demo/.env/local/lib/python2.7/site-packages/pipenv/core.py", line 2245, in do_run
    load_dot_env()
  File "/var/www/django_demo/.env/local/lib/python2.7/site-packages/pipenv/core.py", line 145, in load_dot_env
    dotenv.load_dotenv(denv, override=True)
  File "/var/www/django_demo/.env/lib/python2.7/site-packages/pipenv/vendor/dotenv/main.py", line 257, in load_dotenv
    return DotEnv(f, verbose=verbose).set_as_environment_variables(override=override)
  File "/var/www/django_demo/.env/lib/python2.7/site-packages/pipenv/vendor/dotenv/main.py", line 94, in set_as_environment_variables
    for k, v in self.dict().items():
  File "/var/www/django_demo/.env/lib/python2.7/site-packages/pipenv/vendor/dotenv/main.py", line 73, in dict
    values = OrderedDict(self.parse())
  File "/usr/lib/python2.7/collections.py", line 51, in __init__
    self.__update(*args, **kwds)
  File "/var/www/django_demo/.env/lib/python2.7/_abcoll.py", line 499, in update
    for key, value in other:
  File "/var/www/django_demo/.env/lib/python2.7/site-packages/pipenv/vendor/dotenv/main.py", line 78, in parse
    f = self._get_stream()
  File "/var/www/django_demo/.env/lib/python2.7/site-packages/pipenv/vendor/dotenv/main.py", line 61, in _get_stream
    return io.open(self.dotenv_path)
```
pipenv try to automatic loading environment variables in the `.env` file. unfortunately, I created a virtual environment  named `.env` in the project, then the IOError happened.


## Fix this bug

use `os.path.isfile` instead of `os.path.exists`.



