### PR TITLE
Add specific testing instructions to contributing.rst

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,6 +130,9 @@ venv.bak/
 .spyderproject
 .spyproject
 
+# PyCharm project settings
+.idea
+
 # Rope project settings
 .ropeproject
 

--- a/docs/dev/contributing.rst
+++ b/docs/dev/contributing.rst
@@ -131,7 +131,7 @@ Three ways of running the tests are as follows:
 3. Using pipenv::
 
     pipenv install --dev
-    pipenv run py.test
+    pipenv run pytest
 
 For the last two, it is important that your environment is setup correctly, and
 this may take some work, for example, on a specific Mac installation, the following

--- a/docs/dev/contributing.rst
+++ b/docs/dev/contributing.rst
@@ -127,7 +127,7 @@ Run the tests
 Three ways of running the tests are as follows:
 
 1. ``make test`` (which uses ``docker``)
-2. ``./run-tests.sh``
+2. ``./run-tests.sh`` or ``run-tests.bat``
 3. Using pipenv::
 
     pipenv install --dev

--- a/docs/dev/contributing.rst
+++ b/docs/dev/contributing.rst
@@ -153,5 +153,5 @@ steps may be needed::
 
     export PATH
 
-    # PIP_FIND_LINKS currently broken
+    # PIP_FIND_LINKS currently breaks test_uninstall.py
     unset PIP_FIND_LINKS

--- a/docs/dev/contributing.rst
+++ b/docs/dev/contributing.rst
@@ -67,7 +67,7 @@ Steps for Submitting Code
 When contributing code, you'll want to follow this checklist:
 
 1. Fork the repository on GitHub.
-2. Run the tests to confirm they all pass on your system. If they don't, you'll
+2. `Run the tests`_ to confirm they all pass on your system. If they don't, you'll
    need to investigate why they fail. If you're unable to diagnose this
    yourself, raise it as a bug report by following the guidelines in this
    document: :ref:`bug-reports`.
@@ -120,3 +120,38 @@ hasn't been reported before. Duplicate bug reports are a huge drain on the time
 of other contributors, and should be avoided as much as possible.
 
 .. _GitHub issues: https://github.com/pypa/pipenv/issues
+
+Run the tests
+-------------
+
+Three ways of running the tests are as follows:
+
+1. ``make test`` (which uses ``docker``)
+2. ``./run-tests.sh``
+3. Using pipenv::
+
+    pipenv install --dev
+    pipenv run py.test
+
+For the last two, it is important that your environment is setup correctly, and
+this may take some work, for example, on a specific Mac installation, the following
+steps may be needed::
+
+    # Make sure the tests can access github
+    if [ "$SSH_AGENT_PID" = "" ]
+    then
+       eval `ssh-agent`
+       ssh-add
+    fi
+
+    # Use unix like utilities, installed with brew,
+    # e.g. brew install coreutils
+    for d in /usr/local/opt/*/libexec/gnubin /usr/local/opt/python/libexec/bin
+    do
+      [[ ":$PATH:" != *":$d:"* ]] && PATH="$d:${PATH}"
+    done
+
+    export PATH
+
+    # PIP_FIND_LINKS currently broken
+    unset PIP_FIND_LINKS


### PR DESCRIPTION

### The issue

I wanted to start contributing to the project, the instruction "Run the tests to confirm they all pass on your system" is non-trivial, and took longer than really needed to put into effect.

### The fix

I documented what I did to perform this task.

### Open Concern

The first way I suggest running the tests is `make test`; however, this does not work for me.
I don't know what it would take to have success, but believe it is a legitimate way to achieve the goal.


### The checklist

* [None ] Associated issue
* [Not appropriate] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.


