### PR TITLE
Add try-in-browser button to launch Pipenv playground (README and docs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ The problems that Pipenv seeks to solve are multi-faceted:
 -   Give you insight into your dependency graph (e.g. `$ pipenv graph`).
 -   Streamline development workflow by loading `.env` files.
 
+You can quickly play with Pipenv right in your browser:
+
+[![Try in browser](https://cdn.rawgit.com/rootnroll/library/assets/try.svg)](https://rootnroll.com/d/pipenv/)
+
 Installation
 ------------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -39,6 +39,12 @@ The problems that Pipenv seeks to solve are multi-faceted:
 - Give you insight into your dependency graph (e.g. ``$ pipenv graph``).
 - Streamline development workflow by loading ``.env`` files.
 
+You can quickly play with Pipenv right in your browser:
+
+.. image:: https://cdn.rawgit.com/rootnroll/library/assets/try.svg
+    :target: https://rootnroll.com/d/pipenv/
+    :alt: Try in browser
+
 
 Install Pipenv Today!
 ---------------------


### PR DESCRIPTION
Add the button:
[![Try in browser](https://cdn.rawgit.com/rootnroll/library/assets/try.svg)](https://rootnroll.com/d/pipenv/)
to README and docs to launch a Pipenv playground and try it out right in the browser.

https://rootnroll.com is a standalone service for running cli playgrounds.

Source files used to create the Pipenv playground: https://github.com/rootnroll/library/tree/master/pipenv
Automated build of docker image: https://hub.docker.com/r/rootnroll/demo-pipenv/
