### PR TITLE
Rewrite venv discovery logic

### DIFF
--- a/news/3134.bugfix.rst
+++ b/news/3134.bugfix.rst
@@ -1,0 +1,1 @@
+Fix virtual environment discovery when `PIPENV_VENV_IN_PROJECT` is set, but the in-project `.venv` is a file.

--- a/pipenv/project.py
+++ b/pipenv/project.py
@@ -269,18 +269,33 @@ class Project(object):
         return False
 
     def get_location_for_virtualenv(self):
-        if self.is_venv_in_project():
-            return os.path.join(self.project_directory, ".venv")
+        # If there's no project yet, set location based on config.
+        if not self.project_directory:
+            if self.is_venv_in_project():
+                return os.path.abspath(".venv")
+            return str(get_workon_home().joinpath(self.virtualenv_name))
 
-        name = self.virtualenv_name
-        if self.project_directory:
-            venv_path = os.path.join(self.project_directory, ".venv")
-            if os.path.exists(venv_path) and not os.path.isdir(".venv"):
-                with io.open(venv_path, "r") as f:
-                    name = f.read().strip()
-                # Assume file's contents is a path if it contains slashes.
-                if looks_like_dir(name):
-                    return vistir.compat.Path(name).absolute().as_posix()
+        dot_venv = os.path.join(self.project_directory, ".venv")
+
+        # If there's no .venv in project root, set location based on config.
+        if not os.path.exists(dot_venv):
+            if self.is_venv_in_project():
+                return dot_venv
+            return str(get_workon_home().joinpath(self.virtualenv_name))
+
+        # If .venv in project root is a directory, use it.
+        if os.path.isdir(dot_venv):
+            return dot_venv
+
+        # Now we assume .venv in project root is a file. Use its content.
+        with io.open(dot_venv) as f:
+            name = f.read().strip()
+
+        # If content looks like a path, use it as a relative path.
+        # Otherwise use directory named after content in WORKON_HOME.
+        if looks_like_dir(name):
+            path = vistir.compat.Path(self.project_directory, name)
+            return path.absolute().as_posix()
         return str(get_workon_home().joinpath(name))
 
     @property


### PR DESCRIPTION
### The issue

Found an edge case in `project.get_location_for_virtualenv()`. If `PIPENV_VENV_IN_PROJECT` is true, `.venv` is always used as a directory, not read as a file.

To reproduce:

```
$ mkdir my-project
$ cd my-project
$ export PIPENV_VENV_IN_PROJECT=1
$ touch Pipenv
$ echo './.i-want-my-venv-here' > .venv
$ pipenv lock   # This will fail because Pipenv wants to use .venv as the virtual environment.
```

### The fix

I reorganised the discovery function. Comments are added so branching is more straightforward (hopefully). The new logic works like this:

1. Is there a project root yet? If not…
    * Use `$PWD/.venv` if `PIPENV_VENV_IN_PROJECT` is set
    * Use the `$WORKON_HOME/[name]-[hash]` scheme by default
2. Does `.venv` exist in project root? If not, use the same logic as 1. (replacing `$PWD` with project root)
3. Is `.venv` a directory? If so, use it directly.
4. Read `.venv` as a file.
    * If the content looks like a path, resolve it as a relative path to project root to use.
    * Otherwise use the directory of that name in `$WORKON_HOME`.


### The checklist

* [ ] Associated issue
* [x] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.