### PR TITLE
Do not add index source per-line in requirements files

### DIFF
--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -726,7 +726,7 @@ def do_install_dependencies(
         index_args = prepare_pip_source_args(project.sources)
         index_args = " ".join(index_args).replace(" -", "\n-")
         deps = [
-            req.as_line(sources=project.sources, include_hashes=False) for req in deps_list
+            req.as_line(sources=False, include_hashes=False) for req in deps_list
         ]
         # Output only default dependencies
         click.echo(index_args)


### PR DESCRIPTION
### The issue

Closes https://github.com/pypa/pipenv/issues/3181

### The fix

Since index source per-line is not working, let's just disable it.

### The checklist

* [x] Associated issue
* [ ] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

<!--
### If this is a patch to the `vendor` directory…

Please try to refrain from submitting patches directly to `vendor` or `patched`, but raise your issue to the upstream project instead, and inform Pipenv to upgrade when the upstream project accepts the fix.

A pull request to upgrade vendor packages is strongly discouraged, unless there is a very good reason (e.g. you need to test Pipenv’s integration to a new vendor feature). Pipenv audits and performs vendor upgrades regularly, generally before a new release is about to drop.

If your patch is not or cannot be accepted by upstream, but is essential to Pipenv (make sure to discuss this with maintainers!), please remember to attach a patch file in `tasks/vendoring/patched`, so this divergence from upstream can be recorded and replayed afterwards.
-->
