### PR TITLE
Add test for setup.py::dependency-link field

### DIFF
--- a/tests/integration/test_install_twists.py
+++ b/tests/integration/test_install_twists.py
@@ -57,10 +57,17 @@ zip_safe=False
         assert "six" in p.lockfile["default"]
 
 
-def helper_dependency_links_install_make_setup(pipenv_instance, deplink):
-    setup_py = os.path.join(pipenv_instance.path, "setup.py")
-    with open(setup_py, "w") as fh:
-        contents = """
+class TestDependencyLinks(object):
+    """Ensure dependency_links are parsed and installed.
+
+    This is needed for private repo dependencies.
+    """
+
+    @staticmethod
+    def helper_dependency_links_install_make_setup(pipenv_instance, deplink):
+        setup_py = os.path.join(pipenv_instance.path, "setup.py")
+        with open(setup_py, "w") as fh:
+            contents = """
 from setuptools import setup
 
 setup(
@@ -74,48 +81,44 @@ setup(
         '{0}'
     ]
 )
-        """.strip().format(deplink)
-        fh.write(contents)
+            """.strip().format(deplink)
+            fh.write(contents)
 
+    @staticmethod
+    def helper_dependency_links_install_test(pipenv_instance, deplink):
+        TestDependencyLinks.helper_dependency_links_install_make_setup(pipenv_instance, deplink)
+        c = pipenv_instance.pipenv("install -v -e .")
+        assert c.return_code == 0
+        assert "test-private-dependency" in pipenv_instance.lockfile["default"]
+        assert "version" in pipenv_instance.lockfile["default"]["test-private-dependency"]
+        assert "0.1" in pipenv_instance.lockfile["default"]["test-private-dependency"]["version"]
 
-def helper_dependency_links_install_test(pipenv_instance, deplink):
-    helper_dependency_links_install_make_setup(pipenv_instance, deplink)
-    c = pipenv_instance.pipenv("install -v -e .")
-    assert c.return_code == 0
-    assert "test-private-dependency" in pipenv_instance.lockfile["default"]
-    assert "version" in pipenv_instance.lockfile["default"]["test-private-dependency"]
-    assert "0.1" in pipenv_instance.lockfile["default"]["test-private-dependency"]["version"]
+    @pytest.mark.install
+    @pytest.mark.local
+    @pytest.mark.needs_internet
+    @flaky
+    def test_https_dependency_links_install(self, PipenvInstance, pypi):
+        """Ensure dependency_links are parsed and installed (needed for private repo dependencies).
+        """
+        with temp_environ(), PipenvInstance(pypi=pypi, chdir=True) as p:
+            os.environ['PIP_PROCESS_DEPENDENCY_LINKS'] = '1'
+            TestDependencyLinks.helper_dependency_links_install_test(
+                p,
+                'git+https://github.com/atzannes/test-private-dependency@v0.1#egg=test-private-dependency-v0.1'
+            )
 
-
-@pytest.mark.install
-@pytest.mark.local
-@pytest.mark.needs_internet
-@flaky
-def test_https_dependency_links_install(PipenvInstance, pypi):
-    """Ensure dependency_links are parsed and installed (needed for private repo dependencies).
-    """
-    with temp_environ(), PipenvInstance(pypi=pypi, chdir=True) as p:
-        os.environ['PIP_PROCESS_DEPENDENCY_LINKS'] = '1'
-        helper_dependency_links_install_test(
-            p,
-            'git+https://github.com/atzannes/test-private-dependency@v0.1#egg=test-private-dependency-v0.1'
-        )
-
-
-@pytest.mark.install
-@pytest.mark.local
-@pytest.mark.needs_internet
-@pytest.mark.needs_github_ssh
-@flaky
-def test_ssh_dependency_links_install(PipenvInstance, pypi):
-    """Ensure dependency_links are parsed and installed (needed for private repo dependencies).
-    """
-    with temp_environ(), PipenvInstance(pypi=pypi, chdir=True) as p:
-        os.environ['PIP_PROCESS_DEPENDENCY_LINKS'] = '1'
-        helper_dependency_links_install_test(
-            p,
-            'git+ssh://git@github.com/atzannes/test-private-dependency@v0.1#egg=test-private-dependency-v0.1'
-        )
+    @pytest.mark.install
+    @pytest.mark.local
+    @pytest.mark.needs_internet
+    @pytest.mark.needs_github_ssh
+    @flaky
+    def test_ssh_dependency_links_install(self, PipenvInstance, pypi):
+        with temp_environ(), PipenvInstance(pypi=pypi, chdir=True) as p:
+            os.environ['PIP_PROCESS_DEPENDENCY_LINKS'] = '1'
+            TestDependencyLinks.helper_dependency_links_install_test(
+                p,
+                'git+ssh://git@github.com/atzannes/test-private-dependency@v0.1#egg=test-private-dependency-v0.1'
+            )
 
 
 @pytest.mark.e

--- a/tests/integration/test_install_twists.py
+++ b/tests/integration/test_install_twists.py
@@ -95,8 +95,8 @@ setup(
     with PipenvInstance(pypi=pypi, chdir=True) as p:
         test_deplink(p, 'git+https://github.com/atzannes/test-private-dependency@v0.1#egg=test-private-dependency-v0.1')
 
-    with PipenvInstance(pypi=pypi, chdir=True) as p:
-        test_deplink(p, 'git+ssh://git@github.com/atzannes/test-private-dependency@v0.1#egg=test-private-dependency-v0.1')
+    # with PipenvInstance(pypi=pypi, chdir=True) as p:
+    #     test_deplink(p, 'git+ssh://git@github.com/atzannes/test-private-dependency@v0.1#egg=test-private-dependency-v0.1')
 
 
 @pytest.mark.e

--- a/tests/integration/test_install_twists.py
+++ b/tests/integration/test_install_twists.py
@@ -57,17 +57,10 @@ zip_safe=False
         assert "six" in p.lockfile["default"]
 
 
-@pytest.mark.install
-@pytest.mark.local
-@pytest.mark.needs_internet
-@flaky
-def test_local_dependency_links_install(PipenvInstance, pypi):
-    """Ensure dependency_links are parsed and installed (needed for private repo dependencies).
-    """
-    def make_setup(pipenv_instance, deplink):
-        setup_py = os.path.join(pipenv_instance.path, "setup.py")
-        with open(setup_py, "w") as fh:
-            contents = """
+def helper_dependency_links_install_make_setup(pipenv_instance, deplink):
+    setup_py = os.path.join(pipenv_instance.path, "setup.py")
+    with open(setup_py, "w") as fh:
+        contents = """
 from setuptools import setup
 
 setup(
@@ -81,24 +74,48 @@ setup(
         '{0}'
     ]
 )
-            """.strip().format(deplink)
-            fh.write(contents)
+        """.strip().format(deplink)
+        fh.write(contents)
 
-    def test_deplink(pipenv_instance, deplink):
-        make_setup(pipenv_instance, deplink)
-        c = pipenv_instance.pipenv("install -v -e .")
-        assert c.return_code == 0
-        assert "test-private-dependency" in pipenv_instance.lockfile["default"]
-        assert "version" in pipenv_instance.lockfile["default"]["test-private-dependency"]
-        assert "0.1" in pipenv_instance.lockfile["default"]["test-private-dependency"]["version"]
 
+def helper_dependency_links_install_test(pipenv_instance, deplink):
+    helper_dependency_links_install_make_setup(pipenv_instance, deplink)
+    c = pipenv_instance.pipenv("install -v -e .")
+    assert c.return_code == 0
+    assert "test-private-dependency" in pipenv_instance.lockfile["default"]
+    assert "version" in pipenv_instance.lockfile["default"]["test-private-dependency"]
+    assert "0.1" in pipenv_instance.lockfile["default"]["test-private-dependency"]["version"]
+
+
+@pytest.mark.install
+@pytest.mark.local
+@pytest.mark.needs_internet
+@flaky
+def test_https_dependency_links_install(PipenvInstance, pypi):
+    """Ensure dependency_links are parsed and installed (needed for private repo dependencies).
+    """
     with temp_environ(), PipenvInstance(pypi=pypi, chdir=True) as p:
         os.environ['PIP_PROCESS_DEPENDENCY_LINKS'] = '1'
-        test_deplink(p, 'git+https://github.com/atzannes/test-private-dependency@v0.1#egg=test-private-dependency-v0.1')
+        helper_dependency_links_install_test(
+            p,
+            'git+https://github.com/atzannes/test-private-dependency@v0.1#egg=test-private-dependency-v0.1'
+        )
 
+
+@pytest.mark.install
+@pytest.mark.local
+@pytest.mark.needs_internet
+@pytest.mark.needs_github_ssh
+@flaky
+def test_ssh_dependency_links_install(PipenvInstance, pypi):
+    """Ensure dependency_links are parsed and installed (needed for private repo dependencies).
+    """
     with temp_environ(), PipenvInstance(pypi=pypi, chdir=True) as p:
         os.environ['PIP_PROCESS_DEPENDENCY_LINKS'] = '1'
-        test_deplink(p, 'git+ssh://git@github.com/atzannes/test-private-dependency@v0.1#egg=test-private-dependency-v0.1')
+        helper_dependency_links_install_test(
+            p,
+            'git+ssh://git@github.com/atzannes/test-private-dependency@v0.1#egg=test-private-dependency-v0.1'
+        )
 
 
 @pytest.mark.e

--- a/tests/integration/test_install_twists.py
+++ b/tests/integration/test_install_twists.py
@@ -86,7 +86,7 @@ setup(
 
     def test_deplink(pipenv_instance, deplink):
         make_setup(pipenv_instance, deplink)
-        c = pipenv_instance.pipenv("install -e .")
+        c = pipenv_instance.pipenv("install -v -e .")
         assert c.return_code == 0
         assert "test-private-dependency" in pipenv_instance.lockfile["default"]
         assert "version" in pipenv_instance.lockfile["default"]["test-private-dependency"]

--- a/tests/integration/test_install_twists.py
+++ b/tests/integration/test_install_twists.py
@@ -96,8 +96,9 @@ setup(
         os.environ['PIP_PROCESS_DEPENDENCY_LINKS'] = '1'
         test_deplink(p, 'git+https://github.com/atzannes/test-private-dependency@v0.1#egg=test-private-dependency-v0.1')
 
-    # with PipenvInstance(pypi=pypi, chdir=True) as p:
-    #     test_deplink(p, 'git+ssh://git@github.com/atzannes/test-private-dependency@v0.1#egg=test-private-dependency-v0.1')
+    with temp_environ(), PipenvInstance(pypi=pypi, chdir=True) as p:
+        os.environ['PIP_PROCESS_DEPENDENCY_LINKS'] = '1'
+        test_deplink(p, 'git+ssh://git@github.com/atzannes/test-private-dependency@v0.1#egg=test-private-dependency-v0.1')
 
 
 @pytest.mark.e

--- a/tests/integration/test_install_twists.py
+++ b/tests/integration/test_install_twists.py
@@ -92,7 +92,8 @@ setup(
         assert "version" in pipenv_instance.lockfile["default"]["test-private-dependency"]
         assert "0.1" in pipenv_instance.lockfile["default"]["test-private-dependency"]["version"]
 
-    with PipenvInstance(pypi=pypi, chdir=True) as p:
+    with temp_environ(), PipenvInstance(pypi=pypi, chdir=True) as p:
+        os.environ['PIP_PROCESS_DEPENDENCY_LINKS'] = '1'
         test_deplink(p, 'git+https://github.com/atzannes/test-private-dependency@v0.1#egg=test-private-dependency-v0.1')
 
     # with PipenvInstance(pypi=pypi, chdir=True) as p:

--- a/tests/integration/test_install_twists.py
+++ b/tests/integration/test_install_twists.py
@@ -57,6 +57,10 @@ zip_safe=False
         assert "six" in p.lockfile["default"]
 
 
+@pytest.mark.install
+@pytest.mark.local
+@pytest.mark.needs_internet
+@flaky
 class TestDependencyLinks(object):
     """Ensure dependency_links are parsed and installed.
 
@@ -93,10 +97,6 @@ setup(
         assert "version" in pipenv_instance.lockfile["default"]["test-private-dependency"]
         assert "0.1" in pipenv_instance.lockfile["default"]["test-private-dependency"]["version"]
 
-    @pytest.mark.install
-    @pytest.mark.local
-    @pytest.mark.needs_internet
-    @flaky
     def test_https_dependency_links_install(self, PipenvInstance, pypi):
         """Ensure dependency_links are parsed and installed (needed for private repo dependencies).
         """
@@ -107,11 +107,7 @@ setup(
                 'git+https://github.com/atzannes/test-private-dependency@v0.1#egg=test-private-dependency-v0.1'
             )
 
-    @pytest.mark.install
-    @pytest.mark.local
-    @pytest.mark.needs_internet
     @pytest.mark.needs_github_ssh
-    @flaky
     def test_ssh_dependency_links_install(self, PipenvInstance, pypi):
         with temp_environ(), PipenvInstance(pypi=pypi, chdir=True) as p:
             os.environ['PIP_PROCESS_DEPENDENCY_LINKS'] = '1'


### PR DESCRIPTION
##### The issue

Issue #2613 was fixed via #2643, but the fix did not include a regression test.


##### The fix

This pull request proposes an integration test that failed prior to #2643 but succeeds now.
By taking a look at #2643 it wasn't clear to me how to write a unit test instead of this integration test. Because this integration test relies on web connectivity to a github repository, I created a dummy repo to be used just by this test. I suspect it is preferable to fork that repo under the `pypa` org so as not to have it under my personal account though.


##### The checklist

* [x] Associated issue #2613 
* [ ] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

There doesn't seem to be a relevant fragment for just adding a regression test