### PR TITLE
Remove a 404 link in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -5,10 +5,6 @@ about: Create a report to help us improve
 
 Be sure to check the existing issues (both open and closed!), and make sure you are running the latest version of Pipenv.
 
-If you're requesting a new feature or leaving feedback, please use this forum instead:
-
-    https://kenneth-reitz.uservoice.com/forums/913660-general
-
 Check the [diagnose documentation](https://docs.pipenv.org/diagnose/) for common issues before posting! We may close your issue if it is very similar to one of them. Please be considerate, or be on your way.
 
 Make sure to mention your debugging experience if the documented solution failed.

--- a/.github/ISSUE_TEMPLATE/Custom.md
+++ b/.github/ISSUE_TEMPLATE/Custom.md
@@ -5,10 +5,6 @@ about: Requests for assistance or general usage guidance.
 
 **AVOID POSTING ISSUES UNDER THIS CATEGORY.**
 
-If you're requesting a new feature or leaving feedback, please use this forum instead:
-
-    https://kenneth-reitz.uservoice.com/forums/913660-general
-
 If Pipenv is not functioning as you would like it to, consider filing either a bug report, or a feature request instead.
 
 Please refer to [StackOverflow tag](https://stackoverflow.com/questions/tagged/pipenv) for more information.

--- a/.github/ISSUE_TEMPLATE/Feature_request.md
+++ b/.github/ISSUE_TEMPLATE/Feature_request.md
@@ -5,10 +5,6 @@ about: Suggest an idea for this project
 
 Be sure to check the existing issues (both open and closed!), and make sure you are running the latest version of Pipenv.
 
-If you're requesting a new feature or leaving feedback, please use this forum instead:
-
-    https://kenneth-reitz.uservoice.com/forums/913660-general
-
 Check the [diagnose documentation](https://docs.pipenv.org/diagnose/) for common issues before posting! We may close your issue if it is very similar to one of them. Please be considerate, or be on your way.
 
 Make sure to mention your debugging experience if the documented solution failed.


### PR DESCRIPTION

##### The issue

https://github.com/pypa/pipenv/issues/2893

##### The fix

> How does this pull request fix your problem? Did you consider any alternatives? Why is this the *best* solution, in your opinion?

I just removed this link.

##### The checklist

* [x] Associated issue
* [ ] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.