### PR TITLE
Updated graph command docstrings, fixes #3071

### DIFF
--- a/news/3071.doc.rst
+++ b/news/3071.doc.rst
@@ -1,0 +1,1 @@
+Docstrings for graph command now describe how command works when shell is active

--- a/pipenv/cli/command.py
+++ b/pipenv/cli/command.py
@@ -526,7 +526,7 @@ def update(
     )
 
 
-@cli.command(short_help=u"Displays currently-installed dependency graph information.")
+@cli.command(short_help=u"Displays currently-installed dependency graph information. Will only show dev dependencies while shell is running")
 @option("--bare", is_flag=True, default=False, help="Minimal output.")
 @option("--json", is_flag=True, default=False, help="Output JSON.")
 @option("--json-tree", is_flag=True, default=False, help="Output JSON in nested tree.")


### PR DESCRIPTION
### The issue

#3071 - pipenv graph only shows dev dependencies instead of all dependencies

### The fix

Since graph depends on pipdeptree, fixing graph's interaction with shell is not really doable, so documentation has been edited to reflect how graph works differently in and out of shell.

### The checklist

* [x] Associated issue
* [x] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.
