### PR TITLE
Quote command if it contains parentheses

### DIFF
--- a/news/3158.bugfix.rst
+++ b/news/3158.bugfix.rst
@@ -1,0 +1,1 @@
+Fix package installation when the virtual environment path contains parentheses.

--- a/tests/unit/test_cmdparse.py
+++ b/tests/unit/test_cmdparse.py
@@ -47,3 +47,20 @@ def test_cmdify_complex():
         '-c',
         """ "print(\'Double quote: \\\"\')" """.strip(),
     ]), script
+
+
+@pytest.mark.run
+@pytest.mark.script
+def test_cmdify_quote_if_paren_in_command():
+    """Ensure ONLY the command is quoted if it contains parentheses.
+    """
+    script = Script.parse(' '.join([
+        '"C:\\Python36(x86)\\python.exe"',
+        '-c',
+        "print(123)",
+    ]))
+    assert script.cmdify() == ' '.join([
+        '"C:\\Python36(x86)\\python.exe"',
+        '-c',
+        "print(123)",
+    ]), script


### PR DESCRIPTION
Close #3169. I adopted the solution, but only apply it to the first argument (the command). @frostming can you verify if this fixes your problem?