### PR TITLE
Eliminate superfulous parse-cmdify pairs

### DIFF
--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -1416,8 +1416,6 @@ def pip_install(
         pip_config.update(
             {"PIP_SRC": vistir.misc.fs_str(project.virtualenv_src_location)}
         )
-    cmd = Script.parse(pip_command)
-    pip_command = cmd.cmdify()
     c = delegator.run(pip_command, block=block, env=pip_config)
     return c
 

--- a/pipenv/utils.py
+++ b/pipenv/utils.py
@@ -508,7 +508,7 @@ def resolve(cmd, sp):
     from .vendor.vistir.compat import to_native_string
     EOF.__module__ = "pexpect.exceptions"
     from ._compat import decode_output
-    c = delegator.run(Script.parse(cmd).cmdify(), block=False, env=os.environ.copy())
+    c = delegator.run(cmd, block=False, env=os.environ.copy())
     _out = decode_output("")
     result = None
     out = to_native_string("")


### PR DESCRIPTION
`delegator.run()` accepts a list, so there’s no need to convert it back to string. I *believe* this should work fine.
