### PR TITLE
fix for  #2747 (needs refinement)

### DIFF
--- a/pipenv/cli/command.py
+++ b/pipenv/cli/command.py
@@ -569,7 +569,10 @@ def run_open(state, module, *args, **kwargs):
     else:
         p = c.out.strip().rstrip("cdo")
     echo(crayons.normal("Opening {0!r} in your EDITOR.".format(p), bold=True))
-    edit(filename=p)
+    from ..core import inline_activate_virtual_environment
+    inline_activate_virtual_environment()
+    environment={"VIRTUAL_ENV":os.environ["VIRTUAL_ENV"]}
+    edit(filename=p, env=environment)
     return 0
 
 

--- a/pipenv/cli/command.py
+++ b/pipenv/cli/command.py
@@ -572,7 +572,7 @@ def run_open(state, module, *args, **kwargs):
     from ..core import inline_activate_virtual_environment
     inline_activate_virtual_environment()
     environment={"VIRTUAL_ENV":os.environ["VIRTUAL_ENV"]}
-    edit(filename=p, env=environment)
+    edit(filename=p)
     return 0
 
 

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -126,6 +126,12 @@ def test_pipenv_check(PipenvInstance, pypi):
 
 
 @pytest.mark.cli
+def test_pipenv_open(PipenvInstance, pypi):
+    with PipenvInstance(pypi=pypi) as p:
+        assert p.pipenv("open test").out
+
+
+@pytest.mark.cli
 def test_pipenv_clean_pip_no_warnings(PipenvInstance):
     with PipenvInstance(chdir=True) as p:
         with open('setup.py', 'w') as f:


### PR DESCRIPTION
This PR should fix #2747.

### The issue

Issue #2747 occurs as the original implementation of `run_open` did not pass the virtual environment variable to the editor handler.

### The fix

The virtual environment is initialized using `inline_activate_virtual_environment()` and passed the `VIRTUAL_ENV` variable to the editor.

I considered refactoring `run_open` to share more common logic with `do_run` as suggested by @uranusjr but the alternate solution I came up with involved reusing  click's `get_editor` logic to get the `$EDITOR` variable and to account for if its undefined and building a command which is run using `do_run`. 

I'm not sure which implementation is better, any suggestions?

Also, is there anything I can do to improve my tests?