### PR TITLE
Make README badges inline

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,9 @@ Pipenv: Python Development Workflow for Humans
 ==============================================
 
 [![image](https://img.shields.io/pypi/v/pipenv.svg)](https://pypi.python.org/pypi/pipenv)
-
 [![image](https://img.shields.io/pypi/l/pipenv.svg)](https://pypi.python.org/pypi/pipenv)
-
 [![image](https://badge.buildkite.com/79c7eccf056b17c3151f3c4d0e4c4b8b724539d84f1e037b9b.svg?branch=master)](https://code.kennethreitz.org/source/pipenv/)
-
 [![image](https://img.shields.io/pypi/pyversions/pipenv.svg)](https://pypi.python.org/pypi/pipenv)
-
 [![image](https://img.shields.io/badge/Say%20Thanks-!-1EAEDB.svg)](https://saythanks.io/to/kennethreitz)
 
 ------------------------------------------------------------------------


### PR DESCRIPTION
This makes the badges in the README inline which pushes some of the more informative content up the page.

Super small, nit change, but a bunch of other projects do the same :P
* https://github.com/pypa/pip
* https://github.com/requests/requests