### PR TITLE
Added an example to README.md for installing from git

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,15 @@ Install packages:
     To activate this project's virtualenv, run the following:
     $ pipenv shell
 
+Install from git:
+
+    $ pipenv install -e git+https://github.com/requests/requests.git@v2.19.1#egg=requests
+    Installing -e git+https://github.com/requests/requests.git@v2.19.1#egg=requests…
+    ...
+    Adding -e git+https://github.com/requests/requests.git@v2.19.1#egg=requests to Pipfile's [packages]...
+
+You can also change the tag/ref (or exclude to get the latest version) by adding @version-or-tag before #egg=project_name
+
 Install a dev dependency:
 
     $ pipenv install pytest --dev

--- a/README.md
+++ b/README.md
@@ -220,26 +220,24 @@ Installing from git:
 
 You can install packages with pipenv from git and other version control systems using URLs formatted according to the following rule:
 
-```
     <vcs_type>+<scheme>://<location>/<user_or_organizatoin>/<repository>@<branch_or_tag>#<package_name>
-```
 
 The only optional section is the `@<branch_or_tag>` section.  When using git over SSH, you may use the shorthand vcs and scheme alias `git+git@<location>:<user_or_organization>/<repository>@<branch_or_tag>#<package_name>`. Note that this is translated to `git+ssh://git@<location>` when parsed.
 
 Valid values for `<vcs_type>` include `git`, `bzr`, `svn`, and `hg`.  Valid values for `<scheme>` include `http,`, `https`, `ssh`, and `file`.  In specific cases you also have access to other schemes: `svn` may be combined with `svn` as a scheme, and `bzr` can be combined with `sftp` and `lp`.
 
-Note that it is **strongly recommended** that you install any version-controlled dependencies in editable mode in order to ensure that dependency resolution can be performed with an up to date copy of the repository each time it is performed, and that it includes all known dependencies.
+Note that it is **strongly recommended** that you install any version-controlled dependencies in editable mode, using `pipenv install -e`, in order to ensure that dependency resolution can be performed with an up to date copy of the repository each time it is performed, and that it includes all known dependencies.
 
 Below is an example usage which installs the git repository located at `https://github.com/requests/requests.git` from tag `v2.19.1` as package name `requests`:
 
-```console
     $ pipenv install -e git+https://github.com/requests/requests.git@v2.19#egg=requests
     Creating a Pipfile for this project...
     Installing -e git+https://github.com/requests/requests.git@v2.19.1#egg=requests...
     [...snipped...]
     Adding -e git+https://github.com/requests/requests.git@v2.19.1#egg=requests to Pipfile's [packages]...
     [...]
-```
+
+You can read more about [pip's implementation of vcs support here](https://pip.pypa.io/en/stable/reference/pip_install/#vcs-support).
 
 Install a dev dependency:
 

--- a/README.md
+++ b/README.md
@@ -216,14 +216,30 @@ Install packages:
     To activate this project's virtualenv, run the following:
     $ pipenv shell
 
-Install from git:
+Installing from git:
 
-    $ pipenv install -e git+https://github.com/requests/requests.git@v2.19.1#egg=requests
-    Installing -e git+https://github.com/requests/requests.git@v2.19.1#egg=requests…
-    ...
+You can install packages with pipenv from git and other version control systems using URLs formatted according to the following rule:
+
+```
+    <vcs_type>+<scheme>://<location>/<user_or_organizatoin>/<repository>@<branch_or_tag>#<package_name>
+```
+
+The only optional section is the `@<branch_or_tag>` section.  When using git over SSH, you may use the shorthand vcs and scheme alias `git+git@<location>:<user_or_organization>/<repository>@<branch_or_tag>#<package_name>`. Note that this is translated to `git+ssh://git@<location>` when parsed.
+
+Valid values for `<vcs_type>` include `git`, `bzr`, `svn`, and `hg`.  Valid values for `<scheme>` include `http,`, `https`, `ssh`, and `file`.  In specific cases you also have access to other schemes: `svn` may be combined with `svn` as a scheme, and `bzr` can be combined with `sftp` and `lp`.
+
+Note that it is **strongly recommended** that you install any version-controlled dependencies in editable mode in order to ensure that dependency resolution can be performed with an up to date copy of the repository each time it is performed, and that it includes all known dependencies.
+
+Below is an example usage which installs the git repository located at `https://github.com/requests/requests.git` from tag `v2.19.1` as package name `requests`:
+
+```console
+    $ pipenv install -e git+https://github.com/requests/requests.git@v2.19#egg=requests
+    Creating a Pipfile for this project...
+    Installing -e git+https://github.com/requests/requests.git@v2.19.1#egg=requests...
+    [...snipped...]
     Adding -e git+https://github.com/requests/requests.git@v2.19.1#egg=requests to Pipfile's [packages]...
-
-You can also change the tag/ref (or exclude to get the latest version) by adding @version-or-tag before #egg=project_name
+    [...]
+```
 
 Install a dev dependency:
 

--- a/news/2685.doc
+++ b/news/2685.doc
@@ -1,0 +1,1 @@
+Added simple example to README.md for installing from git.


### PR DESCRIPTION
Thank you for contributing to Pipenv!


##### The issue

There was a request for [additional documentation on installing from git](https://github.com/pypa/pipenv/issues/2685)


##### The fix

 I updated the README.md with an example to install requests, this could also be added to the official docs as well, but I figured this was a good start. I didn't add any additional information to the `news/` directory because I wasn't sure what the naming method was 


##### The checklist

* [ x ] Associated issue
* [ x ] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

<!--
##### If this is a patch to the `vendor` directory…

Please try to refrain from submitting patches directly to `vendor` or `patched`, but raise your issue to the upstream project instead, and inform Pipenv to upgrade when the upstream project accepts the fix.

A pull request to upgrade vendor packages is strongly discouraged, unless there is a very good reason (e.g. you need to test Pipenv’s integration to a new vendor feature). Pipenv audits and performs vendor upgrades regularly, generally before a new release is about to drop.

If your patch is not or cannot be accepted by upstream, but is essential to Pipenv (make sure to discuss this with maintainers!), please remember to attach a patch file in `tasks/vendoring/patched`, so this divergence from upstream can be recorded and replayed afterwards.
-->
