### PR TITLE
Clarify `pipenv install` documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,8 +181,8 @@ Fish is the best shell. You should use it.
                  provided in Pipfile.
       clean      Uninstalls all packages not specified in Pipfile.lock.
       graph      Displays currently–installed dependency graph information.
-      install    Installs provided packages and adds them to Pipfile, or (if none
-                 is given), installs all packages.
+      install    Installs provided packages and adds them to Pipfile, or (if no
+                 packages are given), installs all packages from Pipfile.
       lock       Generates Pipfile.lock.
       open       View a given module in your editor.
       run        Spawns a command installed into the virtualenv.

--- a/pipenv/cli/command.py
+++ b/pipenv/cli/command.py
@@ -209,7 +209,7 @@ def cli(
 
 
 @cli.command(
-    short_help="Installs provided packages and adds them to Pipfile, or (if none is given), installs all packages.",
+    short_help="Installs provided packages and adds them to Pipfile, or (if no packages are given), installs all packages from Pipfile.",
     context_settings=dict(ignore_unknown_options=True, allow_extra_args=True),
 )
 @system_option
@@ -224,7 +224,7 @@ def install(
     state,
     **kwargs
 ):
-    """Installs provided packages and adds them to Pipfile, or (if none is given), installs all packages."""
+    """Installs provided packages and adds them to Pipfile, or (if no packages are given), installs all packages from Pipfile."""
     from ..core import do_install
 
     retcode = do_install(


### PR DESCRIPTION
`if no packages are given` sounds a bit better than
`if none is given` when referring to `provided packages`.

Also mention that `pipenv install` with no provided packages
installs all packages from Pipfile. It is not obvious for
people new to pipenv whether pipenv is using Pipfile or
Pipfile.lock by default.