### PR TITLE
Added missing 'egg=' in the example url

### DIFF
--- a/docs/basics.rst
+++ b/docs/basics.rst
@@ -247,7 +247,7 @@ the current working directory when working on packages::
     "e1839a8" = {path = ".", editable = true}
     ...
 
-.. note:: All sub-dependencies will get added to the ``Pipfile.lock`` as well. Sub-dependencies are **not** added to the 
+.. note:: All sub-dependencies will get added to the ``Pipfile.lock`` as well. Sub-dependencies are **not** added to the
           ``Pipfile.lock`` if you leave the ``-e`` option out.
 
 
@@ -336,7 +336,7 @@ If you experience issues with ``$ pipenv shell``, just check the ``PIPENV_SHELL`
 
 You can install packages with pipenv from git and other version control systems using URLs formatted according to the following rule::
 
-    <vcs_type>+<scheme>://<location>/<user_or_organizatoin>/<repository>@<branch_or_tag>#<package_name>
+    <vcs_type>+<scheme>://<location>/<user_or_organizatoin>/<repository>@<branch_or_tag>#egg=<package_name>
 
 The only optional section is the ``@<branch_or_tag>`` section.  When using git over SSH, you may use the shorthand vcs and scheme alias ``git+git@<location>:<user_or_organization>/<repository>@<branch_or_tag>#<package_name>``. Note that this is translated to ``git+ssh://git@<location>`` when parsed.
 

--- a/news/2792.doc
+++ b/news/2792.doc
@@ -1,0 +1,3 @@
+Fixed the example url for doing "pipenv install -e
+some-repo-url#egg=something", it was missing the "egg=" in the fragment
+identifier.


### PR DESCRIPTION
The example url for doing `pipenv install -e some-repo-url#egg=something` was missing the `egg=` in the fragment identifier. I fixed that.

I'll add a news/ file as soon as I've got a PR number :-)