### PR TITLE
Handle alternate names for UTF-8 encoding

### DIFF
--- a/news/3313.bugfix.rst
+++ b/news/3313.bugfix.rst
@@ -1,0 +1,1 @@
+Handle alternate names for UTF-8 encoding.

--- a/pipenv/_compat.py
+++ b/pipenv/_compat.py
@@ -26,8 +26,8 @@ warnings.filterwarnings("ignore", category=ResourceWarning)
 
 __all__ = [
     "NamedTemporaryFile", "Path", "ResourceWarning", "TemporaryDirectory",
-    "get_terminal_size", "getpreferredencoding", "DEFAULT_ENCODING", "force_encoding",
-    "UNICODE_TO_ASCII_TRANSLATION_MAP", "decode_output", "fix_utf8"
+    "get_terminal_size", "getpreferredencoding", "DEFAULT_ENCODING", "canonical_encoding_name",
+    "force_encoding", "UNICODE_TO_ASCII_TRANSLATION_MAP", "decode_output", "fix_utf8"
 ]
 
 
@@ -46,6 +46,16 @@ def getpreferredencoding():
 DEFAULT_ENCODING = getpreferredencoding()
 
 
+def canonical_encoding_name(name):
+    import codecs
+    try:
+        codec = codecs.lookup(name)
+    except LookupError:
+        return name
+    else:
+        return codec.name
+
+
 # From https://github.com/CarlFK/veyepar/blob/5c5de47/dj/scripts/fixunicode.py
 # MIT LIcensed, thanks Carl!
 def force_encoding():
@@ -57,20 +67,23 @@ def force_encoding():
     else:
         if not (stdout_isatty() and stderr_isatty()):
             return DEFAULT_ENCODING, DEFAULT_ENCODING
-    stdout_encoding = sys.stdout.encoding
-    stderr_encoding = sys.stderr.encoding
+    stdout_encoding = canonical_encoding_name(sys.stdout.encoding)
+    stderr_encoding = canonical_encoding_name(sys.stderr.encoding)
     if sys.platform == "win32" and sys.version_info >= (3, 1):
         return DEFAULT_ENCODING, DEFAULT_ENCODING
-    if stdout_encoding.lower() != "utf-8" or stderr_encoding.lower() != "utf-8":
+    if stdout_encoding != "utf-8" or stderr_encoding != "utf-8":
 
-        from ctypes import pythonapi, py_object, c_char_p
+        try:
+            from ctypes import pythonapi, py_object, c_char_p
+        except ImportError:
+            return DEFAULT_ENCODING, DEFAULT_ENCODING
         try:
             PyFile_SetEncoding = pythonapi.PyFile_SetEncoding
         except AttributeError:
             return DEFAULT_ENCODING, DEFAULT_ENCODING
         else:
             PyFile_SetEncoding.argtypes = (py_object, c_char_p)
-            if stdout_encoding.lower() != "utf-8":
+            if stdout_encoding != "utf-8":
                 try:
                     was_set = PyFile_SetEncoding(sys.stdout, "utf-8")
                 except OSError:
@@ -80,7 +93,7 @@ def force_encoding():
                 else:
                     stdout_encoding = "utf-8"
 
-            if stderr_encoding.lower() != "utf-8":
+            if stderr_encoding != "utf-8":
                 try:
                     was_set = PyFile_SetEncoding(sys.stderr, "utf-8")
                 except OSError:


### PR DESCRIPTION


### The issue

Currently, pipenv does this:
1. In `__init__.py`, `sys.stdout` and `sys.stderr` are replaced by `io.TextIOWrapper`s with `encoding` set to `'utf8'` (no dash): https://github.com/pypa/pipenv/blob/d9ebad335dc4cfff9cb223f7cc3141066044b65b/pipenv/__init__.py#L31-L36
2. In `_compat.py`, the encoding is forced to UTF-8 by checking if `sys.stdout/err.encoding.lower()` is equal to `'utf-8'` (with a dash): https://github.com/pypa/pipenv/blob/d9ebad335dc4cfff9cb223f7cc3141066044b65b/pipenv/_compat.py#L331

Fixes #3313.


### The fix

- Canonicalizes the encoding name using `codecs.lookup()`. This will always return `'utf-8'` for UTF-8 encodings, no matter what alias is used (`'utf8'`, `'UTF-8'`, `'u8'`, etc.)
- Catch `ImportError` when importing `ctypes`, so that this code path doesn't crash with PyPy (which doesn't support ctypes). @frostming mentioned in #3313 that pipenv doesn't officially support PyPy so I can remove this if you'd prefer, but it seems like a net improvement to me.


### The checklist

* [x] Associated issue: #3313
* [x] A news fragment in the `news/` directory: `3313.bugfix.rst`
