### PR TITLE
Add trailing white space to --prompt argument when creating virtualenv

### DIFF
--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -874,7 +874,7 @@ def do_create_virtualenv(python=None, site_packages=False, pypi_mirror=None):
         sys.executable,
         "-m",
         "virtualenv",
-        "--prompt=({0})".format(project.name),
+        "--prompt=({0}) ".format(project.name),
         "--python={0}".format(python),
         project.get_location_for_virtualenv(),
     ]


### PR DESCRIPTION
### The issue

https://github.com/pypa/pipenv/issues/2990#issuecomment-428935640

- Fixes #2990

### The fix

Adding trailing space to ``--prompt`` argument when creating the virtualenv. 