### PR TITLE
Fix parsing of outline tables

### DIFF
--- a/news/2971.bugfix
+++ b/news/2971.bugfix
@@ -1,0 +1,1 @@
+Fix parsing of outline tables.

--- a/pipenv/project.py
+++ b/pipenv/project.py
@@ -477,14 +477,15 @@ class Project(object):
                     # Convert things to inline tables — fancy :)
                     if hasattr(data[section][package], "keys"):
                         _data = data[section][package]
-                        data[section][package] = toml._get_empty_inline_table(dict)
+                        data[section][package] = toml.TomlDecoder().get_empty_inline_table()
                         data[section][package].update(_data)
+            toml_encoder = toml.TomlEncoder(preserve=True)
             # We lose comments here, but it's for the best.)
             try:
-                return contoml.loads(toml.dumps(data, preserve=True))
+                return contoml.loads(toml.dumps(data, encoder=toml_encoder))
 
             except RuntimeError:
-                return toml.loads(toml.dumps(data, preserve=True))
+                return toml.loads(toml.dumps(data, encoder=toml_encoder))
 
         else:
             # Fallback to toml parser, for large files.
@@ -673,7 +674,7 @@ class Project(object):
                     # Convert things to inline tables — fancy :)
                     if hasattr(data[section][package], "keys"):
                         _data = data[section][package]
-                        data[section][package] = toml._get_empty_inline_table(dict)
+                        data[section][package] = toml.TomlDecoder().get_empty_inline_table()
                         data[section][package].update(_data)
             formatted_data = toml.dumps(data).rstrip()
 

--- a/tests/integration/test_install_basic.py
+++ b/tests/integration/test_install_basic.py
@@ -232,6 +232,31 @@ requests = {version = "*"}
         assert c.return_code == 0
 
 
+@pytest.mark.run
+@pytest.mark.alt
+@flaky
+def test_outline_table_specifier(PipenvInstance, pypi):
+    with PipenvInstance(pypi=pypi) as p:
+        with open(p.pipfile_path, "w") as f:
+            contents = """
+[packages.requests]
+version = "*"
+            """.strip()
+            f.write(contents)
+
+        c = p.pipenv("install")
+        assert c.return_code == 0
+
+        assert "requests" in p.lockfile["default"]
+        assert "idna" in p.lockfile["default"]
+        assert "urllib3" in p.lockfile["default"]
+        assert "certifi" in p.lockfile["default"]
+        assert "chardet" in p.lockfile["default"]
+
+        c = p.pipenv('run python -c "import requests; import idna; import certifi;"')
+        assert c.return_code == 0
+
+
 @pytest.mark.bad
 @pytest.mark.install
 def test_bad_packages(PipenvInstance, pypi):


### PR DESCRIPTION
Fixes https://github.com/pypa/pipenv/issues/2960, which was caused by a change in the API for `toml`. 