### PR TITLE
Add JSONDecodeError handling for get_lockfile_hash

### DIFF
--- a/news/2607.bugfix
+++ b/news/2607.bugfix
@@ -1,0 +1,2 @@
+Catch JSON decoding error to prevent exception when the lock file is of
+invalid format.

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -1257,40 +1257,34 @@ def do_init(
                     ),
                     err=True,
                 )
-            elif old_hash is None:
-                # Lockfile corrupted, remove it and replaced
-                click.echo(
-                    crayons.red(
-                        u"Pipfile.lock is corrupted, replaced with ({0})…".format(
-                            new_hash[-6:]
+            else:
+                if not old_hash:
+                    # Lockfile corrupted, remove it and replaced
+                    click.echo(
+                        crayons.red(
+                            u"Pipfile.lock is corrupted, replaced with ({0})…".format(
+                                new_hash[-6:]
+                            ),
+                            bold=True,
                         ),
-                        bold=True,
-                    ),
-                    err=True
-                )
-                os.remove(project.lockfile_location)
+                        err=True
+                    )
+                    os.remove(project.lockfile_location)
+                else:
+                    click.echo(
+                        crayons.red(
+                            u"Pipfile.lock ({0}) out of date, updating to ({1})…".format(
+                                old_hash[-6:], new_hash[-6:]
+                            ),
+                            bold=True,
+                        ),
+                        err=True,
+                    )
                 do_lock(
                     system=system,
                     pre=pre,
                     keep_outdated=keep_outdated,
                     verbose=verbose,
-                    write=True,
-                    pypi_mirror=pypi_mirror,
-                )
-            else:
-                click.echo(
-                    crayons.red(
-                        u"Pipfile.lock ({0}) out of date, updating to ({1})…".format(
-                            old_hash[-6:], new_hash[-6:]
-                        ),
-                        bold=True,
-                    ),
-                    err=True,
-                )
-                do_lock(
-                    system=system,
-                    pre=pre,
-                    keep_outdated=keep_outdated,
                     write=True,
                     pypi_mirror=pypi_mirror,
                 )

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -1258,28 +1258,14 @@ def do_init(
                     err=True,
                 )
             else:
-                if not old_hash:
-                    # Lockfile corrupted, remove it and replaced
-                    click.echo(
-                        crayons.red(
-                            u"Pipfile.lock is corrupted, replaced with ({0})…".format(
-                                new_hash[-6:]
-                            ),
-                            bold=True,
-                        ),
-                        err=True
-                    )
-                    os.remove(project.lockfile_location)
+                if old_hash:
+                    msg = u"Pipfile.lock ({1}) out of date, updating to ({0})…"
                 else:
-                    click.echo(
-                        crayons.red(
-                            u"Pipfile.lock ({0}) out of date, updating to ({1})…".format(
-                                old_hash[-6:], new_hash[-6:]
-                            ),
-                            bold=True,
-                        ),
-                        err=True,
-                    )
+                    msg = u"Pipfile.lock is corrupted, replaced with ({0})…"
+                click.echo(crayons.red(
+                    msg.format(old_hash[-6:], new_hash[-6:]),
+                    bold=True,
+                ), err=True)
                 do_lock(
                     system=system,
                     pre=pre,

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -1257,6 +1257,26 @@ def do_init(
                     ),
                     err=True,
                 )
+            elif old_hash is None:
+                # Lockfile corrupted, remove it and replaced
+                click.echo(
+                    crayons.red(
+                        u"Pipfile.lock is corrupted, replaced with ({0})…".format(
+                            new_hash[-6:]
+                        ),
+                        bold=True,
+                    ),
+                    err=True
+                )
+                os.remove(project.lockfile_location)
+                do_lock(
+                    system=system,
+                    pre=pre,
+                    keep_outdated=keep_outdated,
+                    verbose=verbose,
+                    write=True,
+                    pypi_mirror=pypi_mirror,
+                )
             else:
                 click.echo(
                     crayons.red(

--- a/pipenv/project.py
+++ b/pipenv/project.py
@@ -815,7 +815,11 @@ class Project(object):
         if not os.path.exists(self.lockfile_location):
             return
 
-        lockfile = self.load_lockfile(expand_env_vars=False)
+        try:
+            lockfile = self.load_lockfile(expand_env_vars=False)
+        except json.decoder.JSONDecodeError:
+            # Lockfile corrupted
+            return
         if "_meta" in lockfile and hasattr(lockfile, "keys"):
             return lockfile["_meta"].get("hash", {}).get("sha256")
         # Lockfile exists but has no hash at all

--- a/pipenv/project.py
+++ b/pipenv/project.py
@@ -817,9 +817,9 @@ class Project(object):
 
         try:
             lockfile = self.load_lockfile(expand_env_vars=False)
-        except json.decoder.JSONDecodeError:
+        except ValueError:
             # Lockfile corrupted
-            return
+            return ""
         if "_meta" in lockfile and hasattr(lockfile, "keys"):
             return lockfile["_meta"].get("hash", {}).get("sha256")
         # Lockfile exists but has no hash at all

--- a/tests/integration/test_lock.py
+++ b/tests/integration/test_lock.py
@@ -385,3 +385,25 @@ django = "*"
         django_version = '==2.0.6' if py_version.startswith('3') else '==1.11.13'
         assert py_version == '2.7.14'
         assert p.lockfile['default']['django']['version'] == django_version
+
+
+@pytest.mark.lock
+@pytest.mark.install
+def test_lockfile_corrupted(PipenvInstance):
+    with PipenvInstance() as p:
+        with open(p.lockfile_path, 'w') as f:
+            f.write('{corrupt}')
+        c = p.pipenv('install')
+        assert c.return_code == 0
+        assert p.lockfile['_meta']
+
+
+@pytest.mark.lock
+@pytest.mark.install
+def test_lockfile_with_empty_dict(PipenvInstance):
+    with PipenvInstance() as p:
+        with open(p.lockfile_path, 'w') as f:
+            f.write('{}')
+        c = p.pipenv('install')
+        assert c.return_code == 0
+        assert p.lockfile['_meta']

--- a/tests/integration/test_lock.py
+++ b/tests/integration/test_lock.py
@@ -392,9 +392,10 @@ django = "*"
 def test_lockfile_corrupted(PipenvInstance):
     with PipenvInstance() as p:
         with open(p.lockfile_path, 'w') as f:
-            f.write('{corrupt}')
+            f.write('{corrupted}')
         c = p.pipenv('install')
         assert c.return_code == 0
+        assert 'Pipfile.lock is corrupted' in c.err
         assert p.lockfile['_meta']
 
 
@@ -406,4 +407,5 @@ def test_lockfile_with_empty_dict(PipenvInstance):
             f.write('{}')
         c = p.pipenv('install')
         assert c.return_code == 0
+        assert 'Pipfile.lock is corrupted' in c.err
         assert p.lockfile['_meta']


### PR DESCRIPTION
Now will return None when facing JSONDecodeError when loading the lockfile.

do_init will remove the old lockfile and replace it.

Fix #2607