### PR TITLE
Improve "run" behavior on Windows

### DIFF
--- a/news/2718.behavior
+++ b/news/2718.behavior
@@ -1,0 +1,1 @@
+Fallback to shell mode if `run` fails with Windows error 193 to handle non-executable commands. This should improve usability on Windows, where some users run non-executable files without specifying a command, relying on Windows file association to choose the current command.

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -2087,15 +2087,30 @@ def inline_activate_virtual_environment():
         os.environ["VIRTUAL_ENV"] = root
 
 
-def do_run_nt(script):
+def _launch_windows_subprocess(script):
     import subprocess
 
     command = system_which(script.command)
     options = {"universal_newlines": True}
-    if command:  # Try to use CreateProcess directly if possible.
-        p = subprocess.Popen([command] + script.args, **options)
-    else:  # Command not found, maybe this is a shell built-in?
-        p = subprocess.Popen(script.cmdify(), shell=True, **options)
+
+    # Command not found, maybe this is a shell built-in?
+    if not command:
+        return subprocess.Popen(script.cmdify(), shell=True, **options)
+
+    # Try to use CreateProcess directly if possible.
+    try:
+        return subprocess.Popen([command] + script.args, **options)
+    except WindowsError as e:
+        if e.winerror != 193:
+            raise
+
+    # Windows error 193 "Command is not a valid Win32 application".
+    # Try shell mode to use Windows's file association for file launch.
+    return subprocess.Popen(script.cmdify(), shell=True, **options)
+
+
+def do_run_nt(script):
+    p = _launch_windows_subprocess(script)
     p.communicate()
     sys.exit(p.returncode)
 

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -2097,14 +2097,15 @@ def _launch_windows_subprocess(script):
     if not command:
         return subprocess.Popen(script.cmdify(), shell=True, **options)
 
-    # Try to use CreateProcess directly if possible.
+    # Try to use CreateProcess directly if possible. Specifically catch
+    # Windows error 193 "Command is not a valid Win32 application" to handle
+    # a "command" that is non-executable. See pypa/pipenv#2727.
     try:
         return subprocess.Popen([command] + script.args, **options)
     except WindowsError as e:
         if e.winerror != 193:
             raise
 
-    # Windows error 193 "Command is not a valid Win32 application".
     # Try shell mode to use Windows's file association for file launch.
     return subprocess.Popen(script.cmdify(), shell=True, **options)
 


### PR DESCRIPTION
Provide better error-handling for #2718 (so the command never throws OSError).

Some Windows users are used to launch files without specifying a command, e.g.

    > my-script.py

This works in the shell because Windows will automatically choose an command based on file association, and with newer Python versions, the Py Launcher (py.exe) automatically chooses the correct Python based on shebang-parsing.

A similar syntax, unfortunately, does not currently work in Pipenv

    > pipenv run my-script.py

Since my-script.py will be treated as a real application by the subprocess module.

This patch catch Windows error 193 during subprocess initialization, and fall back to use COMSPEC (shell=True) when it happens, to provide better support for this use case.

##### The checklist

* [x] Associated issue
* [x] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.
