### PR TITLE
Exclude more things from installation which aren't meant to be installed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -107,7 +107,7 @@ setup(
     author="Kenneth Reitz",
     author_email="me@kennethreitz.org",
     url="https://github.com/pypa/pipenv",
-    packages=find_packages(exclude=["tests", "tasks"]),
+    packages=find_packages(exclude=["tests", "tests.*", "tasks", "tasks.*"]),
     entry_points={
         "console_scripts": [
             "pipenv=pipenv:cli",


### PR DESCRIPTION
find_packages' exclude keyword is a bit unintuitive in that it only excludes the top-level directory specified, but happily includes all the children unless you wildcard those too.

Update this to actually match the original intent.