### PR TITLE
Correct capitalization of PyPI

### DIFF
--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -737,7 +737,7 @@
 6.0.0:
  - New locking functionality — support for multiple hashes per release!
  - Hashes are now default, everywhere, once again! We figured it out :)
- - Pipenv talks to the PyPi (Warehouse) API now for grabbing hashes.
+ - Pipenv talks to the PyPI (Warehouse) API now for grabbing hashes.
  - --hashes flag removed.
  - Upgraded to Pipfile spec 2.
  - New --legacy mode for lock.

--- a/setup.py
+++ b/setup.py
@@ -92,7 +92,7 @@ class UploadCommand(Command):
             pass
         self.status("Building Source distribution…")
         os.system("{0} setup.py sdist bdist_wheel".format(sys.executable))
-        self.status("Uploading the package to PyPi via Twine…")
+        self.status("Uploading the package to PyPI via Twine…")
         os.system("twine upload dist/*")
         self.status("Pushing git tags…")
         os.system("git tag v{0}".format(about["__version__"]))

--- a/tests/pytest-pypi/setup.py
+++ b/tests/pytest-pypi/setup.py
@@ -42,7 +42,7 @@ class UploadCommand(Command):
         self.status('Building Source and Wheel (universal) distribution…')
         os.system('{0} setup.py sdist bdist_wheel --universal'.format(sys.executable))
 
-        self.status('Uploading the package to PyPi via Twine…')
+        self.status('Uploading the package to PyPI via Twine…')
         os.system('twine upload dist/*')
 
         self.status('Pushing git tags…')


### PR DESCRIPTION
As spelled on https://pypi.org/.