### PR TITLE
Update skip lock option help info since it is used in several operations

### DIFF
--- a/pipenv/cli/options.py
+++ b/pipenv/cli/options.py
@@ -126,7 +126,7 @@ def skip_lock_option(f):
         state.installstate.skip_lock = value
         return value
     return option("--skip-lock", is_flag=True, default=False, expose_value=False,
-                    help=u"Ignore locking mechanisms when installing—use the Pipfile, instead.",
+                    help=u"Ignore locking mechanisms during operation—use the Pipfile, instead.",
                     callback=callback, type=click.types.BOOL)(f)
 
 

--- a/pipenv/cli/options.py
+++ b/pipenv/cli/options.py
@@ -126,7 +126,7 @@ def skip_lock_option(f):
         state.installstate.skip_lock = value
         return value
     return option("--skip-lock", is_flag=True, default=False, expose_value=False,
-                    help=u"Ignore locking mechanisms during operation—use the Pipfile, instead.",
+                    help=u"Skip locking mechanisms and use the Pipfile instead during operation.",
                     callback=callback, type=click.types.BOOL)(f)
 
 


### PR DESCRIPTION
### The issue

Currently ```--skip-lock``` option is used for several commands, such as ```install```, ```uninstall```. The ```Ignore locking mechanisms when **installing**``` is not appropriately anymore.

### The checklist

* [ ] Associated issue
* [ ] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

<!--
### If this is a patch to the `vendor` directory…

Please try to refrain from submitting patches directly to `vendor` or `patched`, but raise your issue to the upstream project instead, and inform Pipenv to upgrade when the upstream project accepts the fix.

A pull request to upgrade vendor packages is strongly discouraged, unless there is a very good reason (e.g. you need to test Pipenv’s integration to a new vendor feature). Pipenv audits and performs vendor upgrades regularly, generally before a new release is about to drop.

If your patch is not or cannot be accepted by upstream, but is essential to Pipenv (make sure to discuss this with maintainers!), please remember to attach a patch file in `tasks/vendoring/patched`, so this divergence from upstream can be recorded and replayed afterwards.
-->
