### PR TITLE
Move misformatted comments

### DIFF
--- a/pipenv/progress.py
+++ b/pipenv/progress.py
@@ -113,9 +113,10 @@ class Bar(object):
             self.etadisp = self.format_time(self.eta)
         x = int(self.width * progress / self.expected_size)
         if not self.hide:
-            if (progress % self.every) == 0 or (  # True every "every" updates
-                progress == self.expected_size
-            ):  # And when we're done
+            if (
+                progress % self.every == 0  # True every "every" updates
+                or progress == self.expected_size  # And when we're done
+            ):
                 STREAM.write(
                     BAR_TEMPLATE
                     % (
@@ -208,9 +209,10 @@ def mill(it, label="", hide=None, expected_size=None, every=1):
 
     def _show(_i):
         if not hide:
-            if (_i % every) == 0 or (
-                _i == count
-            ):  # True every "every" updates  # And when we're done
+            if (
+                _i % every == 0  # True every "every" updates
+                or _i == count  # And when we're done
+            ):
                 STREAM.write(MILL_TEMPLATE % (label, _mill_char(_i), _i, count))
                 STREAM.flush()
 


### PR DESCRIPTION
##### The issue

Black moved a couple comments to some funky places.

##### The fix


This moves the comments back to the lines to which they refer.


##### The checklist

* [ ] Associated issue
* [ ] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

<!--
##### If this is a patch to the `vendor` directory…

Please try to refrain from submitting patches directly to `vendor` or `patched`, but raise your issue to the upstream project instead, and inform Pipenv to upgrade when the upstream project accepts the fix.

A pull request to upgrade vendor packages is strongly discouraged, unless there is a very good reason (e.g. you need to test Pipenv’s integration to a new vendor feature). Pipenv audits and performs vendor upgrades regularly, generally before a new release is about to drop.

If your patch is not or cannot be accepted by upstream, but is essential to Pipenv (make sure to discuss this with maintainers!), please remember to attach a patch file in `tasks/vendoring/patched`, so this divergence from upstream can be recorded and replayed afterwards.
-->
