### PR TITLE
Fix implementation of `auto_envvar_prefix`

### DIFF
--- a/news/3278.bugfix.rst
+++ b/news/3278.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed an issue which prevented variables from the environment, such as ``PIPENV_DEV`` or ``PIPENV_SYSTEM``, from being parsed and implemented correctly.

--- a/pipenv/__main__.py
+++ b/pipenv/__main__.py
@@ -1,4 +1,4 @@
 from .cli import cli
 
 if __name__ == "__main__":
-    cli(auto_envvar_prefix="PIPENV")
+    cli()

--- a/pipenv/cli/command.py
+++ b/pipenv/cli/command.py
@@ -27,16 +27,20 @@ from .options import (
 # Enable shell completion.
 click_completion.init()
 
+subcommand_context = CONTEXT_SETTINGS.copy()
+subcommand_context.update({
+    "ignore_unknown_options": True,
+    "allow_extra_args": True
+})
+subcommand_context_no_interspersion = subcommand_context.copy()
+subcommand_context_no_interspersion["allow_interspersed_args"] = False
+
 
 @group(cls=PipenvGroup, invoke_without_command=True, context_settings=CONTEXT_SETTINGS)
 @option("--where", is_flag=True, default=False, help="Output project home information.")
 @option("--venv", is_flag=True, default=False, help="Output virtualenv information.")
-@option(
-    "--py", is_flag=True, default=False, help="Output Python interpreter information."
-)
-@option(
-    "--envs", is_flag=True, default=False, help="Output Environment Variable options."
-)
+@option("--py", is_flag=True, default=False, help="Output Python interpreter information.")
+@option("--envs", is_flag=True, default=False, help="Output Environment Variable options.")
 @option("--rm", is_flag=True, default=False, help="Remove the virtualenv.")
 @option("--bare", is_flag=True, default=False, help="Minimal output.")
 @option(
@@ -211,7 +215,7 @@ def cli(
 
 @cli.command(
     short_help="Installs provided packages and adds them to Pipfile, or (if no packages are given), installs all packages from Pipfile.",
-    context_settings=dict(ignore_unknown_options=True, allow_extra_args=True),
+    context_settings=subcommand_context,
 )
 @system_option
 @code_option
@@ -253,7 +257,10 @@ def install(
         ctx.abort()
 
 
-@cli.command(short_help="Un-installs a provided package and removes it from Pipfile.")
+@cli.command(
+    short_help="Un-installs a provided package and removes it from Pipfile.",
+    context_settings=subcommand_context
+)
 @option("--skip-lock/--lock", is_flag=True, default=False, help="Lock afterwards.")
 @option(
     "--all-dev",
@@ -296,7 +303,7 @@ def uninstall(
     if retcode:
         sys.exit(retcode)
 
-@cli.command(short_help="Generates Pipfile.lock.")
+@cli.command(short_help="Generates Pipfile.lock.", context_settings=CONTEXT_SETTINGS)
 @lock_options
 @pass_state
 @pass_context
@@ -328,7 +335,7 @@ def lock(
 
 @cli.command(
     short_help="Spawns a shell within the virtualenv.",
-    context_settings=dict(ignore_unknown_options=True, allow_extra_args=True),
+    context_settings=subcommand_context,
 )
 @option(
     "--fancy",
@@ -387,11 +394,7 @@ def shell(
 @cli.command(
     add_help_option=False,
     short_help="Spawns a command installed into the virtualenv.",
-    context_settings=dict(
-        ignore_unknown_options=True,
-        allow_interspersed_args=False,
-        allow_extra_args=True,
-    ),
+    context_settings=subcommand_context_no_interspersion,
 )
 @common_options
 @argument("command")
@@ -408,7 +411,7 @@ def run(state, command, args):
 
 @cli.command(
     short_help="Checks for security vulnerabilities and against PEP 508 markers provided in Pipfile.",
-    context_settings=dict(ignore_unknown_options=True, allow_extra_args=True),
+    context_settings=subcommand_context
 )
 @option(
     "--unused",
@@ -448,7 +451,7 @@ def check(
     )
 
 
-@cli.command(short_help="Runs lock, then sync.")
+@cli.command(short_help="Runs lock, then sync.", context_settings=CONTEXT_SETTINGS)
 @option("--bare", is_flag=True, default=False, help="Minimal output.")
 @option(
     "--outdated", is_flag=True, default=False, help=u"List out-of-date dependencies."
@@ -525,7 +528,10 @@ def update(
     )
 
 
-@cli.command(short_help=u"Displays currently-installed dependency graph information.")
+@cli.command(
+    short_help=u"Displays currently-installed dependency graph information.",
+    context_settings=CONTEXT_SETTINGS
+)
 @option("--bare", is_flag=True, default=False, help="Minimal output.")
 @option("--json", is_flag=True, default=False, help="Output JSON.")
 @option("--json-tree", is_flag=True, default=False, help="Output JSON in nested tree.")
@@ -537,7 +543,10 @@ def graph(bare=False, json=False, json_tree=False, reverse=False):
     do_graph(bare=bare, json=json, json_tree=json_tree, reverse=reverse)
 
 
-@cli.command(short_help="View a given module in your editor.", name="open")
+@cli.command(
+    short_help="View a given module in your editor.", name="open",
+    context_settings=CONTEXT_SETTINGS
+)
 @common_options
 @argument("module", nargs=1)
 @pass_state
@@ -573,7 +582,10 @@ def run_open(state, module, *args, **kwargs):
     return 0
 
 
-@cli.command(short_help="Installs all packages specified in Pipfile.lock.")
+@cli.command(
+    short_help="Installs all packages specified in Pipfile.lock.",
+    context_settings=CONTEXT_SETTINGS
+)
 @option("--bare", is_flag=True, default=False, help="Minimal output.")
 @sync_options
 @pass_state
@@ -606,7 +618,10 @@ def sync(
         ctx.abort()
 
 
-@cli.command(short_help="Uninstalls all packages not specified in Pipfile.lock.")
+@cli.command(
+    short_help="Uninstalls all packages not specified in Pipfile.lock.",
+    context_settings=CONTEXT_SETTINGS
+)
 @option("--bare", is_flag=True, default=False, help="Minimal output.")
 @option("--dry-run", is_flag=True, default=False, help="Just output unneeded packages.")
 @verbose_option

--- a/pipenv/cli/options.py
+++ b/pipenv/cli/options.py
@@ -12,7 +12,10 @@ from .. import environments
 from ..utils import is_valid_url
 
 
-CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
+CONTEXT_SETTINGS = {
+    "help_option_names": ["-h", "--help"],
+    "auto_envvar_prefix": "PIPENV"
+}
 
 
 class PipenvGroup(Group):
@@ -117,7 +120,7 @@ def sequential_option(f):
         return value
     return option("--sequential", is_flag=True, default=False, expose_value=False,
                   help="Install dependencies one-at-a-time, instead of concurrently.",
-                  callback=callback, type=click.types.BOOL)(f)
+                  callback=callback, type=click.types.BOOL, show_envvar=True)(f)
 
 
 def skip_lock_option(f):
@@ -127,7 +130,8 @@ def skip_lock_option(f):
         return value
     return option("--skip-lock", is_flag=True, default=False, expose_value=False,
                   help=u"Skip locking mechanisms and use the Pipfile instead during operation.",
-                  envvar="PIPENV_SKIP_LOCK", callback=callback, type=click.types.BOOL)(f)
+                  envvar="PIPENV_SKIP_LOCK", callback=callback, type=click.types.BOOL,
+                  show_envvar=True)(f)
 
 
 def keep_outdated_option(f):
@@ -137,7 +141,7 @@ def keep_outdated_option(f):
         return value
     return option("--keep-outdated", is_flag=True, default=False, expose_value=False,
                   help=u"Keep out-dated dependencies from being updated in Pipfile.lock.",
-                  callback=callback, type=click.types.BOOL)(f)
+                  callback=callback, type=click.types.BOOL, show_envvar=True)(f)
 
 
 def selective_upgrade_option(f):
@@ -157,7 +161,7 @@ def ignore_pipfile_option(f):
         return value
     return option("--ignore-pipfile", is_flag=True, default=False, expose_value=False,
                   help="Ignore Pipfile when installing, using the Pipfile.lock.",
-                  callback=callback, type=click.types.BOOL)(f)
+                  callback=callback, type=click.types.BOOL, show_envvar=True)(f)
 
 
 def dev_option(f):
@@ -167,7 +171,7 @@ def dev_option(f):
         return value
     return option("--dev", "-d", is_flag=True, default=False, type=click.types.BOOL,
                   help="Install both develop and default packages.", callback=callback,
-                  expose_value=False)(f)
+                  expose_value=False, show_envvar=True)(f)
 
 
 def pre_option(f):
@@ -238,7 +242,7 @@ def site_packages_option(f):
         return value
     return option("--site-packages", is_flag=True, default=False, type=click.types.BOOL,
                   help="Enable site-packages for the virtualenv.", callback=callback,
-                  expose_value=False)(f)
+                  expose_value=False, show_envvar=True)(f)
 
 
 def clear_option(f):
@@ -248,7 +252,7 @@ def clear_option(f):
         return value
     return option("--clear", is_flag=True, callback=callback, type=click.types.BOOL,
                   help="Clears caches (pipenv, pip, and pip-tools).",
-                  expose_value=False)(f)
+                  expose_value=False, show_envvar=True)(f)
 
 
 def system_option(f):
@@ -258,7 +262,8 @@ def system_option(f):
             state.system = value
         return value
     return option("--system", is_flag=True, default=False, help="System pip management.",
-                  callback=callback, type=click.types.BOOL, expose_value=False)(f)
+                  callback=callback, type=click.types.BOOL, expose_value=False,
+                  show_envvar=True)(f)
 
 
 def requirementstxt_option(f):
@@ -288,7 +293,7 @@ def code_option(f):
             state.installstate.code = value
         return value
     return option("--code", "-c", nargs=1, default=False, help="Import from codebase.",
-                    callback=callback, expose_value=False)(f)
+                  callback=callback, expose_value=False)(f)
 
 
 def deploy_option(f):
@@ -298,7 +303,7 @@ def deploy_option(f):
         return value
     return option("--deploy", is_flag=True, default=False, type=click.types.BOOL,
                   help=u"Abort if the Pipfile.lock is out-of-date, or Python version is"
-                       " wrong.", callback=callback, expose_value=False)(f)
+                  " wrong.", callback=callback, expose_value=False)(f)
 
 
 def setup_verbosity(ctx, param, value):


### PR DESCRIPTION
- Fix implementation of `auto_envvar_prefix`
- Pass context setting directly to each command to prevent
  `PIPENV_<CMD>_<OPTION>` syntax, implementation will use
  `PIPENV_<OPTION>` directly (e.g. `PIPENV_DEV=1` or `PIPENV_SYSTEM=1`
- Fixes #3278
