### PR TITLE
Fixed link to the "be cordial" essay in the contribution doc.

### DIFF
--- a/docs/dev/contributing.rst
+++ b/docs/dev/contributing.rst
@@ -32,7 +32,7 @@ including reporting bugs or requesting features. This golden rule is
 **All contributions are welcome**, as long as
 everyone involved is treated with respect.
 
-.. _be cordial or be on your way: http://kennethreitz.org/be-cordial-or-be-on-your-way/
+.. _be cordial or be on your way: https://www.kennethreitz.org/essays/be-cordial-or-be-on-your-way
 
 .. _early-feedback:
 

--- a/news/2793.doc
+++ b/news/2793.doc
@@ -1,0 +1,1 @@
+Fixed link to the "be cordial" essay in the contribution documentation.


### PR DESCRIPTION
The link to the "be cordial" essay on https://pipenv.readthedocs.io/en/latest/dev/contributing/#be-cordial is out-of-date. I updated it.

Note: the similar link in `CODE_OF_CONDUCT.md` already points at the current essay location, so that one is fine.