### PR TITLE
Level up the template headers

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -9,19 +9,19 @@ Check the [diagnose documentation](https://docs.pipenv.org/diagnose/) for common
 Make sure to mention your debugging experience if the documented solution failed.
 
 
-##### Issue description
+### Issue description
 
 Describe the issue briefly here.
 
-##### Expected result
+### Expected result
 
 Describe what you expected.
 
-##### Actual result
+### Actual result
 
 When possible, provide the verbose output (`--verbose`), especially for locking and dependencies resolving issues.
 
-##### Steps to replicate
+### Steps to replicate
 
 Provide the steps to replicate (which usually at least includes the commands and the Pipfile).
 

--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -10,19 +10,19 @@ Check the [diagnose documentation](https://docs.pipenv.org/diagnose/) for common
 Make sure to mention your debugging experience if the documented solution failed.
 
 
-##### Issue description
+### Issue description
 
 Describe the issue briefly here.
 
-##### Expected result
+### Expected result
 
 Describe what you expected.
 
-##### Actual result
+### Actual result
 
 When possible, provide the verbose output (`--verbose`), especially for locking and dependencies resolving issues.
 
-##### Steps to replicate
+### Steps to replicate
 
 Provide the steps to replicate (which usually at least includes the commands and the Pipfile).
 

--- a/.github/ISSUE_TEMPLATE/Feature_request.md
+++ b/.github/ISSUE_TEMPLATE/Feature_request.md
@@ -9,19 +9,19 @@ Check the [diagnose documentation](https://docs.pipenv.org/diagnose/) for common
 
 Make sure to mention your debugging experience if the documented solution failed.
 
-##### Is your feature request related to a problem? Please describe.
+### Is your feature request related to a problem? Please describe.
 
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
 
-##### Describe the solution you'd like
+### Describe the solution you'd like
 
 A clear and concise description of what you want to happen.
 
-##### Describe alternatives you've considered
+### Describe alternatives you've considered
 
 A clear and concise description of any alternative solutions or features you've considered.
 
-##### Additional context
+### Additional context
 
 Add any other context or screenshots about the feature request here. It may be a good idea to mention that platform and Python version you are on.
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,7 @@
 Thank you for contributing to Pipenv!
 
 
-##### The issue
+### The issue
 
 What is the thing you want to fix? Is it associated with an issue on GitHub? Please mention it.
 
@@ -11,18 +11,18 @@ If your pull request makes a non-insignificant change to Pipenv, such as the use
 
     https://github.com/pypa/pipenv/blob/master/peeps/PEEP-000.md
 
-##### The fix
+### The fix
 
 How does this pull request fix your problem? Did you consider any alternatives? Why is this the *best* solution, in your opinion?
 
 
-##### The checklist
+### The checklist
 
 * [ ] Associated issue
 * [ ] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.
 
 <!--
-##### If this is a patch to the `vendor` directory…
+### If this is a patch to the `vendor` directory…
 
 Please try to refrain from submitting patches directly to `vendor` or `patched`, but raise your issue to the upstream project instead, and inform Pipenv to upgrade when the upstream project accepts the fix.
 


### PR DESCRIPTION
### The issue

When I try to open/view issues or pull requests, I found it a littile bit difficult to distinguish issue/pr headers from their content, since level ```#####``` is too similar with the contents.  Maybe it is better to level up the headers.

Well it is a little bit opinionated, but I still would like to share my thoughts. 😄 

### The fix

Update github templates' header level to ```###```.

### The checklist

* [ ] Associated issue
* [ ] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

<!--
### If this is a patch to the `vendor` directory…

Please try to refrain from submitting patches directly to `vendor` or `patched`, but raise your issue to the upstream project instead, and inform Pipenv to upgrade when the upstream project accepts the fix.

A pull request to upgrade vendor packages is strongly discouraged, unless there is a very good reason (e.g. you need to test Pipenv’s integration to a new vendor feature). Pipenv audits and performs vendor upgrades regularly, generally before a new release is about to drop.

If your patch is not or cannot be accepted by upstream, but is essential to Pipenv (make sure to discuss this with maintainers!), please remember to attach a patch file in `tasks/vendoring/patched`, so this divergence from upstream can be recorded and replayed afterwards.
-->
