### PR TITLE
Fixed vcs is not supported in pip9

### DIFF
--- a/news/2912.bugfix
+++ b/news/2912.bugfix
@@ -1,0 +1,1 @@
+Fixed pip is not loaded from pipenv's patched one but the system one

--- a/pipenv/environments.py
+++ b/pipenv/environments.py
@@ -11,6 +11,8 @@ os.environ["PYTHONDONTWRITEBYTECODE"] = "1"
 # https://bugs.python.org/issue22490
 os.environ.pop("__PYVENV_LAUNCHER__", None)
 
+# Load patched pip instead of system pip
+os.environ["PIP_SHIMS_BASE_MODULE"] = "pipenv.patched.notpip"
 
 PIPENV_CACHE_DIR = os.environ.get("PIPENV_CACHE_DIR", user_cache_dir("pipenv"))
 """Location for Pipenv to store it's package cache.


### PR DESCRIPTION
### The issue

Try to fix https://github.com/pypa/pipenv/issues/2912

### The fix

Load patched pip by setting environment variable ```PIP_SHIMS_BASE_MODULE```

##### The checklist

* [x] Associated issue
* [x] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

<!--
##### If this is a patch to the `vendor` directory…

Please try to refrain from submitting patches directly to `vendor` or `patched`, but raise your issue to the upstream project instead, and inform Pipenv to upgrade when the upstream project accepts the fix.

A pull request to upgrade vendor packages is strongly discouraged, unless there is a very good reason (e.g. you need to test Pipenv’s integration to a new vendor feature). Pipenv audits and performs vendor upgrades regularly, generally before a new release is about to drop.

If your patch is not or cannot be accepted by upstream, but is essential to Pipenv (make sure to discuss this with maintainers!), please remember to attach a patch file in `tasks/vendoring/patched`, so this divergence from upstream can be recorded and replayed afterwards.
-->
