### PR TITLE
Fix "py -m site --user-site" description

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -119,7 +119,7 @@ To install::
     `modifying ~/.profile`_.
 
     On Windows you can find the user base binary directory by running
-    ``py -m site --user-site`` and replacing ``site-packages`` with
+    ``python -m site --user-site`` and replacing ``site-packages`` with
     ``Scripts``. For example, this could return
     ``C:\Users\Username\AppData\Roaming\Python36\site-packages`` so you would
     need to set your ``PATH`` to include


### PR DESCRIPTION
Thank you for contributing to Pipenv!


##### The issue

The command doesn't work with:
"py -m site --user-site"

##### The fix

I think the author's intention was:
"python -m site --user-site"
instead of:
"py -m site --user-site"

so I fixed it.
##### The checklist

* [X] Associated issue
* [X] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

<!--
##### If this is a patch to the `vendor` directory…

Please try to refrain from submitting patches directly to `vendor` or `patched`, but raise your issue to the upstream project instead, and inform Pipenv to upgrade when the upstream project accepts the fix.

A pull request to upgrade vendor packages is strongly discouraged, unless there is a very good reason (e.g. you need to test Pipenv’s integration to a new vendor feature). Pipenv audits and performs vendor upgrades regularly, generally before a new release is about to drop.

If your patch is not or cannot be accepted by upstream, but is essential to Pipenv (make sure to discuss this with maintainers!), please remember to attach a patch file in `tasks/vendoring/patched`, so this divergence from upstream can be recorded and replayed afterwards.
-->
