### PR TITLE
Bugfix/python version warning

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -7,7 +7,7 @@ docutils==0.14
 first==2.0.1
 idna==2.6
 imagesize==0.7.1
-Jinja2==2.9.6
+Jinja2==2.10
 MarkupSafe==1.0
 pbr==3.1.1
 pip-tools==1.9.0

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -550,15 +550,19 @@ def ensure_project(
                 ):
                     click.echo(
                         "{0}: Your Pipfile requires {1} {2}, "
-                        "but you are using {3} ({4}). Running "
-                        "{5} and rebuilding the virtual environment "
-                        "may resolve the issue".format(
+                        "but you are using {3} ({4}).".format(
                             crayons.red("Warning", bold=True),
                             crayons.normal("python_version", bold=True),
                             crayons.blue(project.required_python_version),
                             crayons.blue(python_version(path_to_python)),
                             crayons.green(shorten_path(path_to_python)),
-                            crayons.green("`pipenv --rm`"),
+                        ),
+                        err=True,
+                    )
+                    click.echo(
+                        "  {0} and rebuilding the virtual environment "
+                        "may resolve the issue.".format(
+                            crayons.green("$ pipenv --rm"),
                         ),
                         err=True,
                     )

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -550,8 +550,8 @@ def ensure_project(
                 ):
                     click.echo(
                         "{0}: Your Pipfile requires {1} {2}, "
-                        "but you are using {3} ({4}). Running"
-                        "{5} and rebuilding the virtual environment"
+                        "but you are using {3} ({4}). Running "
+                        "{5} and rebuilding the virtual environment "
                         "may resolve the issue".format(
                             crayons.red("Warning", bold=True),
                             crayons.normal("python_version", bold=True),


### PR DESCRIPTION
Introduced in f141911dabe7. Trailing spaces are needed.

Current message (before this patch):

```
Warning: Your Pipfile requires python_version 3.7, but you are using 3.6.4 (C:\Users\u\D\p\r\.venv\S\python.exe). Running`pipenv --rm` and rebuilding the virtual environmentmay resolve the issue
  $ pipenv check will surely fail.
```

Notice the lack of spaces between “Running” and “`pipenv --rm`”, and between “environment” and “may”.

Message after this patch:

```
Warning: Your Pipfile requires python_version 3.7, but you are using 3.6.4 (C:\Users\u\D\p\r\.venv\S\python.exe).
  $ pipenv --rm and rebuilding the virtual environment may resolve the issue.
  $ pipenv check will surely fail.
```