### PR TITLE
Lock pip version in tests

### DIFF
--- a/.vsts-ci/steps/install-dependencies.yml
+++ b/.vsts-ci/steps/install-dependencies.yml
@@ -1,3 +1,3 @@
 steps:
-- script: 'python -m pip install --upgrade pip && python -m pip install -e .'
+- script: 'python -m pip install --upgrade pip==18.0 && python -m pip install -e .'
   displayName: Upgrade Pip & Install Pipenv


### PR DESCRIPTION
### The issue

To have a stable and repeatable tests, the pip version in tests should be pinned. Otherwise, unexpected bugs such as https://github.com/pypa/pipenv/issues/2924 may fail all CI tests. Passed tests may fail even codebase is not changed as time varies.

The pip version in tests should be the latest but a specific version. After https://github.com/pypa/pipenv/issues/2924 is fixed, it should be pinned back to ```18.1``` again.

How does that sound?

### The fix

Pin pip version in tests to latest but a specific version.

### The checklist

* [ ] Associated issue
* [ ] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

<!--
### If this is a patch to the `vendor` directory…

Please try to refrain from submitting patches directly to `vendor` or `patched`, but raise your issue to the upstream project instead, and inform Pipenv to upgrade when the upstream project accepts the fix.

A pull request to upgrade vendor packages is strongly discouraged, unless there is a very good reason (e.g. you need to test Pipenv’s integration to a new vendor feature). Pipenv audits and performs vendor upgrades regularly, generally before a new release is about to drop.

If your patch is not or cannot be accepted by upstream, but is essential to Pipenv (make sure to discuss this with maintainers!), please remember to attach a patch file in `tasks/vendoring/patched`, so this divergence from upstream can be recorded and replayed afterwards.
-->
