### PR TITLE
Continue to fix cannot concatenate str and type issue during locking

### DIFF
--- a/pipenv/vendor/delegator.py
+++ b/pipenv/vendor/delegator.py
@@ -112,7 +112,7 @@ class Command(object):
         if self.subprocess.before:
             result += self.subprocess.before
 
-        if self.subprocess.after and self.subprocess.after is not pexpect.EOF:
+        if self.subprocess.after and self.subprocess.after not in (pexpect.EOF, pexpect.TIMEOUT):
             try:
                 result += self.subprocess.after
             except (pexpect.EOF, pexpect.TIMEOUT):


### PR DESCRIPTION
### The issue

Continue to fix https://github.com/pypa/pipenv/issues/3102. Sometime ```TIMEOUT``` errors will be raised as well as ```EOF```.

### The checklist

* [x] Associated issue
* [x] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

<!--
### If this is a patch to the `vendor` directory…

Please try to refrain from submitting patches directly to `vendor` or `patched`, but raise your issue to the upstream project instead, and inform Pipenv to upgrade when the upstream project accepts the fix.

A pull request to upgrade vendor packages is strongly discouraged, unless there is a very good reason (e.g. you need to test Pipenv’s integration to a new vendor feature). Pipenv audits and performs vendor upgrades regularly, generally before a new release is about to drop.

If your patch is not or cannot be accepted by upstream, but is essential to Pipenv (make sure to discuss this with maintainers!), please remember to attach a patch file in `tasks/vendoring/patched`, so this divergence from upstream can be recorded and replayed afterwards.
-->
