### PR TITLE
Refactor CLI to lean more heavily on click's built in functionality

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -24,6 +24,8 @@ recursive-include docs/_templates *.html
 recursive-include docs/_static *.js *.css *.png
 recursive-exclude docs requirements*.txt
 
+
+prune peeps
 prune .buildkite
 prune .github
 prune .vsts-ci

--- a/news/1690.bugfix
+++ b/news/1690.bugfix
@@ -1,0 +1,1 @@
+VCS Refs for locked local editable dependencies will now update appropriately to the latest hash when running ``pipenv update``.

--- a/news/2173.bugfix
+++ b/news/2173.bugfix
@@ -1,0 +1,1 @@
+``.tar.gz`` and ``.zip`` artifacts will now have dependencies installed even when they are missing from the lockfile.

--- a/news/2279.bugfix
+++ b/news/2279.bugfix
@@ -1,0 +1,1 @@
+The command line parser will now handle multiple ``-e/--editable`` dependencies properly via click's option parser to help mitigate future parsing issues.

--- a/news/2494.bugfix
+++ b/news/2494.bugfix
@@ -1,0 +1,1 @@
+Fixed a bug which could cause ``-i/--index`` arguments to sometimes be incorrectly picked up in packages.  This is now handled in the command line parser.

--- a/news/2714.bugfix
+++ b/news/2714.bugfix
@@ -1,0 +1,1 @@
+Fixed a bug which could cause the ``-e/--editable`` argument on a dependency to be accidentally parsed as a dependency itself.

--- a/news/2748.bugfix
+++ b/news/2748.bugfix
@@ -1,0 +1,1 @@
+All markers are now included in ``pipenv lock --requirements`` output.

--- a/news/2760.bugfix
+++ b/news/2760.bugfix
@@ -1,0 +1,1 @@
+Fixed a bug in marker resolution which could cause duplicate and non-deterministic markers.

--- a/news/2766.bugfix
+++ b/news/2766.bugfix
@@ -1,0 +1,1 @@
+Fixed a bug in the dependency resolver which caused regular issues when handling ``setup.py`` based dependency resolution.

--- a/news/2814.feature
+++ b/news/2814.feature
@@ -1,0 +1,1 @@
+Deduplicate and refactor CLI to use stateful arguments and object passing.  See `this issue <https://github.com/pallets/click/issues/108>`_ for reference.

--- a/pipenv/_compat.py
+++ b/pipenv/_compat.py
@@ -90,7 +90,7 @@ class TemporaryDirectory(object):
     in it are removed.
     """
 
-    def __init__(self, suffix=None, prefix=None, dir=None):
+    def __init__(self, suffix="", prefix="", dir=None):
         if "RAM_DISK" in os.environ:
             import uuid
 

--- a/pipenv/cli/__init__.py
+++ b/pipenv/cli/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding=utf-8 -*-
+from __future__ import absolute_import, unicode_literals
+from .command import cli

--- a/pipenv/cli/__init__.py
+++ b/pipenv/cli/__init__.py
@@ -1,3 +1,3 @@
 # -*- coding=utf-8 -*-
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import
 from .command import cli

--- a/pipenv/cli/command.py
+++ b/pipenv/cli/command.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, unicode_literals
+from __future__ import absolute_import
 
 import os
 import sys

--- a/pipenv/cli/command.py
+++ b/pipenv/cli/command.py
@@ -193,7 +193,7 @@ def cli(
                 )
                 ctx.abort()
     # --two / --three was passed…
-    if (python or three is not None) or site_packages:
+    if (state.python or state.three is not None) or site_packages:
         ensure_project(
             three=state.three,
             python=state.python,
@@ -319,7 +319,7 @@ def lock(
                         pypi_mirror=state.pypi_mirror)
     do_lock(
         clear=state.clear,
-        pre=state.pre,
+        pre=state.installstate.pre,
         keep_outdated=state.installstate.keep_outdated,
         pypi_mirror=state.pypi_mirror,
     )
@@ -348,12 +348,9 @@ def lock(
 @pass_state
 def shell(
     state,
-    three=None,
-    python=False,
     fancy=False,
     shell_args=None,
     anyway=False,
-    pypi_mirror=None,
 ):
     """Spawns a shell within the virtualenv."""
     from ..core import load_dot_env, do_shell
@@ -378,11 +375,11 @@ def shell(
     if os.name == "nt":
         fancy = True
     do_shell(
-        three=three,
-        python=python,
+        three=state.three,
+        python=state.python,
         fancy=fancy,
         shell_args=shell_args,
-        pypi_mirror=pypi_mirror,
+        pypi_mirror=state.pypi_mirror,
     )
 
 
@@ -481,8 +478,8 @@ def update(
         outdated = bool(dry_run)
     if outdated:
         do_outdated(pypi_mirror=state.pypi_mirror)
-    packages = [p for p in state.packages if p]
-    editable = [p for p in state.editable if p]
+    packages = [p for p in state.installstate.packages if p]
+    editable = [p for p in state.installstate.editables if p]
     if not packages:
         echo(
             "{0} {1} {2} {3}{4}".format(

--- a/pipenv/cli/command.py
+++ b/pipenv/cli/command.py
@@ -212,7 +212,6 @@ def cli(
     short_help="Installs provided packages and adds them to Pipfile, or (if none is given), installs all packages.",
     context_settings=dict(ignore_unknown_options=True, allow_extra_args=True),
 )
-@requirementstxt_option
 @system_option
 @code_option
 @deploy_option
@@ -295,18 +294,10 @@ def uninstall(
 
 
 @cli.command(short_help="Generates Pipfile.lock.")
-@option(
-    "--requirements",
-    "-r",
-    is_flag=True,
-    default=False,
-    help="Generate output compatible with requirements.txt.",
-)
 @lock_options
 @pass_state
 def lock(
     state,
-    requirements=False,
     **kwargs
 ):
     """Generates Pipfile.lock."""
@@ -314,8 +305,8 @@ def lock(
 
     # Ensure that virtualenv is available.
     ensure_project(three=state.three, python=state.python, pypi_mirror=state.pypi_mirror)
-    if requirements:
-        do_init(dev=state.installstate.dev, requirements=requirements,
+    if state.installstate.requirementstxt:
+        do_init(dev=state.installstate.dev, requirements=state.installstate.requirementstxt,
                         pypi_mirror=state.pypi_mirror)
     do_lock(
         clear=state.clear,

--- a/pipenv/cli/command.py
+++ b/pipenv/cli/command.py
@@ -19,7 +19,7 @@ from .. import environments
 from ..__version__ import __version__
 from .options import (
     CONTEXT_SETTINGS, PipenvGroup, code_option, common_options, deploy_option,
-    general_options, install_options, lock_options, pass_state,
+    general_options, install_options, lock_options, pass_state, skip_lock_option,
     pypi_mirror_option, python_option, requirementstxt_option, sync_options,
     system_option, three_option, verbose_option, uninstall_options
 )
@@ -215,6 +215,7 @@ def cli(
 @system_option
 @code_option
 @deploy_option
+@skip_lock_option
 @install_options
 @pass_state
 @pass_context
@@ -498,7 +499,7 @@ def update(
         clear=state.clear,
         pre=state.installstate.pre,
         keep_outdated=state.installstate.keep_outdated,
-        pypi_mirror=state.installstate.pypi_mirror,
+        pypi_mirror=state.pypi_mirror,
     )
     do_sync(
         ctx=ctx,

--- a/pipenv/cli/options.py
+++ b/pipenv/cli/options.py
@@ -273,6 +273,16 @@ def requirementstxt_option(f):
                     help="Import a requirements.txt file.", callback=callback)(f)
 
 
+def requirements_flag(f):
+    def callback(ctx, param, value):
+        state = ctx.ensure_object(State)
+        if value:
+            state.installstate.requirementstxt = value
+        return value
+    return option("--requirements", "-r", default=False, is_flag=True, expose_value=False,
+                    help="Generate output in requirements.txt format.", callback=callback)(f)
+
+
 def code_option(f):
     def callback(ctx, param, value):
         state = ctx.ensure_object(State)
@@ -345,9 +355,7 @@ def uninstall_options(f):
 
 def lock_options(f):
     f = install_base_options(f)
-    f = index_option(f)
-    f = extra_index_option(f)
-    f = skip_lock_option(f)
+    f = requirements_flag(f)
     f = pre_option(f)
     return f
 
@@ -355,13 +363,15 @@ def lock_options(f):
 def sync_options(f):
     f = install_base_options(f)
     f = sequential_option(f)
-    f = sequential_option(f)
     return f
 
 
 def install_options(f):
-    f = lock_options(f)
-    f = sequential_option(f)
+    f = sync_options(f)
+    f = index_option(f)
+    f = extra_index_option(f)
+    f = requirementstxt_option(f)
+    f = pre_option(f)
     f = selective_upgrade_option(f)
     f = ignore_pipfile_option(f)
     f = editable_option(f)

--- a/pipenv/cli/options.py
+++ b/pipenv/cli/options.py
@@ -1,9 +1,16 @@
 # -*- coding=utf-8 -*-
-from __future__ import absolute_import, unicode_literals
-from click import Group, option, Option, make_pass_decorator, argument, BadParameter, BOOL as click_booltype, echo
-from ..utils import is_valid_url
+from __future__ import absolute_import
+
 import os
+
+from click import BOOL as click_booltype
+from click import (
+    BadParameter, Group, Option, argument, echo, make_pass_decorator, option
+)
+
 from .. import environments
+from ..utils import is_valid_url
+
 
 CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
 

--- a/pipenv/cli/options.py
+++ b/pipenv/cli/options.py
@@ -85,7 +85,7 @@ def index_option(f):
         state = ctx.ensure_object(State)
         state.index = value
         return value
-    return option('-i', '--index', expose_value=False, multiple=True, envvar="PIP_INDEX_URL",
+    return option('-i', '--index', expose_value=False, envvar="PIP_INDEX_URL",
                         help='Target PyPI-compatible package index url.', nargs=1,
                         callback=callback)(f)
 

--- a/pipenv/cli/options.py
+++ b/pipenv/cli/options.py
@@ -1,0 +1,368 @@
+# -*- coding=utf-8 -*-
+from __future__ import absolute_import, unicode_literals
+from click import Group, option, Option, make_pass_decorator, argument, BadParameter, BOOL as click_booltype, echo
+from ..utils import is_valid_url
+import os
+from .. import environments
+
+CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
+
+
+class PipenvGroup(Group):
+    """Custom Group class provides formatted main help"""
+
+    def get_help_option(self, ctx):
+        from ..core import format_help
+
+        """Override for showing formatted main help via --help and -h options"""
+        help_options = self.get_help_option_names(ctx)
+        if not help_options or not self.add_help_option:
+            return
+
+        def show_help(ctx, param, value):
+            if value and not ctx.resilient_parsing:
+                if not ctx.invoked_subcommand:
+                    # legit main help
+                    echo(format_help(ctx.get_help()))
+                else:
+                    # legit sub-command help
+                    echo(ctx.get_help(), color=ctx.color)
+                ctx.exit()
+
+        return Option(
+            help_options,
+            is_flag=True,
+            is_eager=True,
+            expose_value=False,
+            callback=show_help,
+            help="Show this message and exit.",
+        )
+
+
+class State(object):
+    def __init__(self):
+        self.index = None
+        self.extra_index_urls = []
+        self.verbose = False
+        self.pypi_mirror = None
+        self.python = None
+        self.two = None
+        self.three = None
+        self.site_packages = False
+        self.clear = False
+        self.system = False
+        self.installstate = InstallState()
+
+
+class InstallState(object):
+    def __init__(self):
+        self.dev = False
+        self.pre = False
+        self.selective_upgrade = False
+        self.keep_outdated = False
+        self.skip_lock = False
+        self.ignore_pipfile = False
+        self.sequential = False
+        self.code = False
+        self.requirementstxt = None
+        self.deploy = False
+        self.packages = []
+        self.editables = []
+
+
+pass_state = make_pass_decorator(State, ensure=True)
+
+
+def index_option(f):
+    def callback(ctx, param, value):
+        state = ctx.ensure_object(State)
+        state.index = value
+        return value
+    return option('-i', '--index', expose_value=False, multiple=True, envvar="PIP_INDEX_URL",
+                        help='Target PyPI-compatible package index url.', nargs=1,
+                        callback=callback)(f)
+
+
+def extra_index_option(f):
+    def callback(ctx, param, value):
+        state = ctx.ensure_object(State)
+        if isinstance(value, (tuple, list)):
+            state.extra_index_urls.extend(list(value))
+        else:
+            state.extra_index_urls.append(value)
+        return value
+    return option("--extra-index-url", multiple=True, expose_value=False,
+        help=u"URLs to the extra PyPI compatible indexes to query for package lookups.",
+        callback=callback, envvar="PIP_EXTRA_INDEX_URL")(f)
+
+
+def editable_option(f):
+    def callback(ctx, param, value):
+        state = ctx.ensure_object(State)
+        state.installstate.editables.extend(value)
+        return value
+    return option('-e', '--editable', expose_value=False, multiple=True,
+                        help='An editable python package URL or path, often to a VCS repo.',
+                        callback=callback)(f)
+
+
+def sequential_option(f):
+    def callback(ctx, param, value):
+        state = ctx.ensure_object(State)
+        state.installstate.sequential = value
+        return value
+    return option("--sequential", is_flag=True, default=False, expose_value=False,
+                    help="Install dependencies one-at-a-time, instead of concurrently.",
+                    callback=callback, type=click_booltype)(f)
+
+
+def skip_lock_option(f):
+    def callback(ctx, param, value):
+        state = ctx.ensure_object(State)
+        state.installstate.skip_lock = value
+        return value
+    return option("--skip-lock", is_flag=True, default=False, expose_value=False,
+                    help=u"Ignore locking mechanisms when installing—use the Pipfile, instead.",
+                    callback=callback, type=click_booltype)(f)
+
+
+def keep_outdated_option(f):
+    def callback(ctx, param, value):
+        state = ctx.ensure_object(State)
+        state.installstate.keep_outdated = value
+        return value
+    return option("--keep-outdated", is_flag=True, default=False, expose_value=False,
+                    help=u"Keep out-dated dependencies from being updated in Pipfile.lock.",
+                    callback=callback, type=click_booltype)(f)
+
+
+def selective_upgrade_option(f):
+    def callback(ctx, param, value):
+        state = ctx.ensure_object(State)
+        state.installstate.selective_upgrade = value
+        return value
+    return option("--selective-upgrade", is_flag=True, default=False, type=click_booltype,
+                    help="Update specified packages.", callback=callback,
+                    expose_value=False)(f)
+
+
+def ignore_pipfile_option(f):
+    def callback(ctx, param, value):
+        state = ctx.ensure_object(State)
+        state.installstate.ignore_pipfile = value
+        return value
+    return option("--ignore-pipfile", is_flag=True, default=False, expose_value=False,
+                    help="Ignore Pipfile when installing, using the Pipfile.lock.",
+                    callback=callback)(f)
+
+
+def dev_option(f):
+    def callback(ctx, param, value):
+        state = ctx.ensure_object(State)
+        state.installstate.dev = value
+        return value
+    return option("--dev", "-d", is_flag=True, default=False, type=click_booltype,
+                    help="Install package(s) in [dev-packages].", callback=callback,
+                    expose_value=False)(f)
+
+
+def pre_option(f):
+    def callback(ctx, param, value):
+        state = ctx.ensure_object(State)
+        state.installstate.pre = value
+        return value
+    return option("--pre", is_flag=True, default=False, help=u"Allow pre-releases.",
+         callback=callback, type=click_booltype, expose_value=False)(f)
+
+
+def package_arg(f):
+    def callback(ctx, param, value):
+        state = ctx.ensure_object(State)
+        state.installstate.packages.extend(value)
+        return value
+    return argument('packages', nargs=-1, callback=callback, expose_value=False,)(f)
+
+
+def three_option(f):
+    def callback(ctx, param, value):
+        state = ctx.ensure_object(State)
+        if value is not None:
+            state.three = value
+            state.two = not value
+        return value
+    return option("--three/--two", is_flag=True, default=None,
+                    help="Use Python 3/2 when creating virtualenv.", callback=callback,
+                    expose_value=False)(f)
+
+
+def python_option(f):
+    def callback(ctx, param, value):
+        state = ctx.ensure_object(State)
+        if value is not None:
+            state.python = validate_python_path(ctx, param, value)
+        return value
+    return option("--python", default=False, nargs=1, callback=callback,
+                    help="Specify which version of Python virtualenv should use.",
+                    expose_value=False)(f)
+
+
+def pypi_mirror_option(f):
+    def callback(ctx, param, value):
+        state = ctx.ensure_object(State)
+        if value is not None:
+            state.pypi_mirror = validate_pypi_mirror(ctx, param, value)
+        return value
+    return option("--pypi-mirror", default=environments.PIPENV_PYPI_MIRROR, nargs=1,
+                    callback=callback, help="Specify a PyPI mirror.", expose_value=False)(f)
+
+
+def verbose_option(f):
+    def callback(ctx, param, value):
+        state = ctx.ensure_object(State)
+        if value:
+            state.verbose = True
+        setup_verbosity(ctx, param, value)
+    return option("--verbose", "-v", is_flag=True, expose_value=False,
+                    callback=callback, help="Verbose mode.")(f)
+
+
+def site_packages_option(f):
+    def callback(ctx, param, value):
+        state = ctx.ensure_object(State)
+        state.site_packages = value
+        return value
+    return option("--site-packages", is_flag=True, default=False, type=click_booltype,
+                    help="Enable site-packages for the virtualenv.", callback=callback,
+                    expose_value=False)(f)
+
+
+def clear_option(f):
+    def callback(ctx, param, value):
+        state = ctx.ensure_object(State)
+        state.clear = value
+        return value
+    return option("--clear", is_flag=True, callback=callback, type=click_booltype,
+                    help="Clears caches (pipenv, pip, and pip-tools).",
+                    expose_value=False)(f)
+
+
+def system_option(f):
+    def callback(ctx, param, value):
+        state = ctx.ensure_object(State)
+        if value is not None:
+            state.system = value
+        return value
+    return option("--system", is_flag=True, default=False, help="System pip management.",
+                    callback=callback, type=click_booltype, expose_value=False)(f)
+
+
+def requirementstxt_option(f):
+    def callback(ctx, param, value):
+        state = ctx.ensure_object(State)
+        if value:
+            state.installstate.requirementstxt = value
+        return value
+    return option("--requirements", "-r", nargs=1, default=False, expose_value=False,
+                    help="Import a requirements.txt file.", callback=callback)(f)
+
+
+def code_option(f):
+    def callback(ctx, param, value):
+        state = ctx.ensure_object(State)
+        if value:
+            state.installstate.code = value
+        return value
+    return option("--code", "-c", nargs=1, default=False, help="Import from codebase.",
+                    callback=callback, expose_value=False)(f)
+
+
+def deploy_option(f):
+    def callback(ctx, param, value):
+        state = ctx.ensure_object(State)
+        state.installstate.deploy = value
+        return value
+    return option("--deploy", is_flag=True, default=False, type=click_booltype,
+                    help=u"Abort if the Pipfile.lock is out-of-date, or Python version is"
+                            " wrong.", callback=callback, expose_value=False)(f)
+
+
+def setup_verbosity(ctx, param, value):
+    if not value:
+        return
+    import logging
+    logging.getLogger("pip").setLevel(logging.INFO)
+    environments.PIPENV_VERBOSITY = 1
+
+
+def validate_python_path(ctx, param, value):
+    # Validating the Python path is complicated by accepting a number of
+    # friendly options: the default will be boolean False to enable
+    # autodetection but it may also be a value which will be searched in
+    # the path or an absolute path. To report errors as early as possible
+    # we'll report absolute paths which do not exist:
+    if isinstance(value, (str, bytes)):
+        if os.path.isabs(value) and not os.path.isfile(value):
+            raise BadParameter("Expected Python at path %s does not exist" % value)
+    return value
+
+
+def validate_pypi_mirror(ctx, param, value):
+    if value and not is_valid_url(value):
+        raise BadParameter("Invalid PyPI mirror URL: %s" % value)
+    return value
+
+
+def common_options(f):
+    f = pypi_mirror_option(f)
+    f = verbose_option(f)
+    f = clear_option(f)
+    f = three_option(f)
+    f = python_option(f)
+    return f
+
+
+def install_base_options(f):
+    f = common_options(f)
+    f = dev_option(f)
+    f = keep_outdated_option(f)
+    return f
+
+
+def uninstall_options(f):
+    f = install_base_options(f)
+    f = skip_lock_option(f)
+    f = editable_option(f)
+    f = package_arg(f)
+    return f
+
+
+def lock_options(f):
+    f = install_base_options(f)
+    f = index_option(f)
+    f = extra_index_option(f)
+    f = skip_lock_option(f)
+    f = pre_option(f)
+    return f
+
+
+def sync_options(f):
+    f = install_base_options(f)
+    f = sequential_option(f)
+    f = sequential_option(f)
+    return f
+
+
+def install_options(f):
+    f = lock_options(f)
+    f = sequential_option(f)
+    f = selective_upgrade_option(f)
+    f = ignore_pipfile_option(f)
+    f = editable_option(f)
+    f = package_arg(f)
+    return f
+
+
+def general_options(f):
+    f = common_options(f)
+    f = site_packages_option(f)
+    return f

--- a/pipenv/cli/options.py
+++ b/pipenv/cli/options.py
@@ -93,10 +93,7 @@ def index_option(f):
 def extra_index_option(f):
     def callback(ctx, param, value):
         state = ctx.ensure_object(State)
-        if isinstance(value, (tuple, list)):
-            state.extra_index_urls.extend(list(value))
-        else:
-            state.extra_index_urls.append(value)
+        state.extra_index_urls.extend(list(value))
         return value
     return option("--extra-index-url", multiple=True, expose_value=False,
         help=u"URLs to the extra PyPI compatible indexes to query for package lookups.",

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -1833,15 +1833,9 @@ def do_install(
     else:
         from .vendor.requirementslib import Requirement
         # make a tuple of (display_name, entry)
-        pkg_dict = {
-            'packages': [(pkg, pkg) for pkg in packages],
-            'editables': [("-e {0}".format(pkg), pkg) for pkg in editable_packages]
-        }
+        pkg_list = packages + ["-e {0}".format(pkg) for pkg in editable_packages]
 
-        for pkg_type, pkg_tuple in pkg_dict.items():
-            if not pkg_tuple:
-                continue
-            pkg_line, pkg_val = pkg_tuple.pop()
+        for pkg_line in pkg_list:
             click.echo(
                 crayons.normal(
                     u"Installing {0}…".format(crayons.green(pkg_line, bold=True)),
@@ -1856,7 +1850,8 @@ def do_install(
                     click.echo("{0}: {1}".format(crayons.red("WARNING"), e))
                     requirements_directory.cleanup()
                     sys.exit(1)
-
+                if index_url:
+                    pkg_requirement.index = index_url
                 c = pip_install(
                     pkg_requirement,
                     ignore_hashes=True,

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -1634,7 +1634,7 @@ def do_install(
     )
     if selective_upgrade:
         keep_outdated = True
-    packages = packages if packages else []
+    packages = packages if packages else[]
     editable_packages = editable_packages if editable_packages else []
     package_args = [p for p in packages if p] + [p for p in editable_packages if p]
     skip_requirements = False
@@ -1814,11 +1814,12 @@ def do_install(
             'packages': [(pkg, pkg) for pkg in packages],
             'editables': [("-e {0}".format(pkg), pkg) for pkg in editable_packages]
         }
+        pkg_tuples = [pkg_tuple for pkg_list in pkg_dict.values() for pkg_tuple in pkg_list]
 
-        for pkg_type, pkg_tuple in pkg_dict.items():
+        for pkg_tuple in pkg_tuples:
             if not pkg_tuple:
                 continue
-            pkg_line, pkg_val = pkg_tuple.pop()
+            pkg_line, pkg_val = pkg_tuple
             click.echo(
                 crayons.normal(
                     u"Installing {0}…".format(crayons.green(pkg_line, bold=True)),
@@ -1965,7 +1966,7 @@ def do_uninstall(
             )
         )
         package_names = project.dev_packages.keys()
-    if packages is False and editable_packages is False and not all_dev:
+    if not packages and not editable_packages and not all_dev:
         click.echo(crayons.red("No package provided!"), err=True)
         return 1
     for package_name in package_names:

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -672,7 +672,7 @@ def do_install_dependencies(
                 click.echo(
                     "{0} {1}! Will try again.".format(
                         crayons.red("An error occurred while installing"),
-                        crayons.green(c.dep.split("--hash")[0].strip()),
+                        crayons.green(c.dep.as_line()),
                     )
                 )
 
@@ -766,9 +766,6 @@ def do_install_dependencies(
         )
         for dep, ignore_hash in progress.bar(failed_deps_list, label=INSTALL_LABEL2):
             # Use a specific index, if specified.
-            dep, index = split_argument(dep, short="i", long_="index", num=1)
-            dep, extra_indexes = split_argument(dep, long_="extra-index-url")
-            dep = Requirement.from_line(dep)
             # Install the module.
             c = pip_install(
                 dep,
@@ -1287,7 +1284,7 @@ def pip_install(
             prefix="pipenv-", suffix="-requirement.txt", dir=requirements_dir
         )
         with os.fdopen(fd, "w") as f:
-            f.write(requirement.normalized_name)
+            f.write(requirement.as_line())
     # Install dependencies when a package is a VCS dependency.
     if requirement and requirement.vcs:
         no_deps = False
@@ -1935,6 +1932,8 @@ def do_uninstall(
     if PIPENV_USE_SYSTEM:
         system = True
     # Ensure that virtualenv is available.
+    # TODO: We probably shouldn't ensure a project exists if the outcome will be to just
+    # install things in order to remove them... maybe tell the user to install first?
     ensure_project(three=three, python=python, pypi_mirror=pypi_mirror)
     editable_pkgs = [
         Requirement.from_line("-e {0}".format(p)).name

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -744,7 +744,7 @@ def do_install_dependencies(
             dep = Requirement.from_line(dep)
             # Install the module.
             prev_no_deps_setting = no_deps
-            if dep.is_file and any(dep.req.uri.endswith(ext) for ext in ['zip', 'tar.gz']):
+            if dep.is_file_or_url and any(dep.req.uri.endswith(ext) for ext in ['zip', 'tar.gz']):
                 no_deps = False
             c = pip_install(
                 dep,
@@ -776,7 +776,7 @@ def do_install_dependencies(
             # Use a specific index, if specified.
             # Install the module.
             prev_no_deps_setting = no_deps
-            if dep.is_file and any(dep.req.uri.endswith(ext) for ext in ['zip', 'tar.gz']):
+            if dep.is_file_or_url and any(dep.req.uri.endswith(ext) for ext in ['zip', 'tar.gz']):
                 no_deps = False
             c = pip_install(
                 dep,

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -1908,7 +1908,7 @@ def do_install(
             )
             # Add the package to the Pipfile.
             try:
-                project.add_package_to_pipfile(pkg_requirement.as_line(), dev)
+                project.add_package_to_pipfile(pkg_requirement, dev)
             except ValueError as e:
                 click.echo(
                     "{0} {1}".format(crayons.red("ERROR (PACKAGE NOT INSTALLED):"), e)

--- a/pipenv/patched/piptools/repositories/pypi.py
+++ b/pipenv/patched/piptools/repositories/pypi.py
@@ -294,9 +294,9 @@ class PyPIRepository(BaseRepository):
                 except (TypeError, ValueError, AttributeError):
                     pass
                 else:
-                    setup_requires = getattr(dist, "requires", None)
+                    setup_requires = getattr(dist, "extras_require", None)
                     if not setup_requires:
-                        setup_requires = getattr(dist, "setup_requires", None)
+                        setup_requires = {"setup_requires": getattr(dist, "setup_requires", None)}
             try:
                 # Pip 9 and below
                 reqset = RequirementSet(

--- a/pipenv/project.py
+++ b/pipenv/project.py
@@ -289,7 +289,7 @@ class Project(object):
                 new_path = [new_path[0], PIPENV_ROOT, PIPENV_PATCHED, PIPENV_VENDOR] + new_path[1:]
                 sys.path = new_path
                 os.environ['VIRTUAL_ENV'] = self.virtualenv_location
-                from .patched.notpip._internal.utils.misc import get_installed_distributions
+                from .vendor.pip_shims.shims import get_installed_distributions
                 return get_installed_distributions(local_only=True)
         else:
             return []
@@ -372,7 +372,10 @@ class Project(object):
 
     @property
     def virtualenv_src_location(self):
-        loc = os.sep.join([self.virtualenv_location, "src"])
+        if self.virtualenv_location:
+            loc = os.sep.join([self.virtualenv_location, "src"])
+        else:
+            loc = os.sep.join([self.project_directory, "src"])
         mkdir_p(loc)
         return loc
 

--- a/pipenv/project.py
+++ b/pipenv/project.py
@@ -770,13 +770,14 @@ class Project(object):
             del p[key][name]
             self.write_toml(p)
 
-    def add_package_to_pipfile(self, package_name, dev=False):
+    def add_package_to_pipfile(self, package, dev=False):
         from .vendor.requirementslib import Requirement
 
         # Read and append Pipfile.
         p = self.parsed_pipfile
         # Don't re-capitalize file URLs or VCSs.
-        package = Requirement.from_line(package_name.strip())
+        if not isinstance(package, Requirement):
+            package = Requirement.from_line(package.strip())
         _, converted = package.pipfile_entry
         key = "dev-packages" if dev else "packages"
         # Set empty group if it doesn't exist yet.

--- a/pipenv/vendor/requirementslib/__init__.py
+++ b/pipenv/vendor/requirementslib/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding=utf-8 -*-
-__version__ = '1.1.5'
+__version__ = '1.1.6.dev0'
 
 
 from .exceptions import RequirementError

--- a/pipenv/vendor/requirementslib/__init__.py
+++ b/pipenv/vendor/requirementslib/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding=utf-8 -*-
-__version__ = '1.1.6.dev0'
+__version__ = '1.1.7.dev0'
 
 
 from .exceptions import RequirementError

--- a/pipenv/vendor/requirementslib/models/markers.py
+++ b/pipenv/vendor/requirementslib/models/markers.py
@@ -82,12 +82,12 @@ class PipenvMarkers(BaseRequirement):
         marker_strings = ["{0} {1}".format(k, pipfile[k]) for k in found_keys]
         if pipfile.get("markers"):
             marker_strings.append(pipfile.get("markers"))
-        markers = []
+        markers = set()
         for marker in marker_strings:
-            markers.append(marker)
+            markers.add(marker)
         combined_marker = None
         try:
-            combined_marker = cls.make_marker(" and ".join(markers))
+            combined_marker = cls.make_marker(" and ".join(sorted(markers)))
         except RequirementError:
             pass
         else:

--- a/pipenv/vendor/requirementslib/models/pipfile.py
+++ b/pipenv/vendor/requirementslib/models/pipfile.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-import os
-
 from vistir.compat import Path
 
 from .requirements import Requirement
@@ -30,10 +28,10 @@ class Pipfile(plette.pipfiles.Pipfile):
         with pipfile_path.open(encoding="utf-8") as fp:
             pipfile = super(Pipfile, cls).load(fp)
         pipfile.dev_requirements = [
-            Requirement.from_pipfile(k, v) for k, v in pipfile.dev_packages.items()
+            Requirement.from_pipfile(k, v) for k, v in pipfile.get("dev-packages", {}).items()
         ]
         pipfile.requirements = [
-            Requirement.from_pipfile(k, v) for k, v in pipfile.packages.items()
+            Requirement.from_pipfile(k, v) for k, v in pipfile.get("packages", {}).items()
         ]
         pipfile.path = pipfile_path
         return pipfile
@@ -57,10 +55,10 @@ class Pipfile(plette.pipfiles.Pipfile):
     def dev_packages(self, as_requirements=True):
         if as_requirements:
             return self.dev_requirements
-        return self.dev_packages
+        return self.get('dev-packages', {})
 
     @property
     def packages(self, as_requirements=True):
         if as_requirements:
             return self.requirements
-        return self.packages
+        return self.get('packages', {})

--- a/pipenv/vendor/requirementslib/models/vcs.py
+++ b/pipenv/vendor/requirementslib/models/vcs.py
@@ -24,12 +24,11 @@ class VCSRepository(object):
 
     def obtain(self):
         if not os.path.exists(self.checkout_directory):
-            self.repo_instance.obtain(self.checkout_directory)
+            self.repo_instance.unpack(self.checkout_directory)
         if self.ref:
-            self.checkout_ref(self.ref)
+            self.update(self.ref)
             self.commit_sha = self.get_commit_hash(self.ref)
         else:
-            self.ref = self.repo_instance.default_arg_rev
             if not self.commit_sha:
                 self.commit_sha = self.get_commit_hash()
 

--- a/pipenv/vendor/requirementslib/models/vcs.py
+++ b/pipenv/vendor/requirementslib/models/vcs.py
@@ -1,6 +1,7 @@
 # -*- coding=utf-8 -*-
 import attr
-from pip_shims import VcsSupport
+from pip_shims import VcsSupport, parse_version, pip_version
+import vistir
 import os
 
 
@@ -24,10 +25,11 @@ class VCSRepository(object):
 
     def obtain(self):
         if not os.path.exists(self.checkout_directory):
-            self.repo_instance.unpack(self.checkout_directory)
+            self.repo_instance.obtain(self.checkout_directory)
         if self.ref:
-            self.update(self.ref)
-            self.commit_sha = self.get_commit_hash(self.ref)
+            with vistir.contextmanagers.cd(self.checkout_directory):
+                self.update(self.ref)
+            self.commit_sha = self.get_commit_hash()
         else:
             if not self.commit_sha:
                 self.commit_sha = self.get_commit_hash()
@@ -37,11 +39,18 @@ class VCSRepository(object):
         if not self.repo_instance.is_commit_id_equal(
             self.checkout_directory, self.get_commit_hash(ref)
         ) and not self.repo_instance.is_commit_id_equal(self.checkout_directory, ref):
-            self.repo_instance.switch(self.checkout_directory, self.url, target_rev)
+            self.repo_instance.update(self.checkout_directory, self.url, target_rev)
+        self.commit_hash = self.get_commit_hash()
 
     def update(self, ref):
         target_rev = self.repo_instance.make_rev_options(ref)
-        self.repo_instance.update(self.checkout_directory, target_rev)
+        if parse_version(pip_version) > parse_version("18.0"):
+            self.repo_instance.update(self.checkout_directory, self.url, target_rev)
+        else:
+            self.repo_instance.update(self.checkout_directory, target_rev)
+        self.commit_hash = self.get_commit_hash()
 
     def get_commit_hash(self, ref=None):
+        if ref:
+            return self.repo_instance.get_revision(self.checkout_directory)
         return self.repo_instance.get_revision(self.checkout_directory)

--- a/pipenv/vendor/requirementslib/models/vcs.py
+++ b/pipenv/vendor/requirementslib/models/vcs.py
@@ -23,34 +23,43 @@ class VCSRepository(object):
         backend = VCS_SUPPORT._registry.get(self.vcs_type)
         return backend(url=self.url)
 
+    @property
+    def is_local(self):
+        url = self.url
+        if '+' in url:
+            url = url.split('+')[1]
+        return url.startswith("file")
+
     def obtain(self):
         if not os.path.exists(self.checkout_directory):
             self.repo_instance.obtain(self.checkout_directory)
         if self.ref:
-            with vistir.contextmanagers.cd(self.checkout_directory):
-                self.update(self.ref)
-            self.commit_sha = self.get_commit_hash()
+            self.checkout_ref(self.ref)
+            self.commit_sha = self.get_commit_hash(self.ref)
         else:
             if not self.commit_sha:
                 self.commit_sha = self.get_commit_hash()
 
     def checkout_ref(self, ref):
-        target_rev = self.repo_instance.make_rev_options(ref)
         if not self.repo_instance.is_commit_id_equal(
             self.checkout_directory, self.get_commit_hash(ref)
         ) and not self.repo_instance.is_commit_id_equal(self.checkout_directory, ref):
-            self.repo_instance.update(self.checkout_directory, self.url, target_rev)
-        self.commit_hash = self.get_commit_hash()
+            if not self.is_local:
+                self.update(ref)
 
     def update(self, ref):
-        target_rev = self.repo_instance.make_rev_options(ref)
+        target_ref = self.repo_instance.make_rev_options(ref)
+        sha = self.repo_instance.get_revision_sha(self.checkout_directory, target_ref.arg_rev)
+        target_rev = target_ref.make_new(sha)
         if parse_version(pip_version) > parse_version("18.0"):
             self.repo_instance.update(self.checkout_directory, self.url, target_rev)
         else:
-            self.repo_instance.update(self.checkout_directory, target_rev)
-        self.commit_hash = self.get_commit_hash()
+            self.repo_instance.update(self.checkout_directory, target_ref)
+        self.commit_hash = self.get_commit_hash(ref)
 
     def get_commit_hash(self, ref=None):
         if ref:
-            return self.repo_instance.get_revision(self.checkout_directory)
+            target_ref = self.repo_instance.make_rev_options(ref)
+            return self.repo_instance.get_revision_sha(self.checkout_directory, target_ref.arg_rev)
+            # return self.repo_instance.get_revision(self.checkout_directory)
         return self.repo_instance.get_revision(self.checkout_directory)

--- a/pipenv/vendor/vendor.txt
+++ b/pipenv/vendor/vendor.txt
@@ -27,7 +27,7 @@ requests==2.19.1
     idna==2.7
     urllib3==1.23
     certifi==2018.8.24
-requirementslib==1.1.5
+requirementslib==1.1.6
     attrs==18.1.0
     distlib==0.2.7
     packaging==17.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,6 @@ lines_between_types=1
 multi_line_output=5
 not_skip=__init__.py
 known_first_party =
-    passa
+    pipenv
     tests
 ignore_trailing_comma=true

--- a/tasks/vendoring/patches/patched/piptools.patch
+++ b/tasks/vendoring/patches/patched/piptools.patch
@@ -19,7 +19,7 @@ index 4e6174c..75f9b49 100644
  # NOTE
  # We used to store the cache dir under ~/.pip-tools, which is not the
 diff --git a/pipenv/patched/piptools/repositories/pypi.py b/pipenv/patched/piptools/repositories/pypi.py
-index 1c4b943..10447b6 100644
+index 1c4b943..84077f0 100644
 --- a/pipenv/patched/piptools/repositories/pypi.py
 +++ b/pipenv/patched/piptools/repositories/pypi.py
 @@ -1,9 +1,10 @@
@@ -33,7 +33,7 @@ index 1c4b943..10447b6 100644
 +import sys
  from contextlib import contextmanager
  from shutil import rmtree
-
+ 
 @@ -15,13 +16,22 @@ from .._compat import (
      Wheel,
      FAVORITE_HASH,
@@ -43,7 +43,7 @@ index 1c4b943..10447b6 100644
 +    InstallRequirement,
 +    SafeFileCache,
  )
-
+ 
 -from ..cache import CACHE_DIR
 +from pip._vendor.packaging.requirements import Requirement
 +from pip._vendor.packaging.specifiers import SpecifierSet, Specifier
@@ -58,12 +58,12 @@ index 1c4b943..10447b6 100644
 +                     make_install_requirement, clean_requires_python)
 +
  from .base import BaseRepository
-
-
+ 
+ 
 @@ -37,6 +47,45 @@ except ImportError:
      from pip.wheel import WheelCache
-
-
+ 
+ 
 +class HashCache(SafeFileCache):
 +    """Caches hashes of PyPI artifacts so we do not need to re-download them
 +
@@ -105,7 +105,7 @@ index 1c4b943..10447b6 100644
 +
  class PyPIRepository(BaseRepository):
      DEFAULT_INDEX_URL = PyPI.simple_url
-
+ 
 @@ -46,10 +95,11 @@ class PyPIRepository(BaseRepository):
      config), but any other PyPI mirror can be used if index_urls is
      changed/configured on the Finder.
@@ -117,7 +117,7 @@ index 1c4b943..10447b6 100644
          self.pip_options = pip_options
 -        self.wheel_cache = WheelCache(CACHE_DIR, pip_options.format_control)
 +        self.wheel_cache = WheelCache(PIPENV_CACHE_DIR, pip_options.format_control)
-
+ 
          index_urls = [pip_options.index_url] + pip_options.extra_index_urls
          if pip_options.no_index:
 @@ -74,11 +124,15 @@ class PyPIRepository(BaseRepository):
@@ -128,20 +128,20 @@ index 1c4b943..10447b6 100644
 +
 +        # stores *full* path + fragment => sha256
 +        self._hash_cache = HashCache(session=session)
-
+ 
          # Setup file paths
          self.freshen_build_caches()
 -        self._download_dir = fs_str(os.path.join(CACHE_DIR, 'pkgs'))
 -        self._wheel_download_dir = fs_str(os.path.join(CACHE_DIR, 'wheels'))
 +        self._download_dir = fs_str(os.path.join(PIPENV_CACHE_DIR, 'pkgs'))
 +        self._wheel_download_dir = fs_str(os.path.join(PIPENV_CACHE_DIR, 'wheels'))
-
+ 
      def freshen_build_caches(self):
          """
 @@ -114,10 +168,14 @@ class PyPIRepository(BaseRepository):
          if ireq.editable:
              return ireq  # return itself as the best match
-
+ 
 -        all_candidates = self.find_all_candidates(ireq.name)
 +        all_candidates = clean_requires_python(self.find_all_candidates(ireq.name))
 +
@@ -152,12 +152,12 @@ index 1c4b943..10447b6 100644
                                                    prereleases=prereleases)
 +        except TypeError:
 +            matching_versions = [candidate.version for candidate in all_candidates]
-
+ 
          # Reuses pip's internal candidate sort key to sort
          matching_candidates = [candidates_by_version[ver] for ver in matching_versions]
 @@ -126,11 +184,71 @@ class PyPIRepository(BaseRepository):
          best_candidate = max(matching_candidates, key=self.finder._candidate_sort_key)
-
+ 
          # Turn the candidate into a pinned InstallRequirement
 -        return make_install_requirement(
 -            best_candidate.project, best_candidate.version, ireq.extras, constraint=ireq.constraint
@@ -211,7 +211,7 @@ index 1c4b943..10447b6 100644
 +            return set(self._json_dep_cache[ireq])
 +        except Exception:
 +            return set()
-
+ 
      def get_dependencies(self, ireq):
 +        json_results = set()
 +
@@ -380,12 +380,12 @@ index 1c4b943..10447b6 100644
              reqset.cleanup_files()
 +
          return set(self._dependencies_cache[ireq])
-
+ 
      def get_hashes(self, ireq):
 @@ -210,6 +434,10 @@ class PyPIRepository(BaseRepository):
          if ireq.editable:
              return set()
-
+ 
 +        vcs = VcsSupport()
 +        if ireq.link and ireq.link.scheme in vcs.all_schemes and 'ssh' in ireq.link.scheme:
 +            return set()
@@ -412,13 +412,13 @@ index 1c4b943..10447b6 100644
 +        # matching_versions = list(
 +        #     ireq.specifier.filter((candidate.version for candidate in all_candidates)))
 +        # matching_candidates = candidates_by_version[matching_versions[0]]
-
+ 
          return {
 -            self._get_file_hash(candidate.location)
 +            self._hash_cache.get_hash(candidate.location)
              for candidate in matching_candidates
          }
-
+ 
 -    def _get_file_hash(self, location):
 -        h = hashlib.new(FAVORITE_HASH)
 -        with open_local_or_remote_file(location, self.session) as fp:

--- a/tasks/vendoring/patches/patched/piptools.patch
+++ b/tasks/vendoring/patches/patched/piptools.patch
@@ -19,7 +19,7 @@ index 4e6174c..75f9b49 100644
  # NOTE
  # We used to store the cache dir under ~/.pip-tools, which is not the
 diff --git a/pipenv/patched/piptools/repositories/pypi.py b/pipenv/patched/piptools/repositories/pypi.py
-index 1c4b943..91902dc 100644
+index 1c4b943..10447b6 100644
 --- a/pipenv/patched/piptools/repositories/pypi.py
 +++ b/pipenv/patched/piptools/repositories/pypi.py
 @@ -1,9 +1,10 @@
@@ -230,7 +230,7 @@ index 1c4b943..91902dc 100644
          """
          Given a pinned or an editable InstallRequirement, returns a set of
          dependencies (also InstallRequirements, but not necessarily pinned).
-@@ -155,20 +273,47 @@ class PyPIRepository(BaseRepository):
+@@ -155,20 +273,46 @@ class PyPIRepository(BaseRepository):
                      os.makedirs(download_dir)
              if not os.path.isdir(self._wheel_download_dir):
                  os.makedirs(self._wheel_download_dir)
@@ -245,21 +245,20 @@ index 1c4b943..91902dc 100644
 +                    from pipenv.utils import chdir
 +                    with chdir(ireq.setup_py_dir):
 +                        from setuptools.dist import distutils
-+                        distutils.core.run_setup(ireq.setup_py)
++                        dist = distutils.core.run_setup(ireq.setup_py)
 +                except (ImportError, InstallationError, TypeError, AttributeError):
 +                    pass
 +                try:
-+                    dist = ireq.get_dist()
++                    dist = ireq.get_dist() if not dist else dist
 +                except InstallationError:
 +                    ireq.run_egg_info()
 +                    dist = ireq.get_dist()
 +                except (TypeError, ValueError, AttributeError):
 +                    pass
 +                else:
-+                    if dist.has_metadata('requires.txt'):
-+                        setup_requires = self.finder.get_extras_links(
-+                            dist.get_metadata_lines('requires.txt')
-+                        )
++                    setup_requires = getattr(dist, "requires", None)
++                    if not setup_requires:
++                        setup_requires = getattr(dist, "setup_requires", None)
              try:
 -                # Pip < 9 and below
 +                # Pip 9 and below
@@ -282,7 +281,7 @@ index 1c4b943..91902dc 100644
                  )
              except TypeError:
                  # Pip >= 10 (new resolver!)
-@@ -188,17 +333,97 @@ class PyPIRepository(BaseRepository):
+@@ -188,17 +332,97 @@ class PyPIRepository(BaseRepository):
                      finder=self.finder,
                      session=self.session,
                      upgrade_strategy="to-satisfy-only",
@@ -383,7 +382,7 @@ index 1c4b943..91902dc 100644
          return set(self._dependencies_cache[ireq])
  
      def get_hashes(self, ireq):
-@@ -210,6 +435,10 @@ class PyPIRepository(BaseRepository):
+@@ -210,6 +434,10 @@ class PyPIRepository(BaseRepository):
          if ireq.editable:
              return set()
  
@@ -394,7 +393,7 @@ index 1c4b943..91902dc 100644
          if not is_pinned_requirement(ireq):
              raise TypeError(
                  "Expected pinned requirement, got {}".format(ireq))
-@@ -217,24 +446,22 @@ class PyPIRepository(BaseRepository):
+@@ -217,24 +445,22 @@ class PyPIRepository(BaseRepository):
          # We need to get all of the candidates that match our current version
          # pin, these will represent all of the files that could possibly
          # satisfy this constraint.

--- a/tasks/vendoring/patches/patched/piptools.patch
+++ b/tasks/vendoring/patches/patched/piptools.patch
@@ -4,18 +4,18 @@ index 4e6174c..75f9b49 100644
 +++ b/pipenv/patched/piptools/locations.py
 @@ -2,10 +2,13 @@ import os
  from shutil import rmtree
- 
+
  from .click import secho
 -from ._compat import user_cache_dir
 +# Patch by vphilippon 2017-11-22: Use pipenv cache path.
 +# from ._compat import user_cache_dir
 +from pipenv.environments import PIPENV_CACHE_DIR
- 
+
  # The user_cache_dir helper comes straight from pip itself
 -CACHE_DIR = user_cache_dir('pip-tools')
 +# CACHE_DIR = user_cache_dir(os.path.join('pip-tools'))
 +CACHE_DIR = PIPENV_CACHE_DIR
- 
+
  # NOTE
  # We used to store the cache dir under ~/.pip-tools, which is not the
 diff --git a/pipenv/patched/piptools/repositories/pypi.py b/pipenv/patched/piptools/repositories/pypi.py
@@ -33,7 +33,7 @@ index 1c4b943..10447b6 100644
 +import sys
  from contextlib import contextmanager
  from shutil import rmtree
- 
+
 @@ -15,13 +16,22 @@ from .._compat import (
      Wheel,
      FAVORITE_HASH,
@@ -43,7 +43,7 @@ index 1c4b943..10447b6 100644
 +    InstallRequirement,
 +    SafeFileCache,
  )
- 
+
 -from ..cache import CACHE_DIR
 +from pip._vendor.packaging.requirements import Requirement
 +from pip._vendor.packaging.specifiers import SpecifierSet, Specifier
@@ -58,12 +58,12 @@ index 1c4b943..10447b6 100644
 +                     make_install_requirement, clean_requires_python)
 +
  from .base import BaseRepository
- 
- 
+
+
 @@ -37,6 +47,45 @@ except ImportError:
      from pip.wheel import WheelCache
- 
- 
+
+
 +class HashCache(SafeFileCache):
 +    """Caches hashes of PyPI artifacts so we do not need to re-download them
 +
@@ -105,7 +105,7 @@ index 1c4b943..10447b6 100644
 +
  class PyPIRepository(BaseRepository):
      DEFAULT_INDEX_URL = PyPI.simple_url
- 
+
 @@ -46,10 +95,11 @@ class PyPIRepository(BaseRepository):
      config), but any other PyPI mirror can be used if index_urls is
      changed/configured on the Finder.
@@ -117,7 +117,7 @@ index 1c4b943..10447b6 100644
          self.pip_options = pip_options
 -        self.wheel_cache = WheelCache(CACHE_DIR, pip_options.format_control)
 +        self.wheel_cache = WheelCache(PIPENV_CACHE_DIR, pip_options.format_control)
- 
+
          index_urls = [pip_options.index_url] + pip_options.extra_index_urls
          if pip_options.no_index:
 @@ -74,11 +124,15 @@ class PyPIRepository(BaseRepository):
@@ -128,20 +128,20 @@ index 1c4b943..10447b6 100644
 +
 +        # stores *full* path + fragment => sha256
 +        self._hash_cache = HashCache(session=session)
- 
+
          # Setup file paths
          self.freshen_build_caches()
 -        self._download_dir = fs_str(os.path.join(CACHE_DIR, 'pkgs'))
 -        self._wheel_download_dir = fs_str(os.path.join(CACHE_DIR, 'wheels'))
 +        self._download_dir = fs_str(os.path.join(PIPENV_CACHE_DIR, 'pkgs'))
 +        self._wheel_download_dir = fs_str(os.path.join(PIPENV_CACHE_DIR, 'wheels'))
- 
+
      def freshen_build_caches(self):
          """
 @@ -114,10 +168,14 @@ class PyPIRepository(BaseRepository):
          if ireq.editable:
              return ireq  # return itself as the best match
- 
+
 -        all_candidates = self.find_all_candidates(ireq.name)
 +        all_candidates = clean_requires_python(self.find_all_candidates(ireq.name))
 +
@@ -152,12 +152,12 @@ index 1c4b943..10447b6 100644
                                                    prereleases=prereleases)
 +        except TypeError:
 +            matching_versions = [candidate.version for candidate in all_candidates]
- 
+
          # Reuses pip's internal candidate sort key to sort
          matching_candidates = [candidates_by_version[ver] for ver in matching_versions]
 @@ -126,11 +184,71 @@ class PyPIRepository(BaseRepository):
          best_candidate = max(matching_candidates, key=self.finder._candidate_sort_key)
- 
+
          # Turn the candidate into a pinned InstallRequirement
 -        return make_install_requirement(
 -            best_candidate.project, best_candidate.version, ireq.extras, constraint=ireq.constraint
@@ -211,7 +211,7 @@ index 1c4b943..10447b6 100644
 +            return set(self._json_dep_cache[ireq])
 +        except Exception:
 +            return set()
- 
+
      def get_dependencies(self, ireq):
 +        json_results = set()
 +
@@ -256,9 +256,9 @@ index 1c4b943..10447b6 100644
 +                except (TypeError, ValueError, AttributeError):
 +                    pass
 +                else:
-+                    setup_requires = getattr(dist, "requires", None)
++                    setup_requires = getattr(dist, "extras_require", None)
 +                    if not setup_requires:
-+                        setup_requires = getattr(dist, "setup_requires", None)
++                        setup_requires = {"setup_requires": getattr(dist, "setup_requires", None)}
              try:
 -                # Pip < 9 and below
 +                # Pip 9 and below
@@ -380,12 +380,12 @@ index 1c4b943..10447b6 100644
              reqset.cleanup_files()
 +
          return set(self._dependencies_cache[ireq])
- 
+
      def get_hashes(self, ireq):
 @@ -210,6 +434,10 @@ class PyPIRepository(BaseRepository):
          if ireq.editable:
              return set()
- 
+
 +        vcs = VcsSupport()
 +        if ireq.link and ireq.link.scheme in vcs.all_schemes and 'ssh' in ireq.link.scheme:
 +            return set()
@@ -412,13 +412,13 @@ index 1c4b943..10447b6 100644
 +        # matching_versions = list(
 +        #     ireq.specifier.filter((candidate.version for candidate in all_candidates)))
 +        # matching_candidates = candidates_by_version[matching_versions[0]]
- 
+
          return {
 -            self._get_file_hash(candidate.location)
 +            self._hash_cache.get_hash(candidate.location)
              for candidate in matching_candidates
          }
- 
+
 -    def _get_file_hash(self, location):
 -        h = hashlib.new(FAVORITE_HASH)
 -        with open_local_or_remote_file(location, self.session) as fp:
@@ -435,11 +435,11 @@ index 05ec8fd..2f94f6b 100644
 +++ b/pipenv/patched/piptools/resolver.py
 @@ -8,13 +8,14 @@ from itertools import chain, count
  import os
- 
+
  from first import first
 +from pip._vendor.packaging.markers import default_environment
  from ._compat import InstallRequirement
- 
+
  from . import click
  from .cache import DependencyCache
  from .exceptions import UnsupportedConstraint
@@ -447,7 +447,7 @@ index 05ec8fd..2f94f6b 100644
 -from .utils import (format_requirement, format_specifier, full_groupby,
 +from .utils import (format_requirement, format_specifier, full_groupby, dedup, simplify_markers,
                      is_pinned_requirement, key_from_ireq, key_from_req, UNSAFE_PACKAGES)
- 
+
  green = partial(click.style, fg='green')
 @@ -28,6 +29,7 @@ class RequirementSummary(object):
      def __init__(self, ireq):
@@ -456,11 +456,11 @@ index 05ec8fd..2f94f6b 100644
 +        self.markers = ireq.markers
          self.extras = str(sorted(ireq.extras))
          self.specifier = str(ireq.specifier)
- 
+
 @@ -71,7 +73,7 @@ class Resolver(object):
          with self.repository.allow_all_wheels():
              return {ireq: self.repository.get_hashes(ireq) for ireq in ireqs}
- 
+
 -    def resolve(self, max_rounds=10):
 +    def resolve(self, max_rounds=12):
          """
@@ -516,14 +516,14 @@ index 05ec8fd..2f94f6b 100644
 +                    ireq.extras = ireq.extra
          elif not is_pinned_requirement(ireq):
              raise TypeError('Expected pinned or editable requirement, got {}'.format(ireq))
- 
+
 @@ -283,14 +301,14 @@ class Resolver(object):
          if ireq not in self.dependency_cache:
              log.debug('  {} not in cache, need to check index'.format(format_requirement(ireq)), fg='yellow')
              dependencies = self.repository.get_dependencies(ireq)
 -            self.dependency_cache[ireq] = sorted(str(ireq.req) for ireq in dependencies)
 +            self.dependency_cache[ireq] = sorted(format_requirement(_ireq) for _ireq in dependencies)
- 
+
          # Example: ['Werkzeug>=0.9', 'Jinja2>=2.4']
          dependency_strings = self.dependency_cache[ireq]
          log.debug('  {:25} requires {}'.format(format_requirement(ireq),
@@ -531,7 +531,7 @@ index 05ec8fd..2f94f6b 100644
          for dependency_string in dependency_strings:
 -            yield InstallRequirement.from_line(dependency_string, constraint=ireq.constraint)
 +                yield InstallRequirement.from_line(dependency_string, constraint=ireq.constraint)
- 
+
      def reverse_dependencies(self, ireqs):
          non_editable = [ireq for ireq in ireqs if not ireq.editable]
 diff --git a/pipenv/patched/piptools/repositories/local.py b/pipenv/patched/piptools/repositories/local.py
@@ -554,25 +554,25 @@ index fde5816..23a05f2 100644
 @@ -2,6 +2,7 @@
  from __future__ import (absolute_import, division, print_function,
                          unicode_literals)
- 
+
 +import six
  import os
  import sys
  from itertools import chain, groupby
 @@ -11,13 +12,79 @@ from contextlib import contextmanager
  from ._compat import InstallRequirement
- 
+
  from first import first
 -
 +from pip._vendor.packaging.specifiers import SpecifierSet, InvalidSpecifier
 +from pip._vendor.packaging.version import Version, InvalidVersion, parse as parse_version
 +from pip._vendor.packaging.markers import Marker, Op, Value, Variable
  from .click import style
- 
- 
+
+
  UNSAFE_PACKAGES = {'setuptools', 'distribute', 'pip'}
- 
- 
+
+
 +def simplify_markers(ireq):
 +    """simplify_markers "This code cleans up markers for a specific :class:`~InstallRequirement`"
 +
@@ -642,8 +642,8 @@ index fde5816..23a05f2 100644
      if ireq.req is None and ireq.link is not None:
 @@ -43,16 +110,51 @@ def comment(text):
      return style(text, fg='green')
- 
- 
+
+
 -def make_install_requirement(name, version, extras, constraint=False):
 +def make_install_requirement(name, version, extras, markers, constraint=False):
      # If no extras are specified, the extras string is blank
@@ -651,7 +651,7 @@ index fde5816..23a05f2 100644
      if extras:
          # Sort extras for stability
          extras_string = "[{}]".format(",".join(sorted(extras)))
- 
+
 -    return InstallRequirement.from_line(
 -        str('{}{}=={}'.format(name, extras_string, version)),
 -        constraint=constraint)
@@ -693,8 +693,8 @@ index fde5816..23a05f2 100644
 +        parts.append("; {0}".format(requirement.marker))
 +
 +    return "".join(parts)
- 
- 
+
+
  def format_requirement(ireq, marker=None):
 @@ -63,10 +165,10 @@ def format_requirement(ireq, marker=None):
      if ireq.editable:
@@ -702,14 +702,14 @@ index fde5816..23a05f2 100644
      else:
 -        line = str(ireq.req).lower()
 +        line = _requirement_to_str_lowercase_name(ireq.req)
- 
+
 -    if marker:
 -        line = '{} ; {}'.format(line, marker)
 +    if marker and ';' not in line:
 +        line = '{}; {}'.format(line, marker)
- 
+
      return line
- 
+
 diff --git a/pipenv/patched/piptools/_compat/pip_compat.py b/pipenv/patched/piptools/_compat/pip_compat.py
 index 7e8cdf3..0a0d27d 100644
 --- a/pipenv/patched/piptools/_compat/pip_compat.py
@@ -717,7 +717,7 @@ index 7e8cdf3..0a0d27d 100644
 @@ -1,30 +1,42 @@
  # -*- coding=utf-8 -*-
  import importlib
- 
+
 -def do_import(module_path, subimport=None, old_path=None):
 +
 +def do_import(module_path, subimport=None, old_path=None, vendored_name=None):
@@ -744,8 +744,8 @@ index 7e8cdf3..0a0d27d 100644
      if subimport:
          return getattr(_tmp, subimport, _tmp)
      return _tmp
--    
- 
+-
+
 -InstallRequirement = do_import('req.req_install', 'InstallRequirement')
 -parse_requirements = do_import('req.req_file', 'parse_requirements')
 -RequirementSet = do_import('req.req_set', 'RequirementSet')

--- a/tasks/vendoring/patches/patched/piptools.patch
+++ b/tasks/vendoring/patches/patched/piptools.patch
@@ -717,7 +717,7 @@ index 7e8cdf3..0a0d27d 100644
 @@ -1,30 +1,42 @@
  # -*- coding=utf-8 -*-
  import importlib
-
+ 
 -def do_import(module_path, subimport=None, old_path=None):
 +
 +def do_import(module_path, subimport=None, old_path=None, vendored_name=None):
@@ -744,8 +744,8 @@ index 7e8cdf3..0a0d27d 100644
      if subimport:
          return getattr(_tmp, subimport, _tmp)
      return _tmp
--
-
+-    
+ 
 -InstallRequirement = do_import('req.req_install', 'InstallRequirement')
 -parse_requirements = do_import('req.req_file', 'parse_requirements')
 -RequirementSet = do_import('req.req_set', 'RequirementSet')

--- a/tests/integration/test_install_basic.py
+++ b/tests/integration/test_install_basic.py
@@ -344,7 +344,7 @@ def test_editable_no_args(PipenvInstance):
     with PipenvInstance() as p:
         c = p.pipenv("install -e")
         assert c.return_code != 0
-        assert "Please provide path to editable package" in c.err
+        assert "Error: -e option requires an argument" in c.err
 
 
 @pytest.mark.install

--- a/tests/integration/test_install_twists.py
+++ b/tests/integration/test_install_twists.py
@@ -13,15 +13,10 @@ from flaky import flaky
 @pytest.mark.extras
 @pytest.mark.install
 @pytest.mark.local
-@pytest.mark.parametrize(
-    "line, pipfile",
-    [["-e .[dev]", {"testpipenv": {"path": ".", "editable": True, "extras": ["dev"]}}]],
-)
-def test_local_extras_install(PipenvInstance, pypi, line, pipfile):
+def test_local_extras_install(PipenvInstance, pypi):
     """Ensure -e .[extras] installs.
     """
     with PipenvInstance(pypi=pypi, chdir=True) as p:
-        project = Project()
         setup_py = os.path.join(p.path, "setup.py")
         with open(setup_py, "w") as fh:
             contents = """
@@ -40,7 +35,17 @@ zip_safe=False
 )
             """.strip()
             fh.write(contents)
-        project.write_toml({"packages": pipfile, "dev-packages": {}})
+        line = "-e .[dev]"
+        # pipfile = {"testpipenv": {"path": ".", "editable": True, "extras": ["dev"]}}
+        project = Project()
+        with open(os.path.join(p.path, 'Pipfile'), 'w') as fh:
+            fh.write("""
+[packages]
+testpipenv = {path = ".", editable = true, extras = ["dev"]}
+
+[dev-packages]
+            """.strip())
+        # project.write_toml({"packages": pipfile, "dev-packages": {}})
         c = p.pipenv("install")
         assert c.return_code == 0
         assert "testpipenv" in p.lockfile["default"]

--- a/tests/integration/test_install_uri.py
+++ b/tests/integration/test_install_uri.py
@@ -97,16 +97,18 @@ def test_file_urls_work(PipenvInstance, pip_src_dir):
 @pytest.mark.files
 @pytest.mark.urls
 @pytest.mark.needs_internet
-def test_local_vcs_urls_work(PipenvInstance, pypi):
+def test_local_vcs_urls_work(PipenvInstance, pypi, tmpdir):
+    six_dir = tmpdir.join("six")
+    six_path = Path(six_dir.strpath)
     with PipenvInstance(pypi=pypi, chdir=True) as p:
-        six_path = Path(p.path).joinpath("six").absolute()
         c = delegator.run(
-            "git clone " "https://github.com/benjaminp/six.git {0}".format(six_path)
+            "git clone https://github.com/benjaminp/six.git {0}".format(six_dir.strpath)
         )
         assert c.return_code == 0
 
         c = p.pipenv("install git+{0}#egg=six".format(six_path.as_uri()))
         assert c.return_code == 0
+        assert "six" in p.pipfile["packages"]
 
 
 @pytest.mark.e

--- a/tests/integration/test_sync.py
+++ b/tests/integration/test_sync.py
@@ -7,7 +7,7 @@ import pytest
 
 @pytest.mark.sync
 def test_sync_error_without_lockfile(PipenvInstance, pypi):
-    with PipenvInstance(pypi=pypi) as p:
+    with PipenvInstance(pypi=pypi, chdir=True) as p:
         with open(p.pipfile_path, 'w') as f:
             f.write("""
 [packages]
@@ -40,7 +40,7 @@ six = "*"
 def test_sync_should_not_lock(PipenvInstance, pypi):
     """Sync should not touch the lock file, even if Pipfile is changed.
     """
-    with PipenvInstance(pypi=pypi) as p:
+    with PipenvInstance(pypi=pypi, chdir=True) as p:
         with open(p.pipfile_path, 'w') as f:
             f.write("""
 [packages]


### PR DESCRIPTION
We currently handle a lot of parsing in custom functions that are quite broadly speaking broken at a lot of edge cases.  This refactor (which I put off a lot because I didn't really understand how to do this with click's tooling, but now I do) restructures a lot of the cruft we've merged in over the last year or so and builds it back into click's parser.

Additionally this will centralize various options to avoid having them repeated throughout  the CLI declarations.  This also pulls in updates to `requirementslib` with some bugfixes and enhancements around VCS checkout handling, plus a minor tweak to our patched version of `pip-tools` which fixes a bug in some overlooked `setup.py` runners where we forgot to actually assign the resulting distribution to a variable (which has caused a number of issues).

Caught a few other very minor issues in the refactor during syntax cleanups.

- Supersedes and closes #2733 
- Supersedes and closes #2734 
- Fixes #2714 
- Fixes #2766 
- Fixes #2760 
- Fixes #2748 
- Fixes #2494 
- Fixes #2279 
- Fixes #2173 
- Fixes #1690