### PR TITLE
Abort pipenv when pip install fails

### DIFF
--- a/news/3318.bugfix.rst
+++ b/news/3318.bugfix.rst
@@ -1,0 +1,1 @@
+Abort pipenv before adding the non-exist package to Pipfile.

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -1926,6 +1926,8 @@ def do_install(
                         extra_indexes=extra_index_url,
                         pypi_mirror=pypi_mirror,
                     )
+                    if not c.ok:
+                        raise RuntimeError(c.err)
                 except (ValueError, RuntimeError) as e:
                     sp.write_err(vistir.compat.fs_str(
                         "{0}: {1}".format(crayons.red("WARNING"), e),
@@ -1933,6 +1935,7 @@ def do_install(
                     sp.fail(environments.PIPENV_SPINNER_FAIL_TEXT.format(
                         "Installation Failed",
                     ))
+                    sys.exit(1)
                 # Warn if --editable wasn't passed.
                 if pkg_requirement.is_vcs and not pkg_requirement.editable:
                     sp.write_err(

--- a/tests/integration/test_install_basic.py
+++ b/tests/integration/test_install_basic.py
@@ -431,3 +431,11 @@ def test_install_creates_pipfile(PipenvInstance):
         c = p.pipenv("install")
         assert c.return_code == 0
         assert os.path.isfile(p.pipfile_path)
+
+
+@pytest.mark.install
+def test_install_non_exist_dep(PipenvInstance, pypi):
+    with PipenvInstance(pypi=pypi, chdir=True) as p:
+        c = p.pipenv("install dateutil")
+        assert not c.ok
+        assert "dateutil" not in p.pipfile["packages"]


### PR DESCRIPTION
### The fix

Abort pipenv when installing a non-exist package, before adding the package name to Pipfile.
Closes #3318 

### The checklist

* [x] Associated issue
* [x] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

<!--
### If this is a patch to the `vendor` directory…

Please try to refrain from submitting patches directly to `vendor` or `patched`, but raise your issue to the upstream project instead, and inform Pipenv to upgrade when the upstream project accepts the fix.

A pull request to upgrade vendor packages is strongly discouraged, unless there is a very good reason (e.g. you need to test Pipenv’s integration to a new vendor feature). Pipenv audits and performs vendor upgrades regularly, generally before a new release is about to drop.

If your patch is not or cannot be accepted by upstream, but is essential to Pipenv (make sure to discuss this with maintainers!), please remember to attach a patch file in `tasks/vendoring/patched`, so this divergence from upstream can be recorded and replayed afterwards.
-->
