### PR TITLE
Adding some git+git and git+ssh tests as examples

### DIFF
--- a/tests/integration/test_install_uri.py
+++ b/tests/integration/test_install_uri.py
@@ -43,10 +43,9 @@ def test_git_vcs_install(PipenvInstance, pip_src_dir, pypi):
 
 @pytest.mark.vcs
 @pytest.mark.install
-@pytest.mark.needs_ssh_keys
+@pytest.mark.needs_github_ssh
 @pytest.mark.needs_internet
 @flaky
-@pytest.mark.skip(reason="must set valid SSH keys in testing environment")
 def test_ssh_vcs_install(PipenvInstance, pip_src_dir, pypi):
     with PipenvInstance(pypi=pypi, chdir=True) as p:
         c = p.pipenv("install git+ssh://git@github.com/benjaminp/six.git@1.11.0#egg=six")

--- a/tests/integration/test_install_uri.py
+++ b/tests/integration/test_install_uri.py
@@ -25,6 +25,38 @@ def test_basic_vcs_install(PipenvInstance, pip_src_dir, pypi):
         assert "gitdb2" in p.lockfile["default"]
 
 
+@pytest.mark.vcs
+@pytest.mark.install
+@pytest.mark.needs_internet
+@flaky
+def test_git_vcs_install(PipenvInstance, pip_src_dir, pypi):
+    with PipenvInstance(pypi=pypi, chdir=True) as p:
+        c = p.pipenv("install git+git://github.com/benjaminp/six.git@1.11.0#egg=six")
+        assert c.return_code == 0
+        assert "six" in p.pipfile["packages"]
+        assert "git" in p.pipfile["packages"]["six"]
+        assert p.lockfile["default"]["six"] == {
+            "git": "git://github.com/benjaminp/six.git",
+            "ref": "15e31431af97e5e64b80af0a3f598d382bcdd49a",
+        }
+
+
+@pytest.mark.vcs
+@pytest.mark.install
+@pytest.mark.needs_internet
+@flaky
+def test_ssh_vcs_install(PipenvInstance, pip_src_dir, pypi):
+    with PipenvInstance(pypi=pypi, chdir=True) as p:
+        c = p.pipenv("install git+ssh://git@github.com/benjaminp/six.git@1.11.0#egg=six")
+        assert c.return_code == 0
+        assert "six" in p.pipfile["packages"]
+        assert "git" in p.pipfile["packages"]["six"]
+        assert p.lockfile["default"]["six"] == {
+            "git": "ssh://git@github.com/benjaminp/six.git",
+            "ref": "15e31431af97e5e64b80af0a3f598d382bcdd49a",
+        }
+
+
 @pytest.mark.files
 @pytest.mark.urls
 @pytest.mark.needs_internet

--- a/tests/integration/test_install_uri.py
+++ b/tests/integration/test_install_uri.py
@@ -43,8 +43,10 @@ def test_git_vcs_install(PipenvInstance, pip_src_dir, pypi):
 
 @pytest.mark.vcs
 @pytest.mark.install
+@pytest.mark.needs_ssh_keys
 @pytest.mark.needs_internet
 @flaky
+@pytest.mark.skip(reason="must set valid SSH keys in testing environment")
 def test_ssh_vcs_install(PipenvInstance, pip_src_dir, pypi):
     with PipenvInstance(pypi=pypi, chdir=True) as p:
         c = p.pipenv("install git+ssh://git@github.com/benjaminp/six.git@1.11.0#egg=six")


### PR DESCRIPTION
I was trying to figure out why I was not able to install some `git+git` and some `git+ssh` dependencies with pipenv. Turns out I was falling prey to the slight syntax differences of those two alternatives compared to `git+https`. 

I adapted the `git+https` test for `git+git` and `git+ssh` and thought I'd contribute them. Not sure if it is worth keeping the `gitdb2` check in the two new tests though.