### PR TITLE
Fixed unnecessary extras are added in lockfiles

### DIFF
--- a/news/3026.bugfix
+++ b/news/3026.bugfix
@@ -1,0 +1,1 @@
+Fixed unnecessary extras are added when translating markers

--- a/pipenv/utils.py
+++ b/pipenv/utils.py
@@ -1182,7 +1182,9 @@ def translate_markers(pipfile_entry):
     new_pipfile = dict(pipfile_entry).copy()
     marker_set = set()
     if "markers" in new_pipfile:
-        marker_set.add(str(Marker(new_pipfile.get("markers"))))
+        marker = str(Marker(new_pipfile.pop("markers")))
+        if 'extra' not in marker:
+            marker_set.add(marker)
     for m in pipfile_markers:
         entry = "{0}".format(pipfile_entry[m])
         if m != "markers":

--- a/tests/integration/test_lock.py
+++ b/tests/integration/test_lock.py
@@ -169,6 +169,28 @@ maya = "*"
 
 @pytest.mark.extras
 @pytest.mark.lock
+def test_lock_extras_without_install(PipenvInstance, pypi):
+    with PipenvInstance(pypi=pypi) as p:
+        with open(p.pipfile_path, 'w') as f:
+            contents = """
+[packages]
+requests = {version = "*", extras = ["socks"]}
+            """.strip()
+            f.write(contents)
+
+        c = p.pipenv('lock')
+        assert c.return_code == 0
+        assert "requests" in p.lockfile["default"]
+        assert "pysocks" in p.lockfile["default"]
+        assert "markers" not in p.lockfile["default"]['pysocks']
+
+        c = p.pipenv('lock -r')
+        assert c.return_code == 0
+        assert "extra == 'socks'" not in c.out.strip()
+
+
+@pytest.mark.extras
+@pytest.mark.lock
 @pytest.mark.complex
 @pytest.mark.skip(reason='Needs numpy to be mocked')
 @pytest.mark.needs_internet


### PR DESCRIPTION
### The issue

Fixed https://github.com/pypa/pipenv/issues/3026

### The fix

This is a annoying critical bug. Fixed by do not append ```extra``` when translating markers since they are unnecessary. Also test is added to avoid regression in further development.

### The checklist

* [x] Associated issue
* [x] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

<!--
### If this is a patch to the `vendor` directory…

Please try to refrain from submitting patches directly to `vendor` or `patched`, but raise your issue to the upstream project instead, and inform Pipenv to upgrade when the upstream project accepts the fix.

A pull request to upgrade vendor packages is strongly discouraged, unless there is a very good reason (e.g. you need to test Pipenv’s integration to a new vendor feature). Pipenv audits and performs vendor upgrades regularly, generally before a new release is about to drop.

If your patch is not or cannot be accepted by upstream, but is essential to Pipenv (make sure to discuss this with maintainers!), please remember to attach a patch file in `tasks/vendoring/patched`, so this divergence from upstream can be recorded and replayed afterwards.
-->
