### PR TITLE
Correctly pass verbosity to resolver

### DIFF
--- a/news/2732.bugfix
+++ b/news/2732.bugfix
@@ -1,0 +1,1 @@
+Correctly pass `verbose` and `debug` flags to the resolver subprocess so it generates appropriate output. This also resolves a bug introduced by the fix to #2527.

--- a/pipenv/resolver.py
+++ b/pipenv/resolver.py
@@ -22,6 +22,7 @@ def which(*args, **kwargs):
 def main():
     do_pre = "--pre" in " ".join(sys.argv)
     do_clear = "--clear" in " ".join(sys.argv)
+    is_verbose = "--verbose" in " ".join(sys.argv)
     is_debug = "--debug" in " ".join(sys.argv)
     system = "--system" in " ".join(sys.argv)
     new_sys_argv = []
@@ -35,11 +36,17 @@ def main():
 
     os.environ["PIP_PYTHON_VERSION"] = ".".join([str(s) for s in sys.version_info[:3]])
     os.environ["PIP_PYTHON_PATH"] = sys.executable
-    if int(os.environ.get("PIPENV_VERBOSITY", 0)) > 0:
-        logging.getLogger("notpip").setLevel(logging.INFO)
+
+    verbosity = int(os.environ.get("PIPENV_VERBOSITY", 0))
     if is_debug:
-        # Shit's getting real at this point.
+        verbosity = max(verbosity, 2)
+    elif is_verbose:
+        verbosity = max(verbosity, 1)
+    if verbosity > 1:   # Shit's getting real at this point.
         logging.getLogger("notpip").setLevel(logging.DEBUG)
+    elif verbosity > 0:
+        logging.getLogger("notpip").setLevel(logging.INFO)
+
     if "PIPENV_PACKAGES" in os.environ:
         packages = os.environ["PIPENV_PACKAGES"].strip().split("\n")
     else:

--- a/pipenv/utils.py
+++ b/pipenv/utils.py
@@ -352,11 +352,10 @@ def venv_resolve_deps(
     if not deps:
         return []
     resolver = escape_grouped_arguments(resolver.__file__.rstrip("co"))
-    cmd = "{0} {1} {2} {3} {4} {5}".format(
+    cmd = "{0} {1} {2} {3} {4}".format(
         escape_grouped_arguments(which("python", allow_global=allow_global)),
         resolver,
         "--pre" if pre else "",
-        "--verbose" if (environments.is_verbose()) else "",
         "--clear" if clear else "",
         "--system" if allow_global else "",
     )
@@ -364,6 +363,7 @@ def venv_resolve_deps(
         os.environ["PIPENV_PACKAGES"] = "\n".join(deps)
         if pypi_mirror:
             os.environ["PIPENV_PYPI_MIRROR"] = str(pypi_mirror)
+        os.environ["PIPENV_VERBOSITY"] = str(environments.PIPENV_VERBOSITY)
         c = delegator.run(cmd, block=True)
     try:
         assert c.return_code == 0


### PR DESCRIPTION
##### The issue

`pipenv lock --verbose` does not set `PIPENV_VERBOSITY` correct for the resolver subprocess, and does not correctly show verbose output.


##### The fix

This patch adds the verbosity value into environment variables to make sure the resolver knows itself is in verbose (or debug) mode.

Some other changes are added to make the verbose flag understood by `pipenv-resolver`, and works well with environment variables (using `max()` calls).


##### The checklist

* [ ] Associated issue
* [x] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.
