### PR TITLE
Fix PIPENV_VERBOSITY parsing logic

### DIFF
--- a/news/3069.trivial
+++ b/news/3069.trivial
@@ -1,0 +1,1 @@
+- Fix PIPENV_VERBOSITY parsing logic

--- a/pipenv/environments.py
+++ b/pipenv/environments.py
@@ -229,9 +229,9 @@ SESSION_IS_INTERACTIVE = bool(os.isatty(sys.stdout.fileno()))
 # Internal, consolidated verbosity representation as an integer. The default
 # level is 0, increased for wordiness and decreased for terseness.
 PIPENV_VERBOSITY = os.environ.get("PIPENV_VERBOSITY", "")
-if PIPENV_VERBOSITY.isdigit():
+try:
     PIPENV_VERBOSITY = int(PIPENV_VERBOSITY)
-else:
+except ValueError:
     if PIPENV_VERBOSE:
         PIPENV_VERBOSITY = 1
     elif PIPENV_QUIET:

--- a/pipenv/environments.py
+++ b/pipenv/environments.py
@@ -231,7 +231,7 @@ SESSION_IS_INTERACTIVE = bool(os.isatty(sys.stdout.fileno()))
 PIPENV_VERBOSITY = os.environ.get("PIPENV_VERBOSITY", "")
 try:
     PIPENV_VERBOSITY = int(PIPENV_VERBOSITY)
-except ValueError:
+except (ValueError, TypeError):
     if PIPENV_VERBOSE:
         PIPENV_VERBOSITY = 1
     elif PIPENV_QUIET:


### PR DESCRIPTION
### The issue

The issue is describe in #3068 : Impossible to hide the "Courtesy Notice" about active virtualenv.

The origin of the issue is that a value of `-1` for `PIPENV_VERBOSITY` is ignored but the current logic.

### The fix

`isdigit()` is not adapted to test a negative value:
```
In [1]: '-1'.isdigit()
Out[1]: False
```

Use `int()` to cast and catch `ValueError`.

### The checklist

* [x] Associated issue
* [x] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

<!--
### If this is a patch to the `vendor` directory…

Please try to refrain from submitting patches directly to `vendor` or `patched`, but raise your issue to the upstream project instead, and inform Pipenv to upgrade when the upstream project accepts the fix.

A pull request to upgrade vendor packages is strongly discouraged, unless there is a very good reason (e.g. you need to test Pipenv’s integration to a new vendor feature). Pipenv audits and performs vendor upgrades regularly, generally before a new release is about to drop.

If your patch is not or cannot be accepted by upstream, but is essential to Pipenv (make sure to discuss this with maintainers!), please remember to attach a patch file in `tasks/vendoring/patched`, so this divergence from upstream can be recorded and replayed afterwards.
-->
