### PR TITLE
Fix unicode encoding to replace non-ascii chars

### DIFF
--- a/news/3131.bugfix.rst
+++ b/news/3131.bugfix.rst
@@ -1,0 +1,1 @@
+Added additional logic for ignoring and replacing non-ascii characters when formatting console output on non-UTF-8 systems.

--- a/pipenv/_compat.py
+++ b/pipenv/_compat.py
@@ -379,11 +379,12 @@ def decode_output(output):
         return output
     try:
         output = output.encode(DEFAULT_ENCODING)
-    except (AttributeError, UnicodeDecodeError):
+    except (AttributeError, UnicodeDecodeError, UnicodeEncodeError):
         if six.PY2:
             output = unicode.translate(vistir.misc.to_text(output),
                                             UNICODE_TO_ASCII_TRANSLATION_MAP)
         else:
             output = output.translate(UNICODE_TO_ASCII_TRANSLATION_MAP)
-    output = output.decode(DEFAULT_ENCODING)
+        output = output.encode(DEFAULT_ENCODING, "replace")
+    return vistir.misc.to_text(output, encoding=DEFAULT_ENCODING, errors="replace")
     return output


### PR DESCRIPTION
Fix unicode encoding to replace non-ascii chars

- Drops any unmapped non-ascii characters on non-utf8 systems
- Fixes #3131