### PR TITLE
Update code of conduct location

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,3 +1,3 @@
-Be cordial or be on your way.
+PyPA Projects are governed by the PyPA code of conduct available here:
 
-https://www.kennethreitz.org/essays/be-cordial-or-be-on-your-way
+https://www.pypa.io/en/latest/code-of-conduct/


### PR DESCRIPTION
##### The issue

The code of conduct document linked to the wrong code of conduct.

##### The fix

This fixes the code of conduct document to link to the PyPA code of conduct.
