### PR TITLE
Quote arguments with carets for cmd.exe

### DIFF
--- a/news/3307.bugfix.rst
+++ b/news/3307.bugfix.rst
@@ -1,0 +1,1 @@
+Quote command arguments with carets (``^``) on Windows to work around unintended shell escapes.

--- a/tests/unit/test_cmdparse.py
+++ b/tests/unit/test_cmdparse.py
@@ -64,3 +64,12 @@ def test_cmdify_quote_if_paren_in_command():
         '-c',
         "print(123)",
     ]), script
+
+
+@pytest.mark.run
+@pytest.mark.script
+def test_cmdify_quote_if_carets():
+    """Ensure arguments are quoted if they contain carets.
+    """
+    script = Script('foo^bar', ['baz^rex'])
+    assert script.cmdify() == '"foo^bar" "baz^rex"', script


### PR DESCRIPTION
Carets introduce a difficult situation since they are essentially “lossy” when parsed. Consider this in cmd.exe:

    > echo "foo^bar"
    "foo^bar"
    > echo foo^^bar
    foo^bar

The two commands produce different results, but are both parsed by the shell as `foo^bar`, and there's essentially no sensible way to tell what was actually passed in. This implementation assumes the quoted variation (the first) since it is easier to implement, and arguably the more common case.

Fix #3307.

* [x] Associated issue
* [x] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.
