### PR TITLE
Quote command if parentheses exist

### DIFF
--- a/news/3168.bugfix.rst
+++ b/news/3168.bugfix.rst
@@ -1,0 +1,1 @@
+Fix a bug that pipenv fails to install packages if the virtualenv path contains ``()``.

--- a/pipenv/cmdparse.py
+++ b/pipenv/cmdparse.py
@@ -66,7 +66,7 @@ class Script(object):
         See also: https://docs.python.org/3/library/subprocess.html#converting-argument-sequence
         """
         return " ".join(
-            arg if not next(re.finditer(r'\s', arg), None)
+            arg if not next(re.finditer(r'[\s()]', arg), None)
             else '"{0}"'.format(re.sub(r'(\\*)"', r'\1\1\\"', arg))
             for arg in self._parts
         )

--- a/tests/unit/test_cmdparse.py
+++ b/tests/unit/test_cmdparse.py
@@ -47,3 +47,18 @@ def test_cmdify_complex():
         '-c',
         """ "print(\'Double quote: \\\"\')" """.strip(),
     ]), script
+
+
+@pytest.mark.run
+@pytest.mark.script
+def test_cmdify_with_parenthese():
+    script = Script.parse([
+        'C:\\Users\\Me\\.virtualenvs\\test(new)\\Scripts\\pip.exe',
+        'install',
+        'requests'
+    ])
+    assert script.cmdify() == ' '.join([
+        '"C:\\Users\\Me\\.virtualenvs\\test(new)\\Scripts\\pip.exe"',
+        'install',
+        'requests'
+    ]), script


### PR DESCRIPTION
Thank you for contributing to Pipenv!


### The issue

Fixes #3168 

### The fix

Quote the command if it contains `()`.

### The checklist

* [x] Associated issue
* [x] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

<!--
### If this is a patch to the `vendor` directory…

Please try to refrain from submitting patches directly to `vendor` or `patched`, but raise your issue to the upstream project instead, and inform Pipenv to upgrade when the upstream project accepts the fix.

A pull request to upgrade vendor packages is strongly discouraged, unless there is a very good reason (e.g. you need to test Pipenv’s integration to a new vendor feature). Pipenv audits and performs vendor upgrades regularly, generally before a new release is about to drop.

If your patch is not or cannot be accepted by upstream, but is essential to Pipenv (make sure to discuss this with maintainers!), please remember to attach a patch file in `tasks/vendoring/patched`, so this divergence from upstream can be recorded and replayed afterwards.
-->
