### PR TITLE
Create virtualenvs directory if it does not exist

### DIFF
--- a/news/2877.bugfix
+++ b/news/2877.bugfix
@@ -1,0 +1,1 @@
+Fixed a bug where `pipenv` crashes when the `WORKON_HOME` directory does not exist.

--- a/pipenv/utils.py
+++ b/pipenv/utils.py
@@ -1281,7 +1281,10 @@ def get_workon_home():
             workon_home = os.path.join(
                 os.environ.get("XDG_DATA_HOME", "~/.local/share"), "virtualenvs"
             )
-    return Path(os.path.expandvars(workon_home)).expanduser()
+    # Create directory if it does not already exist
+    expanded_path = Path(os.path.expandvars(workon_home)).expanduser()
+    mkdir_p(str(expanded_path))
+    return expanded_path
 
 
 def is_virtual_environment(path):


### PR DESCRIPTION
##### The issue

This PR fixes #2786 as `pipenv` tries to iterate through `WORKON_HOME` (`virtualenvs` folder) without ensuring it exists first.

##### The fix

Creating the `WORKON_HOME` directory from inside `pipenv/utils.py:get_workon_home`.

##### The checklist

* [x] Associated issue
* [x] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.
