### PR TITLE
Fix parsing of verify_ssl=false in urls with authentication in Pipfile

### DIFF
--- a/news/2656.bugfix
+++ b/news/2656.bugfix
@@ -1,0 +1,1 @@
+Fixed a bug which sometimes caused pipenv to parse the ``trusted_host`` argument to pip incorrectly when parsing source URLs which specify ``verify_ssl = false``.

--- a/pipenv/utils.py
+++ b/pipenv/utils.py
@@ -200,7 +200,7 @@ def prepare_pip_source_args(sources, pip_args=None):
         # Trust the host if it's not verified.
         if not sources[0].get("verify_ssl", True):
             pip_args.extend(
-                ["--trusted-host", urlparse(sources[0]["url"]).netloc.split(":")[0]]
+                ["--trusted-host", urlparse(sources[0]["url"]).hostname]
             )
         # Add additional sources as extra indexes.
         if len(sources) > 1:

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -371,6 +371,20 @@ twine = "*"
                     "https://user:password@custom.example.com/simple",
                 ],
             ),
+            (
+                [
+                    {
+                        "url": "https://user:password@custom.example.com/simple",
+                        "verify_ssl": False,
+                    },
+                ],
+                [
+                    "-i",
+                    "https://user:password@custom.example.com/simple",
+                    "--trusted-host",
+                    "custom.example.com",
+                ],
+            ),
         ],
     )
     def test_prepare_pip_source_args(self, sources, expected_args):


### PR DESCRIPTION
`pipenv` breaks when the first specified source in the Pipfile contains a username and password.