### PR TITLE
Add ability to override the pyup.io API key for the check command

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -240,6 +240,9 @@ Example::
    API access throttling based on overall usage rather than individual
    client usage.
 
+   You can also use your own safety API key by setting the
+   environment variable ``PIPENV_CHECK_KEY``.
+
 
 ☤ Community Integrations
 ------------------------

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -55,6 +55,7 @@ from .environments import (
     PIPENV_DONT_USE_PYENV,
     SESSION_IS_INTERACTIVE,
     PIPENV_CACHE_DIR,
+    PIPENV_CHECK_KEY,
 )
 
 # Packages that should be ignored later.
@@ -2275,15 +2276,15 @@ def do_check(
     else:
         ignored = ""
     c = delegator.run(
-        '"{0}" {1} check --json --key=1ab8d58f-5122e025-83674263-bc1e79e0 {2}'.format(
-            python, escape_grouped_arguments(path), ignored
+        '"{0}" {1} check --json --key={2} {3}'.format(
+            python, escape_grouped_arguments(path), PIPENV_CHECK_KEY, ignored
         )
     )
     try:
         results = simplejson.loads(c.out)
     except ValueError:
         click.echo("An error occurred:", err=True)
-        click.echo(c.err, err=True)
+        click.echo(c.err if len(c.err) > 0 else c.out, err=True)
         sys.exit(1)
     for (package, resolved, installed, description, vuln) in results:
         click.echo(

--- a/pipenv/environments.py
+++ b/pipenv/environments.py
@@ -194,6 +194,7 @@ Default is to prompt the user for an answer if the current command line session
 if interactive.
 """
 
+PIPENV_CHECK_KEY = os.environ.get("PIPENV_CHECK_KEY", "1ab8d58f-5122e025-83674263-bc1e79e0")
 
 # Internal, support running in a different Python from sys.executable.
 PIPENV_PYTHON = os.environ.get("PIPENV_PYTHON")


### PR DESCRIPTION
This an attempted fix for part of the problem in #2825, being able to supply your own API key for `pipenv check`
I haven't created any news fragments, if needed I might need some pointers on how to go about that.