### PR TITLE
#2317 documentation variable expansion

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -353,12 +353,12 @@ To prevent pipenv from loading the ``.env`` file, set the ``PIPENV_DONT_LOAD_ENV
 ☤ Custom Script Shortcuts
 -------------------------
 
-Pipenv supports creating custom shortcuts in the (optional) ``[scripts]`` section of your Pipfile. 
+Pipenv supports creating custom shortcuts in the (optional) ``[scripts]`` section of your Pipfile.
 
 You can then run ``pipenv run <shortcut name>`` in your terminal to run the command in the
-context of your pipenv virtual environment even if you have not activated the pipenv shell first. 
+context of your pipenv virtual environment even if you have not activated the pipenv shell first.
 
-For example, in your Pipfile:: 
+For example, in your Pipfile::
 
     [scripts]
     printspam = "python -c \"print('I am a silly example, no one would need to do this')\""
@@ -380,7 +380,7 @@ For example::
 ☤ Support for Environment Variables
 -----------------------------------
 
-Pipenv supports the usage of environment variables in values. For example::
+Pipenv supports the usage of environment variables in values, only in the ``[[source]]`` section. For example::
 
     [[source]]
     url = "https://${PYPI_USERNAME}:${PYPI_PASSWORD}@my_private_repo.example.com/simple"
@@ -394,8 +394,8 @@ Pipenv supports the usage of environment variables in values. For example::
     maya = {version="*", index="pypi"}
     records = "*"
 
-Environment variables may be specified as ``${MY_ENVAR}`` or ``$MY_ENVAR``.
-On Windows, ``%MY_ENVAR%`` is supported in addition to ``${MY_ENVAR}`` or ``$MY_ENVAR``.
+Environment variables is better specified as ``${MY_ENVAR}``.
+But they may be ``$MY_ENVAR`` or ``%MY_ENVAR%`` on Windows.
 
 
 ☤ Configuration With Environment Variables

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -394,8 +394,8 @@ Pipenv supports the usage of environment variables in values, only in the ``[[so
     maya = {version="*", index="pypi"}
     records = "*"
 
-Environment variables is better specified as ``${MY_ENVAR}``.
-But they may be ``$MY_ENVAR`` or ``%MY_ENVAR%`` on Windows.
+Environment variables is better specified as ``${MY_ENVAR}`` or ``$MY_ENVAR``.
+On Windows, ``%MY_ENVAR%`` is supported in addition to ``${MY_ENVAR}`` or ``$MY_ENVAR``.
 
 
 ☤ Configuration With Environment Variables

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -358,7 +358,9 @@ Pipenv supports creating custom shortcuts in the (optional) ``[scripts]`` sectio
 You can then run ``pipenv run <shortcut name>`` in your terminal to run the command in the
 context of your pipenv virtual environment even if you have not activated the pipenv shell first.
 
-For example, in your Pipfile::
+For example, in your Pipfile:
+
+.. code-block:: toml
 
     [scripts]
     printspam = "python -c \"print('I am a silly example, no one would need to do this')\""
@@ -369,10 +371,13 @@ And then in your terminal::
     I am a silly example, no one would need to do this
 
 Commands that expect arguments will also work.
-For example::
+For example:
 
+.. code-block:: toml
     [scripts]
     echospam = "echo I am really a very silly example"
+
+::
 
     $ pipenv run echospam "indeed"
     I am really a very silly example indeed
@@ -380,7 +385,11 @@ For example::
 ☤ Support for Environment Variables
 -----------------------------------
 
-Pipenv supports the usage of environment variables in values, only in the ``[[source]]`` section. For example::
+Pipenv supports the usage of environment variables in place of authentication fragments
+in your Pipfile. These will only be parsed if they are present in the ``[[source]]``
+section. For example:
+
+.. code-block:: toml
 
     [[source]]
     url = "https://${PYPI_USERNAME}:${PYPI_PASSWORD}@my_private_repo.example.com/simple"
@@ -394,7 +403,8 @@ Pipenv supports the usage of environment variables in values, only in the ``[[so
     maya = {version="*", index="pypi"}
     records = "*"
 
-Environment variables is better specified as ``${MY_ENVAR}`` or ``$MY_ENVAR``.
+Environment variables may be specified as ``${MY_ENVAR}`` or ``$MY_ENVAR``.
+
 On Windows, ``%MY_ENVAR%`` is supported in addition to ``${MY_ENVAR}`` or ``$MY_ENVAR``.
 
 

--- a/news/2317.doc.rst
+++ b/news/2317.doc.rst
@@ -1,0 +1,1 @@
+Added documenation about variable expansion in ``Pipfile`` entries.


### PR DESCRIPTION
### The issue

Documentation should mention variable expansion works only in [[source]] entries #2317


### The fix

As suggested I added the use of the operator only in the [[source]] section.
I also simplified the text on the alternatives of usage of variable expansion.

- Fixes #2317 
