### PR TITLE
default .env with local overrides

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,2 @@
+# Override with your own in .env.local
 HELLO=WORLD

--- a/.gitignore
+++ b/.gitignore
@@ -119,6 +119,7 @@ celerybeat-schedule
 
 # Environments
 .env
+.env.local
 .venv
 env/
 venv/

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -163,23 +163,22 @@ def load_dot_env():
             os.sep.join([project_directory, ".env.local"])
         ]
 
+    click.echo(
+        crayons.normal("Loading .env environment variables…", bold=True),
+        err=True,
+    )
+
     for dotenv_file in dotenv_files:
-        if os.path.isfile(dotenv_file):
+        if environments.PIPENV_DOTENV_LOCATION and not os.path.isfile(dotenv_file):
             click.echo(
-                crayons.normal("Loading .env environment variables…", bold=True),
+                "{0}: file {1}={2} does not exist!!\n{3}".format(
+                    crayons.red("Warning", bold=True),
+                    crayons.normal("PIPENV_DOTENV_LOCATION", bold=True),
+                    crayons.normal(environments.PIPENV_DOTENV_LOCATION, bold=True),
+                    crayons.red("Not loading environment variables.", bold=True),
+                ),
                 err=True,
             )
-        else:
-            if environments.PIPENV_DOTENV_LOCATION:
-                click.echo(
-                    "{0}: file {1}={2} does not exist!!\n{3}".format(
-                        crayons.red("Warning", bold=True),
-                        crayons.normal("PIPENV_DOTENV_LOCATION", bold=True),
-                        crayons.normal(environments.PIPENV_DOTENV_LOCATION, bold=True),
-                        crayons.red("Not loading environment variables.", bold=True),
-                    ),
-                    err=True,
-                )
         dotenv.load_dotenv(dotenv_file, override=True)
 
 

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -163,22 +163,29 @@ def load_dot_env():
             os.sep.join([project_directory, ".env.local"])
         ]
 
-    click.echo(
-        crayons.normal("Loading .env environment variables…", bold=True),
-        err=True,
-    )
-
     for dotenv_file in dotenv_files:
-        if environments.PIPENV_DOTENV_LOCATION and not os.path.isfile(dotenv_file):
+        if os.path.isfile(dotenv_file):
+            # No need to print the absolute path for project directory files
+            if not environments.PIPENV_DOTENV_LOCATION:
+                pretty_path = os.path.split(dotenv_file)[1]
+            else:
+                pretty_path = dotenv_file
+
             click.echo(
-                "{0}: file {1}={2} does not exist!!\n{3}".format(
-                    crayons.red("Warning", bold=True),
-                    crayons.normal("PIPENV_DOTENV_LOCATION", bold=True),
-                    crayons.normal(environments.PIPENV_DOTENV_LOCATION, bold=True),
-                    crayons.red("Not loading environment variables.", bold=True),
-                ),
+                crayons.normal("Loading {0} environment variables…".format(pretty_path), bold=True),
                 err=True,
             )
+        else:
+            if environments.PIPENV_DOTENV_LOCATION:
+                click.echo(
+                    "{0}: file {1}={2} does not exist!!\n{3}".format(
+                        crayons.red("Warning", bold=True),
+                        crayons.normal("PIPENV_DOTENV_LOCATION", bold=True),
+                        crayons.normal(environments.PIPENV_DOTENV_LOCATION, bold=True),
+                        crayons.red("Not loading environment variables.", bold=True),
+                    ),
+                    err=True,
+                )
         dotenv.load_dotenv(dotenv_file, override=True)
 
 

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -146,39 +146,41 @@ def do_clear():
 
 def load_dot_env():
     """Loads .env file into sys.environ."""
-    if not environments.PIPENV_DONT_LOAD_ENV:
-        if environments.PIPENV_DOTENV_LOCATION:
-            # As per $PATH, first should take precedence, so reverse.
-            # e.g. "path/to/.env.local;path/to/.env"
-            dotenv_files = reversed(
-                environments.PIPENV_DOTENV_LOCATION.split(os.pathsep)
+    if environments.PIPENV_DONT_LOAD_ENV:
+        return
+
+    if environments.PIPENV_DOTENV_LOCATION:
+        # As per $PATH, first should take precedence, so reverse.
+        # e.g. "path/to/.env.local;path/to/.env"
+        dotenv_files = reversed(
+            environments.PIPENV_DOTENV_LOCATION.split(os.pathsep)
+        )
+    else:
+        # If the project doesn't exist yet, check current directory for a .env file
+        project_directory = project.project_directory or "."
+        dotenv_files = [
+            os.sep.join([project_directory, ".env"]),
+            os.sep.join([project_directory, ".env.local"])
+        ]
+
+    for dotenv_file in dotenv_files:
+        if os.path.isfile(dotenv_file):
+            click.echo(
+                crayons.normal("Loading .env environment variables…", bold=True),
+                err=True,
             )
         else:
-            # If the project doesn't exist yet, check current directory for a .env file
-            project_directory = project.project_directory or "."
-            dotenv_files = [
-                os.sep.join([project_directory, ".env"]),
-                os.sep.join([project_directory, ".env.local"])
-            ]
-
-        for dotenv_file in dotenv_files:
-            if os.path.isfile(dotenv_file):
+            if environments.PIPENV_DOTENV_LOCATION:
                 click.echo(
-                    crayons.normal("Loading .env environment variables…", bold=True),
+                    "{0}: file {1}={2} does not exist!!\n{3}".format(
+                        crayons.red("Warning", bold=True),
+                        crayons.normal("PIPENV_DOTENV_LOCATION", bold=True),
+                        crayons.normal(environments.PIPENV_DOTENV_LOCATION, bold=True),
+                        crayons.red("Not loading environment variables.", bold=True),
+                    ),
                     err=True,
                 )
-            else:
-                if environments.PIPENV_DOTENV_LOCATION:
-                    click.echo(
-                        "{0}: file {1}={2} does not exist!!\n{3}".format(
-                            crayons.red("Warning", bold=True),
-                            crayons.normal("PIPENV_DOTENV_LOCATION", bold=True),
-                            crayons.normal(environments.PIPENV_DOTENV_LOCATION, bold=True),
-                            crayons.red("Not loading environment variables.", bold=True),
-                        ),
-                        err=True,
-                    )
-            dotenv.load_dotenv(dotenv_file, override=True)
+        dotenv.load_dotenv(dotenv_file, override=True)
 
 
 def add_to_path(p):

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -147,29 +147,38 @@ def do_clear():
 def load_dot_env():
     """Loads .env file into sys.environ."""
     if not environments.PIPENV_DONT_LOAD_ENV:
-        # If the project doesn't exist yet, check current directory for a .env file
-        project_directory = project.project_directory or "."
-        dotenv_file = environments.PIPENV_DOTENV_LOCATION or os.sep.join(
-            [project_directory, ".env"]
-        )
-
-        if os.path.isfile(dotenv_file):
-            click.echo(
-                crayons.normal("Loading .env environment variables…", bold=True),
-                err=True,
+        if environments.PIPENV_DOTENV_LOCATION:
+            # As per $PATH, first should take precedence, so reverse.
+            # e.g. "path/to/.env.local;path/to/.env"
+            dotenv_files = reversed(
+                environments.PIPENV_DOTENV_LOCATION.split(os.pathsep)
             )
         else:
-            if environments.PIPENV_DOTENV_LOCATION:
+            # If the project doesn't exist yet, check current directory for a .env file
+            project_directory = project.project_directory or "."
+            dotenv_files = [
+                os.sep.join([project_directory, ".env"]),
+                os.sep.join([project_directory, ".env.local"])
+            ]
+
+        for dotenv_file in dotenv_files:
+            if os.path.isfile(dotenv_file):
                 click.echo(
-                    "{0}: file {1}={2} does not exist!!\n{3}".format(
-                        crayons.red("Warning", bold=True),
-                        crayons.normal("PIPENV_DOTENV_LOCATION", bold=True),
-                        crayons.normal(environments.PIPENV_DOTENV_LOCATION, bold=True),
-                        crayons.red("Not loading environment variables.", bold=True),
-                    ),
+                    crayons.normal("Loading .env environment variables…", bold=True),
                     err=True,
                 )
-        dotenv.load_dotenv(dotenv_file, override=True)
+            else:
+                if environments.PIPENV_DOTENV_LOCATION:
+                    click.echo(
+                        "{0}: file {1}={2} does not exist!!\n{3}".format(
+                            crayons.red("Warning", bold=True),
+                            crayons.normal("PIPENV_DOTENV_LOCATION", bold=True),
+                            crayons.normal(environments.PIPENV_DOTENV_LOCATION, bold=True),
+                            crayons.red("Not loading environment variables.", bold=True),
+                        ),
+                        err=True,
+                    )
+            dotenv.load_dotenv(dotenv_file, override=True)
 
 
 def add_to_path(p):

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -33,6 +33,37 @@ def test_load_dot_env_from_environment_variable_location(capsys):
 
 
 @pytest.mark.core
+def test_load_dot_env_local_from_environment_variable_location_overrides(capsys):
+    key_one, key_two, key_three = 'KEY_ONE', 'KEY_TWO', 'KEY_THREE'
+
+    with temp_environ(), TemporaryDirectory(prefix='pipenv-', suffix='') as tempdir:
+        dotenv_path = os.path.join(tempdir.name, 'test.env')
+        environs = {
+            key_one: 'value_one',
+            key_two: 'value_two',
+        }
+        with open(dotenv_path, 'w') as f:
+            f.write('\n'.join('{}={}'.format(k, v) for k, v in environs.items()))
+
+        dotenv_local_path = os.path.join(tempdir.name, 'test.env.local')
+        environs_local = {
+            key_two: 'value_two_local',
+            key_three: 'value_three_local',
+        }
+        with open(dotenv_local_path, 'w') as f:
+            f.write('\n'.join('{}={}'.format(k, v) for k, v in environs_local.items()))
+
+        dotenv_paths = os.pathsep.join([dotenv_local_path, dotenv_path])
+
+        with mock.patch('pipenv.environments.PIPENV_DOTENV_LOCATION', dotenv_paths):
+            load_dot_env()
+
+        assert os.environ[key_one] == environs[key_one]
+        assert os.environ[key_two] == environs_local[key_two]
+        assert os.environ[key_three] == environs_local[key_three]
+
+
+@pytest.mark.core
 def test_doesnt_load_dot_env_if_disabled(capsys):
     with temp_environ(), TemporaryDirectory(prefix='pipenv-', suffix='') as tempdir:
         dotenv_path = os.path.join(tempdir.name, 'test.env')


### PR DESCRIPTION
Hi,

I'm unsure if this now the correct place for a feature request (the [link](https://kenneth-reitz.uservoice.com/forums/913660-general) in the issue template no longer seems to be working).

I've been using Vue.js for some web development and their build tool have some nice .env support which I think would be nice to have in pipenv.

So with the Vue.js webpack template you can have a `.env` file which you can commit to your source control which is nice to provide some default configurations to all developers. You can then override that `.env` with a `.env.local` which will merge over the top replacing any redeclared environment variable values. This one is obviously not tracked by source control.

Wondering if that's a feature which others would also like to see.

Thanks.