### PR TITLE
Create a PEEP for dedicated credential fields

### DIFF
--- a/peeps/PEEP-003.md
+++ b/peeps/PEEP-003.md
@@ -1,0 +1,46 @@
+# PEEP-003: Dedicated fields for source credentials
+
+This PEEP proposes to add dedicated fields to contain credentials that will be
+url-encoded for a private index.
+
+☤
+
+For now, the easiest way to install packages from a private index is to use
+environment variables in the Pipfile:
+
+```
+[[source]]
+url = "https://$USERNAME:${PASSWORD}@mypypi.example.com/simple"
+verify_ssl = true
+name = "pypi"
+```
+
+But these variables may contain special characters that need to be encoded. For
+instance:
+
+```bash
+USERNAME="my#username"
+```
+
+This can be done manually with [`urllib.parse.quote()`](https://docs.python.org/3.7/library/urllib.parse.html#urllib.parse.quote)
+for instance, but it makes the process less smooth for the user.
+
+This PEEP proposes to add fields to store credentials that will be encoded by
+pipenv:
+
+```
+[[source]]
+url = "https://mypypi.example.com/simple"
+verify_ssl = true
+name = "pypi"
+username = "$USERNAME"
+password = "$PASSWORD"
+```
+
+```bash
+USERNAME="my#username"; PASSWORD="xxx/yyy"; pipenv install
+```
+
+We cannot automatically encode credentials passed in the `url` fields as they
+may have already been encoded. By using dedicated fields, we make it clear that
+the credentials will be encoded by pipenv.


### PR DESCRIPTION
Thank you for contributing to Pipenv!


### The issue

#3085 

### The fix

Perhaps the fields `username` and `password` should only contain the **name** of an environment variable and not its value. Otherwise, the user can include the credentials in the Pipfile, which is a bad practice:
```
[[source]]
url = "https://mypypi.example.com/simple"
verify_ssl = true
name = "pypi"
username = "my#username"
password = "my/pass"
```

### The checklist

* [x] Associated issue
* [ ] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

<!--
### If this is a patch to the `vendor` directory…

Please try to refrain from submitting patches directly to `vendor` or `patched`, but raise your issue to the upstream project instead, and inform Pipenv to upgrade when the upstream project accepts the fix.

A pull request to upgrade vendor packages is strongly discouraged, unless there is a very good reason (e.g. you need to test Pipenv’s integration to a new vendor feature). Pipenv audits and performs vendor upgrades regularly, generally before a new release is about to drop.

If your patch is not or cannot be accepted by upstream, but is essential to Pipenv (make sure to discuss this with maintainers!), please remember to attach a patch file in `tasks/vendoring/patched`, so this divergence from upstream can be recorded and replayed afterwards.
-->
