### PR TITLE
Better output of pipenv clean and uninstall

### DIFF
--- a/news/3179.trivial
+++ b/news/3179.trivial
@@ -1,0 +1,1 @@
+Better output of pipenv uninstall and clean

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -2087,7 +2087,7 @@ def do_uninstall(
         normalized_bad_pkg = canonicalize_name(bad_package)
         if normalized_bad_pkg in package_map:
             if environments.is_verbose():
-                click.echo("Ignoring {0}.".format(repr(bad_package)), err=True)
+                click.echo("Ignoring {0}.".format(bad_package), err=True)
             pkg_name_index = package_names.index(package_map[normalized_bad_pkg])
             del package_names[pkg_name_index]
     used_packages = develop | default & installed_package_names
@@ -2126,7 +2126,7 @@ def do_uninstall(
     for normalized, package_name in selected_pkg_map.items():
         click.echo(
             crayons.white(
-                fix_utf8("Uninstalling {0}…".format(repr(package_name))), bold=True
+                fix_utf8("Uninstalling {0}…".format(package_name)), bold=True
             )
         )
         # Uninstall the package.
@@ -2643,7 +2643,7 @@ def do_clean(ctx, three=None, python=None, dry_run=False, bare=False, pypi_mirro
     for bad_package in BAD_PACKAGES:
         if canonicalize_name(bad_package) in installed_package_names:
             if environments.is_verbose():
-                click.echo("Ignoring {0}.".format(repr(bad_package)), err=True)
+                click.echo("Ignoring {0}.".format(bad_package), err=True)
             del installed_package_names[installed_package_names.index(
                 canonicalize_name(bad_package)
             )]
@@ -2663,7 +2663,7 @@ def do_clean(ctx, three=None, python=None, dry_run=False, bare=False, pypi_mirro
             if not bare:
                 click.echo(
                     crayons.white(
-                        fix_utf8("Uninstalling {0}…".format(repr(apparent_bad_package))), bold=True
+                        fix_utf8("Uninstalling {0}…".format(apparent_bad_package)), bold=True
                     )
                 )
             # Uninstall the package.


### PR DESCRIPTION
### The issue

Closes #3179

### The fix

The package names can be unicode or str in python2. Using ```repr``` will translate them to ```u''``` or ```''``` format.

I think removing ```repr``` is safe since the names are passed into ```format```. Actually some codes already did this such as https://github.com/pypa/pipenv/blob/master/pipenv/core.py#L2164-L2168

### The checklist

* [x] Associated issue
* [x] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

<!--
### If this is a patch to the `vendor` directory…

Please try to refrain from submitting patches directly to `vendor` or `patched`, but raise your issue to the upstream project instead, and inform Pipenv to upgrade when the upstream project accepts the fix.

A pull request to upgrade vendor packages is strongly discouraged, unless there is a very good reason (e.g. you need to test Pipenv’s integration to a new vendor feature). Pipenv audits and performs vendor upgrades regularly, generally before a new release is about to drop.

If your patch is not or cannot be accepted by upstream, but is essential to Pipenv (make sure to discuss this with maintainers!), please remember to attach a patch file in `tasks/vendoring/patched`, so this divergence from upstream can be recorded and replayed afterwards.
-->
