### PR TITLE
Fix double completion message on locking

### DIFF
--- a/news/3183.bugfix.rst
+++ b/news/3183.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed new spinner success message to write only one success message during resolution.

--- a/news/3185.bugfix.rst
+++ b/news/3185.bugfix.rst
@@ -1,0 +1,1 @@
+Pipenv will now correctly respect the ``--pre`` option when used with ``pipenv install``.

--- a/pipenv/cli/options.py
+++ b/pipenv/cli/options.py
@@ -338,6 +338,7 @@ def common_options(f):
 def install_base_options(f):
     f = common_options(f)
     f = dev_option(f)
+    f = pre_option(f)
     f = keep_outdated_option(f)
     return f
 
@@ -353,7 +354,6 @@ def uninstall_options(f):
 def lock_options(f):
     f = install_base_options(f)
     f = requirements_flag(f)
-    f = pre_option(f)
     return f
 
 

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -969,7 +969,6 @@ def do_lock(
     pypi_mirror=None,
 ):
     """Executes the freeze functionality."""
-    from .utils import get_vcs_deps
 
     cached_lockfile = {}
     if not pre:
@@ -1931,38 +1930,39 @@ def do_install(
                         extra_indexes=extra_index_url,
                         pypi_mirror=pypi_mirror,
                     )
-                except (ValueError, RuntimeError):
+                except (ValueError, RuntimeError) as e:
                     sp.write_err(vistir.compat.fs_str("{0}: {1}".format(crayons.red("WARNING"), e)))
                     sp.fail(environments.PIPENV_SPINNER_FAIL_TEXT.format("Installation Failed"))
-                # Warn if --editable wasn't passed.
-                if pkg_requirement.is_vcs and not pkg_requirement.editable:
-                    sp.write_err(
-                        "{0}: You installed a VCS dependency in non-editable mode. "
-                        "This will work fine, but sub-dependencies will not be resolved by {1}."
-                        "\n  To enable this sub-dependency functionality, specify that this dependency is editable."
-                        "".format(
-                            crayons.red("Warning", bold=True),
-                            crayons.red("$ pipenv lock"),
-                        )
-                    )
-                click.echo(crayons.blue(format_pip_output(c.out)))
-                # Ensure that package was successfully installed.
-                if c.return_code != 0:
-                    sp.write_err(vistir.compat.fs_str(
-                        "{0} An error occurred while installing {1}!".format(
-                            crayons.red("Error: ", bold=True), crayons.green(pkg_line)
-                        ),
-                    ))
-                    sp.write_err(vistir.compat.fs_str(crayons.blue(format_pip_error(c.err))))
-                    if "setup.py egg_info" in c.err:
-                        sp.write_err(vistir.compat.fs_str(
-                            "This is likely caused by a bug in {0}. "
-                            "Report this to its maintainers.".format(
-                                crayons.green(pkg_requirement.name)
+                else:
+                    # Warn if --editable wasn't passed.
+                    if pkg_requirement.is_vcs and not pkg_requirement.editable:
+                        sp.write_err(
+                            "{0}: You installed a VCS dependency in non-editable mode. "
+                            "This will work fine, but sub-dependencies will not be resolved by {1}."
+                            "\n  To enable this sub-dependency functionality, specify that this dependency is editable."
+                            "".format(
+                                crayons.red("Warning", bold=True),
+                                crayons.red("$ pipenv lock"),
                             )
+                        )
+                    click.echo(crayons.blue(format_pip_output(c.out)))
+                    # Ensure that package was successfully installed.
+                    if c.return_code != 0:
+                        sp.write_err(vistir.compat.fs_str(
+                            "{0} An error occurred while installing {1}!".format(
+                                crayons.red("Error: ", bold=True), crayons.green(pkg_line)
+                            ),
                         ))
-                    sp.fail(environments.PIPENV_SPINNER_FAIL_TEXT.format("Installation Failed"))
-                    sys.exit(1)
+                        sp.write_err(vistir.compat.fs_str(crayons.blue(format_pip_error(c.err))))
+                        if "setup.py egg_info" in c.err:
+                            sp.write_err(vistir.compat.fs_str(
+                                "This is likely caused by a bug in {0}. "
+                                "Report this to its maintainers.".format(
+                                    crayons.green(pkg_requirement.name)
+                                )
+                            ))
+                        sp.fail(environments.PIPENV_SPINNER_FAIL_TEXT.format("Installation Failed"))
+                        sys.exit(1)
                 sp.write(vistir.compat.fs_str(
                     u"{0} {1} {2} {3}{4}".format(
                         crayons.normal(u"Adding", bold=True),

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -1028,27 +1028,17 @@ def do_lock(
         deps = convert_deps_to_pip(
             settings["packages"], project, r=False, include_index=True
         )
-        # Add refs for VCS installs.
-        # TODO: be smarter about this.
-        vcs_reqs, vcs_lockfile = get_vcs_deps(
-            project,
-            which=which,
-            clear=clear,
-            pre=pre,
-            allow_global=system,
-            dev=settings["dev"],
-        )
-        vcs_lines = [req.as_line() for req in vcs_reqs if req.editable]
         results, vcs_results = venv_resolve_deps(
             deps,
             which=which,
             project=project,
-            vcs_deps=vcs_lines,
+            dev=settings["dev"],
             clear=clear,
             pre=pre,
             allow_global=system,
             pypi_mirror=pypi_mirror,
         )
+        vcs_results, vcs_lockfile = vcs_results
         # Add dependencies to lockfile.
         for dep in results:
             is_top_level = dep["name"] in settings["packages"]

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -1913,6 +1913,7 @@ def do_install(
                             crayons.red("Warning", bold=True),
                             crayons.red("$ pipenv lock"),
                         )
+                    )
                     click.echo(crayons.blue(format_pip_output(c.out)))
                     # Ensure that package was successfully installed.
                     if c.return_code != 0:

--- a/pipenv/project.py
+++ b/pipenv/project.py
@@ -617,15 +617,14 @@ class Project(object):
             data = tomlkit.parse(contents)
             # Convert all outline tables to inline tables.
             for section in ("packages", "dev-packages"):
-                table_data = data.get(section, tomlkit.table())
+                table_data = data.get(section, {})
                 for package, value in table_data.items():
                     if isinstance(value, dict):
-                        table = tomlkit.inline_table()
-                        table.update(value)
-                        table_data[package] = table
+                        package_table = tomlkit.inline_table()
+                        package_table.update(value)
+                        data[section][package] = package_table
                     else:
-                        table_data[package] = value
-                data[section] = table_data
+                        data[section][package] = value
             return data
         except Exception:
             # We lose comments here, but it's for the best.)
@@ -1036,6 +1035,10 @@ class Project(object):
             # Skip for wildcard version
             return
         # Add the package to the group.
+        if isinstance(converted, dict):
+            package_table = tomlkit.inline_table()
+            package_table.update(converted)
+            converted = package_table
         p[key][name or package.normalized_name] = converted
         # Write Pipfile.
         self.write_toml(p)

--- a/pipenv/utils.py
+++ b/pipenv/utils.py
@@ -572,7 +572,10 @@ def venv_resolve_deps(
             click_echo(output.split("RESULTS:")[0], err=True)
     try:
         results = json.loads(results.split("RESULTS:")[1].strip())
-        vcs_results = json.loads(vcs_results.split("RESULTS:")[1].strip())
+        if vcs_results:
+            vcs_results = json.loads(vcs_results.split("RESULTS:")[1].strip())
+        else:
+            vcs_results = []
 
     except (IndexError, JSONDecodeError):
         for out, err in [(c.out, c.err), (vcs_results, vcs_err)]:

--- a/pipenv/utils.py
+++ b/pipenv/utils.py
@@ -579,9 +579,6 @@ def venv_resolve_deps(
                 dev=dev,
             )
             vcs_deps = [req.as_line() for req in vcs_reqs if req.editable]
-            sp.write(environments.PIPENV_SPINNER_OK_TEXT.format(
-                "Successfully pinned VCS Packages!"
-            ))
     cmd = [
         which("python", allow_global=allow_global),
         Path(resolver.__file__.rstrip("co")).as_posix()


### PR DESCRIPTION
- Pass `pre` correctly when using `pipenv install --pre`
- Ensures we always make inline tables when writing to pipfile
- Fixes #3183
- Fixes #3185
