### PR TITLE
Issue #3102 - Converts output of subprocess to str in `_pexpect_out`

### DIFF
--- a/pipenv/vendor/delegator.py
+++ b/pipenv/vendor/delegator.py
@@ -111,7 +111,7 @@ class Command(object):
             result += self.subprocess.before
 
         if self.subprocess.after:
-            result += self.subprocess.after
+            result += str(self.subprocess.after)
 
         result += self.subprocess.read()
         return result


### PR DESCRIPTION
### The issue

Issue #3102

### The fix

Output of `subprocess.after` is not always a `str`, and cannot be concatenate to `str`. This PR converts the variable to `str` before concatenation.

### The checklist

* [x] Associated issue
* [ ] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.
