### PR TITLE
Fix #3062

### DIFF
--- a/pipenv/project.py
+++ b/pipenv/project.py
@@ -926,8 +926,8 @@ class Project(object):
     @property
     def _pyversion(self):
         include_dir = vistir.compat.Path(self.virtualenv_location) / "include"
-        python_path = next(iter(list(include_dir.iterdir())), None)
-        if python_path and python_path.name.startswith("python"):
+        python_path = next((x for x in include_dir.iterdir() if x.name.startswith("python")), None)
+        if python_path:
             python_version = python_path.name.replace("python", "")
             py_version_short, abiflags = python_version[:3], python_version[3:]
             return {"py_version_short": py_version_short, "abiflags": abiflags}


### PR DESCRIPTION
### The issue

This fixes #3062.

`_pyversion` is meant to determine the short version ("x.y") and ABI-flags of the Python interpreter that was used to create a virtual environment. It does this by looking inside the _include_ directory of the virtual environment. It assumes there will be a subdirectory (or a symlink to a directory) that contains the Python headers, whose name is the Python-interpreter that created the venv (e.g. `python3.6m`). This can be cut up into the short Python version and the ABI-flags.

However, it can currently fail to do that if there are packages installed that put data files into the _include_ directory. An example is PyGObject, which puts its header _pygobject.h_ in a subdirectory of _include_.

### The fix

Before, `_pyversion` looked at the first file it found inside _include_, which didn't always turn out to be the directory containing the Python-headers. Improve this by looking at the first file that begins with "python" instead.

It should be noted that this can still fail if there are multiple files beginning with "python". I am open to suggestions on improving this further.

### The checklist

* [x] Associated issue
* [ ] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

