### PR TITLE
pipenv open custom command help #3081

### DIFF
--- a/pipenv/cli/command.py
+++ b/pipenv/cli/command.py
@@ -533,7 +533,13 @@ def graph(bare=False, json=False, json_tree=False, reverse=False):
 @argument("module", nargs=1)
 @pass_state
 def run_open(state, module, *args, **kwargs):
-    """View a given module in your editor."""
+    """View a given module in your editor.
+
+    This uses the EDITOR environment variable. You can temporarily override it,
+    for example:
+
+        EDITOR=atom pipenv open requests
+    """
     from ..core import which, ensure_project
 
     # Ensure that virtualenv is available.


### PR DESCRIPTION
As discussed in https://github.com/pypa/pipenv/issues/3081 clarifies how custom commands can be used with `pipenv open`.

To test:

```
$ pipenv run python -m pipenv open --help
Usage: __main__.py open [OPTIONS] MODULE

  View a given module in your editor, as defined by the EDITOR environment
  variable. You can temporarily override it, for example:

      EDITOR=atom pipenv open requests

Options:
  --python TEXT       Specify which version of Python virtualenv should use.
  --three / --two     Use Python 3/2 when creating virtualenv.
  --clear             Clears caches (pipenv, pip, and pip-tools).
  -v, --verbose       Verbose mode.
  --pypi-mirror TEXT  Specify a PyPI mirror.
  -h, --help          Show this message and exit.
```