### PR TITLE
Fix 2 ResourceWarning: unclosed file, in tests

### DIFF
--- a/news/2808.trivial
+++ b/news/2808.trivial
@@ -1,0 +1,1 @@
+Fix 2 ResourceWarning: unclosed file, in tests.

--- a/tests/integration/test_install_twists.py
+++ b/tests/integration/test_install_twists.py
@@ -210,9 +210,10 @@ Requests = "==2.14.0"   # Inline comment
         c = p.pipenv("install python_DateUtil")
         assert c.return_code == 0
         assert "python-dateutil" in p.pipfile["packages"]
-        contents = open(p.pipfile_path).read()
-        assert "# Pre comment" in contents
-        assert "# Inline comment" in contents
+        with open(p.pipfile_path) as f:
+            contents = f.read()
+            assert "# Pre comment" in contents
+            assert "# Inline comment" in contents
 
 
 @pytest.mark.files

--- a/tests/integration/test_uninstall.py
+++ b/tests/integration/test_uninstall.py
@@ -148,6 +148,7 @@ python_DateUtil = "*"   # Inline comment
         c = p.pipenv("uninstall python_dateutil")
         assert "Requests" in p.pipfile["packages"]
         assert "python_DateUtil" not in p.pipfile["packages"]
-        contents = open(p.pipfile_path).read()
-        assert "# Pre comment" in contents
-        assert "# Inline comment" in contents
+        with open(p.pipfile_path) as f:
+            contents = f.read()
+            assert "# Pre comment" in contents
+            assert "# Inline comment" in contents


### PR DESCRIPTION
##### The issue

There are 2 unclosed files in tests, nothing big.

##### The fix

Use context managers.

##### The checklist

* [ ] Associated issue
* [x] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.
