### PR TITLE
Ignore OSError in is_virtual_environment check

### DIFF
--- a/news/2676.bugfix
+++ b/news/2676.bugfix
@@ -1,0 +1,1 @@
+Prevent crashing when a virtual environment in ``WORKON_HOME`` is faulty.

--- a/pipenv/utils.py
+++ b/pipenv/utils.py
@@ -1350,8 +1350,12 @@ def is_virtual_environment(path):
     if not path.is_dir():
         return False
     for bindir_name in ('bin', 'Scripts'):
-        for python_like in path.joinpath(bindir_name).glob('python*'):
-            if python_like.is_file() and os.access(str(python_like), os.X_OK):
+        for python in path.joinpath(bindir_name).glob('python*'):
+            try:
+                exeness = python.is_file() and os.access(str(python), os.X_OK)
+            except OSError:
+                exeness = False
+            if exeness:
                 return True
     return False
 


### PR DESCRIPTION
This works around a faulty virtual environment on my machine that makes Python throw `OSError: too many level of symlinks`. If a virtual environment is faulty, we can just ignore it.