### PR TITLE
Clear pythonfinder cache after Python install

### DIFF
--- a/news/3287.bugfix.rst
+++ b/news/3287.bugfix.rst
@@ -1,0 +1,1 @@
+Clear pythonfinder cache after Python install

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -455,6 +455,11 @@ def ensure_python(three=None, python=None):
                             sp.ok(environments.PIPENV_SPINNER_OK_TEXT.format("Success!"))
                             # Print the results, in a beautiful blue…
                             click.echo(crayons.blue(c.out), err=True)
+                            # Clear the pythonfinder caches
+                            from .vendor.pythonfinder import Finder
+                            finder = Finder(system=False, global_search=True)
+                            finder.find_python_version.cache_clear()
+                            finder.find_all_python_versions.cache_clear()
                     # Find the newly installed Python, hopefully.
                     version = str(version)
                     path_to_python = find_a_system_python(version)


### PR DESCRIPTION
### The issue

After a new Python version was installed by `pyenv` it was never found, because the old Pythons were cached.

### The fix

Bust the cache after installing a new Python.

### The checklist

* [x] Associated issue (fixes #3136 again)
* [x] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.
