### PR TITLE
Add --bare behavior to sync and clean

### DIFF
--- a/news/3041.feature
+++ b/news/3041.feature
@@ -1,1 +1,1 @@
---bare now has an effect on clean, and use sync's bare option to reduce output.
+--bare now has an effect on clean, and sync's bare option is now used to reduce output.

--- a/news/3041.feature
+++ b/news/3041.feature
@@ -1,0 +1,1 @@
+--bare now has effect on sync and clean.

--- a/news/3041.feature
+++ b/news/3041.feature
@@ -1,1 +1,1 @@
---bare now has effect on sync and clean.
+--bare now has an effect on clean, and use sync's bare option to reduce output.

--- a/pipenv/cli/command.py
+++ b/pipenv/cli/command.py
@@ -590,6 +590,7 @@ def sync(
 
 
 @cli.command(short_help="Uninstalls all packages not specified in Pipfile.lock.")
+@option("--bare", is_flag=True, default=False, help="Minimal output.")
 @option("--dry-run", is_flag=True, default=False, help="Just output unneeded packages.")
 @verbose_option
 @three_option

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -2513,8 +2513,9 @@ def do_sync(
         deploy=deploy,
         system=system,
     )
-    requirements_dir.cleanup()
-    click.echo(crayons.green("All dependencies are now up-to-date!"))
+    requirements_dir.cleanup() 
+    if not bare:
+        click.echo(crayons.green("All dependencies are now up-to-date!"))
 
 
 def do_clean(ctx, three=None, python=None, dry_run=False, bare=False, pypi_mirror=None):
@@ -2543,14 +2544,15 @@ def do_clean(ctx, three=None, python=None, dry_run=False, bare=False, pypi_mirro
             )]
     failure = False
     for apparent_bad_package in installed_package_names:
-        if dry_run:
+        if dry_run and not bare:
             click.echo(apparent_bad_package)
         else:
-            click.echo(
-                crayons.white(
-                    "Uninstalling {0}…".format(repr(apparent_bad_package)), bold=True
+            if not bare:
+                click.echo(
+                    crayons.white(
+                        "Uninstalling {0}…".format(repr(apparent_bad_package)), bold=True
+                    )
                 )
-            )
             # Uninstall the package.
             c = delegator.run(
                 "{0} uninstall {1} -y".format(which_pip(), apparent_bad_package)


### PR DESCRIPTION
Implement some behavior for --bare in sync and clean, and add bare an option to do_clean in cli.py


### The issue

https://github.com/pypa/pipenv/issues/3041



### The fix

Added logic for --bare to sync and clean since they are passed in as arguments. 
Excluding error messages.

Also added --bare as a click option to clean.

### The checklist

* [x] Associated issue
* [x] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

