### PR TITLE
Keyword arg error in Getting `add_index_to_pipfile`

### DIFF
--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -238,7 +238,7 @@ def import_requirements(r=None, dev=False):
                 project.add_package_to_pipfile(str(package.req), dev=dev)
     for index in indexes:
         trusted = index in trusted_hosts
-        project.add_index_to_pipfile(index, trusted_host=trusted)
+        project.add_index_to_pipfile(index, verify_ssl=trusted)
     project.recase_pipfile()
 
 


### PR DESCRIPTION
Latest release of pipenv gave me this error; seemed like an easy fix

Thank you for contributing to Pipenv!


### The issue

Looks like a call to `add_index_to_pipfile` uses a keyword called `trusted_host`, but the keyword is `verify_ssl`

### The fix

Changed `trusted_host` to `verify_ssl`. Doesn't look like it's referenced anywhere else. And it fixed pipenv for me.
Don't believe there is an issue for it though.


### The checklist

* [ ] Associated issue
* [ ] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

<!--
### If this is a patch to the `vendor` directory…

Please try to refrain from submitting patches directly to `vendor` or `patched`, but raise your issue to the upstream project instead, and inform Pipenv to upgrade when the upstream project accepts the fix.

A pull request to upgrade vendor packages is strongly discouraged, unless there is a very good reason (e.g. you need to test Pipenv’s integration to a new vendor feature). Pipenv audits and performs vendor upgrades regularly, generally before a new release is about to drop.

If your patch is not or cannot be accepted by upstream, but is essential to Pipenv (make sure to discuss this with maintainers!), please remember to attach a patch file in `tasks/vendoring/patched`, so this divergence from upstream can be recorded and replayed afterwards.
-->
