### PR TITLE
Fix a bug with enviroment variable injection to the git repo url

### DIFF
--- a/news/2635.bugfix
+++ b/news/2635.bugfix
@@ -1,0 +1,1 @@
+Fix a enviroment injection issue when dealing with git repo url dependencies. The problem issued when pipenv trying to execute command similar to "git clone -q git+https://${USER}:${PASSWORD}/github.com" using python subprocess.Popen, the enviroment variable inside this command is not propely resolved.Which will cause a permission deny error or a repo not found error. 

--- a/pipenv/patched/notpip/_internal/utils/misc.py
+++ b/pipenv/patched/notpip/_internal/utils/misc.py
@@ -642,6 +642,8 @@ def call_subprocess(cmd, show_stdout=True, cwd=None,
         command_desc = ' '.join(cmd_parts)
     logger.debug("Running command %s", command_desc)
     env = os.environ.copy()
+    for idx in range(len(cmd)):
+        cmd[idx] = os.path.expandvars(cmd[idx])
     if extra_environ:
         env.update(extra_environ)
     for name in unset_environ:


### PR DESCRIPTION
Thank you for contributing to Pipenv!


##### The issue

Fix a enviroment injection issue when dealing with git repo url dependencies. The problem issued when pipenv trying to execute command similar to "git clone -q git+https://${USER}:${PASSWORD}/github.com" using python subprocess.Popen, the enviroment variable inside this command is not propely resolved.Which will cause a permission deny error or a repo not found error.

##### The fix

using os.path.expandvars(cmd-parts) before passing to subprocess.

##### The checklist

* [ ] Associated issue

https://github.com/pypa/pipenv/issues/2635 

* [ ] A news fragment:

news/2365.bugfix