### PR TITLE
Added inotifier to watch  on a thread. Needs refinement

### DIFF
--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -2033,8 +2033,9 @@ def do_shell(three=None, python=False, fancy=False, shell_args=None, pypi_mirror
     click.echo("Launching subshell in virtual environment…", err=True)
 
     fork_args = (project.virtualenv_location, project.project_directory, shell_args)
-    dotenv_file = environments.PIPENV_DOTENV_LOCATION or os.sep.join(
-        [project.project_directory, ".env"]
+
+    dotenv_file = environments.PIPENV_DOTENV_LOCATION or os.path.join(
+        project.project_directory, ".env"
     )
    
     if fancy:

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -2033,13 +2033,16 @@ def do_shell(three=None, python=False, fancy=False, shell_args=None, pypi_mirror
     click.echo("Launching subshell in virtual environment…", err=True)
 
     fork_args = (project.virtualenv_location, project.project_directory, shell_args)
-
+    dotenv_file = environments.PIPENV_DOTENV_LOCATION or os.sep.join(
+        [project.project_directory, ".env"]
+    )
+   
     if fancy:
         shell.fork(*fork_args)
         return
 
     try:
-        shell.fork_compat(*fork_args)
+        shell.fork_compat(*fork_args, dotenv_file)
     except (AttributeError, ImportError):
         click.echo(
             u"Compatibility mode not supported. "

--- a/pipenv/shells.py
+++ b/pipenv/shells.py
@@ -109,7 +109,7 @@ class Shell(object):
             c.sendline(" ".join(args))
 
         notifier = None
-        if not os.name == "nt":
+        if not os.name == "nt":  # I don't know how windows does inotify
             import pyinotify
 
             wm = pyinotify.WatchManager()


### PR DESCRIPTION
##### The issue

When in an active virtualenv ,changes to `.env` file require manual deactivation/reactivation
It would be great if this was automatic.

related to [Issue #1015](https://github.com/pypa/pipenv/issues/1015)

##### The fix
At first I wanted a command to manually retrigger the load, but since commands are run from a child process it's not possible to export the values to the parent environment.

My solution is to use pyinotify to spawn a thread to watch the dotenv file and manually send the new env to the opened shell in the callback.

I'm not convinced that this is the best solution but it "technically works".
Currently this PR sends a line exporting the values in the subshell. This is not ideal and I'm looking for suggestions on how to improve this in anyway. Does pexpect offer something to set the process's environment?

I'm not sure how important/desirable this behavior is to everyone who uses pipenv. Perhaps this should be configurable, so it only happens when you specifiy it. Please advise.

##### The checklist

- [ x ] Associated issue

* [ ] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.  <- Don't really understand this, would welcome guidance
