### PR TITLE
Fix python path discovery if not called python

### DIFF
--- a/.azure-pipelines/jobs/run-tests-windows.yml
+++ b/.azure-pipelines/jobs/run-tests-windows.yml
@@ -4,6 +4,10 @@ steps:
   inputs:
     versionSpec: '$(python.version)'
     architecture: '$(python.architecture)'
+    addToPath: true
+
+- script: |
+    echo '##vso[task.setvariable variable=PIPENV_DEFAULT_PYTHON_VERSION]$(python.version)'
 
 - template: ../steps/install-dependencies.yml
 

--- a/.azure-pipelines/jobs/run-tests-windows.yml
+++ b/.azure-pipelines/jobs/run-tests-windows.yml
@@ -6,8 +6,10 @@ steps:
     architecture: '$(python.architecture)'
     addToPath: true
 
-- script: |
-    echo '##vso[task.setvariable variable=PIPENV_DEFAULT_PYTHON_VERSION]$(python.version)'
+- powershell: |
+    Write-Host "##vso[task.setvariable variable=PIPENV_DEFAULT_PYTHON_VERSION]$env:PYTHON_VERSION"
+  env:
+    PYTHON_VERSION: $(python.version)
 
 - template: ../steps/install-dependencies.yml
 

--- a/.azure-pipelines/jobs/run-tests.yml
+++ b/.azure-pipelines/jobs/run-tests.yml
@@ -4,23 +4,14 @@ steps:
   inputs:
     versionSpec: '$(python.version)'
     architecture: '$(python.architecture)'
+    addToPath: true
+
+- script: |
+      echo '##vso[task.setvariable variable=PIPENV_DEFAULT_PYTHON_VERSION]$(python.version)'
 
 - template: ../steps/install-dependencies.yml
 
-- bash: |
-    mkdir -p "$AGENT_HOMEDIRECTORY/.virtualenvs"
-    mkdir -p "$WORKON_HOME"
-    pip install certifi
-    export GIT_SSL_CAINFO="$(python -m certifi)"
-    export LANG="C.UTF-8"
-    export PIP_PROCESS_DEPENDENCY_LINKS="1"
-    echo "Path $PATH"
-    echo "Installing Pipenv…"
-    pip install -e "$(pwd)[test]" --upgrade
-    pipenv install --deploy --dev
-    pipenv run pip install -e "$(pwd)[test]" --upgrade
-    echo pipenv --venv && echo pipenv --py && echo pipenv run python --version
-  displayName: Make Virtualenv
+- template: ../steps/create-virtualenv-linux.yml
 
 - script: |
     # Fix Git SSL errors

--- a/.azure-pipelines/steps/create-virtualenv-linux.yml
+++ b/.azure-pipelines/steps/create-virtualenv-linux.yml
@@ -1,0 +1,14 @@
+steps:
+- bash: |
+    mkdir -p "$AGENT_HOMEDIRECTORY/.virtualenvs"
+    mkdir -p "$WORKON_HOME"
+    pip install certifi
+    export GIT_SSL_CAINFO="$(python -m certifi)"
+    export LANG="C.UTF-8"
+    export PIP_PROCESS_DEPENDENCY_LINKS="1"
+    echo "Path $PATH"
+    echo "Installing Pipenv…"
+    pipenv install --deploy --dev
+    pipenv run pip install -e "$(pwd)[test]" --upgrade
+    echo pipenv --venv && echo pipenv --py && echo pipenv run python --version
+  displayName: Make Virtualenv

--- a/.azure-pipelines/steps/create-virtualenv.yml
+++ b/.azure-pipelines/steps/create-virtualenv.yml
@@ -1,6 +1,14 @@
 steps:
+- powershell: |
+    Write-Host "##vso[task.setvariable variable=PY_EXE]"(py -"$PIPENV_DEFAULT_PYTHON_VERSION" -c 'import sys; print(sys.executable)')
+
 - script: |
-    virtualenv D:\.venv
-    D:\.venv\Scripts\pip.exe install -e .[test] && D:\.venv\Scripts\pipenv install --dev && D:\.venv\Scripts\pipenv run pip install -e .[test]
+    echo "Python exe: "$(PY_EXE)
+    virtualenv --python=$(PY_EXE) D:\.venv
+    echo "##vso[task.setvariable variable=VIRTUAL_ENV]"$(PY_EXE)
+    python -m pip install -e .[test] --upgrade
+    D:\.venv\Scripts\pip.exe install -e .[test] --upgrade
+    D:\.venv\Scripts\pipenv install --dev
+    D:\.venv\Scripts\pipenv run pip install -e .[test]
     echo D:\.venv\Scripts\pipenv --venv && echo D:\.venv\Scripts\pipenv --py && echo D:\.venv\Scripts\pipenv run python --version
   displayName: Make Virtualenv

--- a/.azure-pipelines/steps/create-virtualenv.yml
+++ b/.azure-pipelines/steps/create-virtualenv.yml
@@ -1,14 +1,30 @@
 steps:
-- powershell: |
-    Write-Host "##vso[task.setvariable variable=PY_EXE]"(py -"$PIPENV_DEFAULT_PYTHON_VERSION" -c 'import sys; print(sys.executable)')
 
-- script: |
-    echo "Python exe: "$(PY_EXE)
-    virtualenv --python=$(PY_EXE) D:\.venv
-    echo "##vso[task.setvariable variable=VIRTUAL_ENV]"$(PY_EXE)
-    python -m pip install -e .[test] --upgrade
-    D:\.venv\Scripts\pip.exe install -e .[test] --upgrade
-    D:\.venv\Scripts\pipenv install --dev
-    D:\.venv\Scripts\pipenv run pip install -e .[test]
-    echo D:\.venv\Scripts\pipenv --venv && echo D:\.venv\Scripts\pipenv --py && echo D:\.venv\Scripts\pipenv run python --version
+- powershell: |
+    $env:PY_EXE=$(python -c "import sys; print(sys.executable)")
+    if (!$env:PY_EXE) {
+        $env:PY_EXE="python"
+    }
+    Write-Host "##vso[task.setvariable variable=PY_EXE]"$env:PY_EXE
+    Write-Host "Found Python: $env:PY_EXE"
+    Invoke-Expression "$env:PY_EXE -m virtualenv D:\.venv"
+    Write-Host "##vso[task.setvariable variable=VIRTUAL_ENV]D:\.venv"
+    Invoke-Expression "D:\.venv\Scripts\activate.ps1"
+    $env:VIRTUAL_ENV="D:\.venv"
+    Write-Host "Installing local package..."
+    Invoke-Expression "$env:PY_EXE -m pip install -e .[test] --upgrade"
+    Write-Host "upgrading local package in virtual env"
+    $venv_scripts = Join-Path -path D:\.venv -childpath Scripts
+    $venv_py = Join-Path -path $venv_scripts -childpath python.exe
+    Invoke-Expression "$venv_py -m pip install -e .[test] --upgrade"
+    Write-Host "Installing pipenv development packages"
+    Invoke-Expression "$venv_py -m pipenv install --dev"
+    Write-Host "Installing local package in pipenv environment"
+    Invoke-Expression "$venv_py -m pipenv run pip install -e .[test]"
+    Write-Host "Printing metadata"
+    Write-Host $(Invoke-Expression "$venv_py -m pipenv --venv")
+    Write-Host $(Invoke-Expression "$venv_py -m pipenv --py")
+    Write-Host $(Invoke-Expression "$venv_py -m pipenv run python --version")
   displayName: Make Virtualenv
+  env:
+    PIPENV_DEFAULT_PYTHON_VERSION: $(PIPENV_DEFAULT_PYTHON_VERSION)

--- a/.azure-pipelines/steps/install-dependencies.yml
+++ b/.azure-pipelines/steps/install-dependencies.yml
@@ -1,3 +1,3 @@
 steps:
-- script: 'python -m pip install --upgrade pip && python -m pip install -e .[test]'
+- script: 'python -m pip install --upgrade pip setuptools wheel && python -m pip install -e .[test] --upgrade'
   displayName: Upgrade Pip & Install Pipenv

--- a/.gitignore
+++ b/.gitignore
@@ -145,6 +145,10 @@ venv.bak/
 # mypy
 .mypy_cache/
 
+# Temporarily generating these with pytype locally for type safety
+typeshed/
+pytype.cfg
+
 ### Python Patch ###
 .venv/
 

--- a/news/2783.bugfix.rst
+++ b/news/2783.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed an issue which caused errors due to reliance on the system utilities ``which`` and ``where`` which may not always exist on some systems.
+- Fixed a bug which caused periodic failures in python discovery when executables named ``python`` were not present on the target ``$PATH``.

--- a/pipenv/__init__.py
+++ b/pipenv/__init__.py
@@ -26,6 +26,8 @@ warnings.filterwarnings("ignore", category=DependencyWarning)
 warnings.filterwarnings("ignore", category=ResourceWarning)
 warnings.filterwarnings("ignore", category=UserWarning)
 
+
+
 if sys.version_info >= (3, 1) and sys.version_info <= (3, 6):
     if sys.stdout.isatty() and sys.stderr.isatty():
         import io
@@ -45,6 +47,17 @@ try:
         del sys.modules["concurrency"]
 except Exception:
     pass
+
+if sys.version_info >= (3, 0):
+    stdout = sys.stdout.buffer
+    stderr = sys.stderr.buffer
+else:
+    stdout = sys.stdout
+    stderr = sys.stderr
+
+from .vendor.vistir.misc import get_wrapped_stream
+sys.stderr = get_wrapped_stream(stderr)
+sys.stdout = get_wrapped_stream(stdout)
 
 from .cli import cli
 from . import resolver

--- a/pipenv/__init__.py
+++ b/pipenv/__init__.py
@@ -27,18 +27,6 @@ warnings.filterwarnings("ignore", category=ResourceWarning)
 warnings.filterwarnings("ignore", category=UserWarning)
 
 
-
-if sys.version_info >= (3, 1) and sys.version_info <= (3, 6):
-    if sys.stdout.isatty() and sys.stderr.isatty():
-        import io
-        import atexit
-        stdout_wrapper = io.TextIOWrapper(sys.stdout.buffer, encoding='utf8')
-        atexit.register(stdout_wrapper.close)
-        stderr_wrapper = io.TextIOWrapper(sys.stderr.buffer, encoding='utf8')
-        atexit.register(stderr_wrapper.close)
-        sys.stdout = stdout_wrapper
-        sys.stderr = stderr_wrapper
-
 os.environ["PIP_DISABLE_PIP_VERSION_CHECK"] = fs_str("1")
 
 # Hack to make things work better.
@@ -48,6 +36,7 @@ try:
 except Exception:
     pass
 
+from .vendor.vistir.misc import get_wrapped_stream
 if sys.version_info >= (3, 0):
     stdout = sys.stdout.buffer
     stderr = sys.stderr.buffer
@@ -55,9 +44,10 @@ else:
     stdout = sys.stdout
     stderr = sys.stderr
 
-from .vendor.vistir.misc import get_wrapped_stream
+
 sys.stderr = get_wrapped_stream(stderr)
 sys.stdout = get_wrapped_stream(stdout)
+
 
 from .cli import cli
 from . import resolver

--- a/pipenv/cmdparse.py
+++ b/pipenv/cmdparse.py
@@ -10,7 +10,7 @@ class ScriptEmptyError(ValueError):
 
 
 def _quote_if_contains(value, pattern):
-    if next(re.finditer(pattern, value), None):
+    if next(iter(re.finditer(pattern, value)), None):
         return '"{0}"'.format(re.sub(r'(\\*)"', r'\1\1\\"', value))
     return value
 

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -328,8 +328,6 @@ def find_a_system_python(line):
     * Nothing fits, return None.
     """
 
-    if os.path.isabs(line):
-        return line
     from .vendor.pythonfinder import Finder
     finder = Finder(system=False, global_search=True)
     if not line:

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -1441,7 +1441,7 @@ def pip_install(
                 ignore_hashes = True
     else:
         ignore_hashes = True if not requirement.hashes else False
-        install_reqs = requirement.as_line(as_list=True)
+        install_reqs = requirement.as_line(as_list=True, include_hashes=not ignore_hashes)
         if not requirement.markers:
             install_reqs = [escape_cmd(r) for r in install_reqs]
         elif len(install_reqs) > 1:
@@ -2301,6 +2301,12 @@ def do_shell(three=None, python=False, fancy=False, shell_args=None, pypi_mirror
         project.project_directory,
         shell_args,
     )
+    # Only set PIPENV_ACTIVE after finishing reading virtualenv_location
+    # Set an environment variable, so we know we're in the environment.
+    # otherwise its value will be changed
+    os.environ["PIPENV_ACTIVE"] = vistir.misc.fs_str("1")
+
+    os.environ.pop("PIP_SHIMS_BASE_MODULE", None)
 
     if fancy:
         shell.fork(*fork_args)

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -466,6 +466,8 @@ def ensure_virtualenv(three=None, python=None, site_packages=False, pypi_mirror=
             ensure_environment()
             # Ensure Python is available.
             python = ensure_python(three=three, python=python)
+            if python is not None and not isinstance(python, six.string_types):
+                python = python.path.as_posix()
             # Create the virtualenv.
             # Abort if --system (or running in a virtualenv).
             if PIPENV_USE_SYSTEM:
@@ -487,7 +489,9 @@ def ensure_virtualenv(three=None, python=None, site_packages=False, pypi_mirror=
     elif (python) or (three is not None) or (site_packages is not False):
         USING_DEFAULT_PYTHON = False
         # Ensure python is installed before deleting existing virtual env
-        ensure_python(three=three, python=python)
+        python = ensure_python(three=three, python=python)
+        if python is not None and not isinstance(python, six.string_types):
+            python = python.path.as_posix()
 
         click.echo(crayons.red("Virtualenv already exists!"), err=True)
         # If VIRTUAL_ENV is set, there is a possibility that we are

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -923,12 +923,13 @@ def do_create_virtualenv(python=None, site_packages=False, pypi_mirror=None):
         )
         click.echo(crayons.blue("{0}".format(c.out)), err=True)
         if c.returncode != 0:
-            sp.fail(environments.PIPENV_SPINNER_FAIL_TEXT.format("Failed creating virtual environment"))
+            sp.fail(environments.PIPENV_SPINNER_FAIL_TEXT.format(u"Failed creating virtual environment"))
             raise exceptions.VirtualenvCreationException(
                 extra=[crayons.blue("{0}".format(c.err)),]
             )
         else:
-            sp.green.ok(environments.PIPENV_SPINNER_OK_TEXT.format("Successfully created virtual environment!"))
+
+            sp.green.ok(environments.PIPENV_SPINNER_OK_TEXT.format(u"Successfully created virtual environment!"))
 
     # Associate project directory with the environment.
     # This mimics Pew's "setproject".

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -11,7 +11,7 @@ import warnings
 import click
 import six
 import urllib3.util as urllib3_util
-from pipenv.vendor import vistir
+import vistir
 
 import click_completion
 import crayons
@@ -2297,13 +2297,6 @@ def do_shell(three=None, python=False, fancy=False, shell_args=None, pypi_mirror
         project.project_directory,
         shell_args,
     )
-
-    # Set an environment variable, so we know we're in the environment.
-    # Only set PIPENV_ACTIVE after finishing reading virtualenv_location
-    # otherwise its value will be changed
-    os.environ["PIPENV_ACTIVE"] = vistir.misc.fs_str("1")
-
-    os.environ.pop("PIP_SHIMS_BASE_MODULE", None)
 
     if fancy:
         shell.fork(*fork_args)

--- a/pipenv/exceptions.py
+++ b/pipenv/exceptions.py
@@ -33,7 +33,7 @@ def handle_exception(exc_type, exception, traceback, hook=sys.excepthook):
                 line = "      {0}".format(line)
             else:
                 line = "  {0}".format(line)
-            line = "[pipenv.exceptions.{0!s}]: {1}".format(
+            line = "[{0!s}]: {1}".format(
                 exception.__class__.__name__, line
             )
             click_echo(decode_for_output(line), err=True)

--- a/pipenv/utils.py
+++ b/pipenv/utils.py
@@ -1873,7 +1873,7 @@ def find_python(finder, line=None):
         finder = Finder(global_search=True)
     if not line:
         result = next(iter(finder.find_all_python_versions()), None)
-    elif line and line[0].isnumeric() or re.match(r'[\d\.]+', line):
+    elif line and line[0].digit() or re.match(r'[\d\.]+', line):
         result = finder.find_python_version(line)
     else:
         result = finder.find_python_version(name=line)

--- a/pipenv/utils.py
+++ b/pipenv/utils.py
@@ -1860,6 +1860,14 @@ def find_python(finder, line=None):
     :rtype: str
     """
 
+    if line and not isinstance(line, six.string_types):
+        raise TypeError(
+            "Invalid python search type: expected string, received {0!r}".format(line)
+        )
+    if line and os.path.isabs(line):
+        if os.name == "nt":
+            line = posixpath.join(*line.split(os.path.sep))
+        return line
     if not finder:
         from pipenv.vendor.pythonfinder import Finder
         finder = Finder(global_search=True)

--- a/pipenv/utils.py
+++ b/pipenv/utils.py
@@ -119,22 +119,22 @@ def convert_toml_outline_tables(parsed):
     return parsed
 
 
-def run_command(cmd, *args, catch_exceptions=True, **kwargs):
+def run_command(cmd, *args, **kwargs):
     """
     Take an input command and run it, handling exceptions and error codes and returning
     its stdout and stderr.
 
     :param cmd: The list of command and arguments.
     :type cmd: list
-    :param bool catch_exceptions: Whether to catch and raise exceptions on failure
     :returns: A 2-tuple of the output and error from the command
     :rtype: Tuple[str, str]
     :raises: exceptions.PipenvCmdError
     """
 
     from pipenv.vendor import delegator
-    from ._compat import decode_output
+    from ._compat import decode_for_output
     from .cmdparse import Script
+    catch_exceptions = kwargs.pop("catch_exceptions", True)
     if isinstance(cmd, (six.string_types, list, tuple)):
         cmd = Script.parse(cmd)
     if not isinstance(cmd, Script):
@@ -152,7 +152,7 @@ def run_command(cmd, *args, catch_exceptions=True, **kwargs):
     c.block()
     if environments.is_verbose():
         click_echo("Command output: {0}".format(
-            crayons.blue(decode_output(c.out))
+            crayons.blue(decode_for_output(c.out))
         ), err=True)
     if not c.ok and catch_exceptions:
         raise PipenvCmdError(cmd_string, c.out, c.err, c.return_code)
@@ -438,7 +438,7 @@ class Resolver(object):
                         new_constraints = {}
                         _, new_entry = req.pipfile_entry
                         new_lock = {
-                            pep_423_name(new_req.normalized_name): new_entry
+                            pep423_name(new_req.normalized_name): new_entry
                         }
                     else:
                         new_constraints, new_lock = cls.get_deps_from_req(new_req)

--- a/pipenv/utils.py
+++ b/pipenv/utils.py
@@ -141,6 +141,7 @@ def run_command(cmd, *args, **kwargs):
         raise TypeError("Command input must be a string, list or tuple")
     if "env" not in kwargs:
         kwargs["env"] = os.environ.copy()
+    kwargs["env"]["PYTHONIOENCODING"] = "UTF-8"
     try:
         cmd_string = cmd.cmdify()
     except TypeError:
@@ -149,13 +150,13 @@ def run_command(cmd, *args, **kwargs):
     if environments.is_verbose():
         click_echo("Running command: $ {0}".format(cmd_string, err=True))
     c = delegator.run(cmd_string, *args, **kwargs)
-    c.block()
+    return_code = c.return_code
     if environments.is_verbose():
         click_echo("Command output: {0}".format(
             crayons.blue(decode_for_output(c.out))
         ), err=True)
     if not c.ok and catch_exceptions:
-        raise PipenvCmdError(cmd_string, c.out, c.err, c.return_code)
+        raise PipenvCmdError(cmd_string, c.out, c.err, return_code)
     return c
 
 

--- a/pipenv/vendor/vistir/misc.py
+++ b/pipenv/vendor/vistir/misc.py
@@ -590,6 +590,7 @@ def decode_for_output(output, target_stream=None, translation_map=None):
     try:
         output = _encode(output, encoding=encoding, translation_map=translation_map)
     except (UnicodeDecodeError, UnicodeEncodeError):
+        output = to_native_string(output)
         output = _encode(
             output, encoding=encoding, errors="replace", translation_map=translation_map
         )

--- a/pipenv/vendor/vistir/path.py
+++ b/pipenv/vendor/vistir/path.py
@@ -19,6 +19,7 @@ from .compat import (
     Path,
     ResourceWarning,
     TemporaryDirectory,
+    FileNotFoundError,
     _fs_encoding,
     _NamedTemporaryFile,
     finalize,

--- a/pipenv/vendor/vistir/spin.py
+++ b/pipenv/vendor/vistir/spin.py
@@ -147,6 +147,7 @@ class DummySpinner(object):
         else:
             stdout = sys.stdout
         stdout.write(decode_output(u"\r", target_stream=stdout))
+        text = to_text(text)
         line = decode_output(u"{0}\n".format(text), target_stream=stdout)
         stdout.write(line)
         stdout.write(CLEAR_LINE)
@@ -154,6 +155,7 @@ class DummySpinner(object):
     def write_err(self, text=None):
         if text is None or isinstance(text, six.string_types) and text == "None":
             pass
+        text = to_text(text)
         if not self.stderr.closed:
             stderr = self.stderr
         else:

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,7 +2,23 @@
 addopts = -ra -n auto
 testpaths = tests
 ; Add vendor and patched in addition to the default list of ignored dirs
-norecursedirs = .* build dist CVS _darcs {arch} *.egg vendor patched news tasks docs tests/test_artifacts
+; Additionally, ignore tasks, news, test subdirectories and peeps directory
+norecursedirs =
+    .* build
+    dist
+    CVS
+    _darcs
+    {arch}
+    *.egg
+    vendor
+    patched
+    news
+    tasks
+    docs
+    tests/test_artifacts
+    tests/pytest-pypi
+    tests/pypi
+    peeps
 filterwarnings =
     ignore::DeprecationWarning
     ignore::PendingDeprecationWarning

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,7 @@ ignore =
     # E402: module level import not at top of file
     # E501: line too long
     # W503: line break before binary operator
-    E127,E128,E129,E222,E231,E402,E501,W503
+    E402,E501,W503
 
 [isort]
 atomic=true
@@ -29,3 +29,10 @@ known_first_party =
     pipenv
     tests
 ignore_trailing_comma=true
+
+[mypy]
+ignore_missing_imports=true
+follow_imports=skip
+html_report=mypyhtml
+python_version=3.6
+mypy_path=typeshed/pyi:typeshed/imports

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -94,13 +94,13 @@ def pytest_runtest_setup(item):
     ):
         pytest.skip('must use python > 2.7 on windows')
     if item.get_marker('py3_only') is not None and (
-        sys.version_info[:2] < (3, 0)
+        sys.version_info < (3, 0)
     ):
-        pytest.mark.skip('test only runs on python 3')
+        pytest.skip('test only runs on python 3')
     if item.get_marker('lte_py36') is not None and (
-        sys.version_info[:2] >= (3, 7)
+        sys.version_info >= (3, 7)
     ):
-        pytest.mark.skip('test only runs on python < 3.7')
+        pytest.skip('test only runs on python < 3.7')
 
 
 @pytest.fixture

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -85,6 +85,14 @@ def pytest_runtest_setup(item):
         sys.version_info[:2] <= (2, 7) and os.name == "nt"
     ):
         pytest.skip('must use python > 2.7 on windows')
+    if item.get_marker('py3_only') is not None and (
+        sys.version_info[:2] < (3, 0)
+    ):
+        pytest.mark.skip('test only runs on python 3')
+    if item.get_marker('lte_py36') is not None and (
+        sys.version_info[:2] >= (3, 7)
+    ):
+        pytest.mark.skip('test only runs on python < 3.7')
 
 
 @pytest.fixture

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -23,16 +23,24 @@ warnings.simplefilter("default", category=ResourceWarning)
 HAS_WARNED_GITHUB = False
 
 
+def try_internet(url="http://httpbin.org/ip", timeout=1.5):
+    resp = requests.get(url, timeout=timeout)
+    resp.raise_for_status()
+
+
 def check_internet():
-    try:
-        # Kenneth represents the Internet LGTM.
-        resp = requests.get('http://httpbin.org/ip', timeout=1.0)
-        resp.raise_for_status()
-    except Exception:
-        warnings.warn('Cannot connect to HTTPBin...', RuntimeWarning)
-        warnings.warn('Will skip tests requiring Internet', RuntimeWarning)
-        return False
-    return True
+    has_internet = False
+    for url in ("http://httpbin.org/ip", "http://clients3.google.com/generate_204"):
+        try:
+            try_internet(url)
+        except Exception:
+            warnings.warn(
+                "Failed connecting to internet: {0}".format(url), RuntimeWarning
+            )
+        else:
+            has_internet = True
+            break
+    return has_internet
 
 
 def check_github_ssh():

--- a/tests/integration/test_install_basic.py
+++ b/tests/integration/test_install_basic.py
@@ -315,6 +315,7 @@ tablib = "<0.12"
             """.strip()
             f.write(contents)
         c = p.pipenv("install")
+        assert c.ok
         assert "tablib" in p.pipfile["packages"]
         assert "tablib" in p.lockfile["default"]
         assert "six" in p.pipfile["packages"]

--- a/tests/integration/test_install_markers.py
+++ b/tests/integration/test_install_markers.py
@@ -10,10 +10,6 @@ from pipenv.project import Project
 from pipenv.utils import temp_environ
 
 
-py3_only = pytest.mark.skipif(sys.version_info < (3, 0), reason="requires Python3")
-skip_py37 = pytest.mark.skipif(sys.version_info >= (3, 7), reason="Skip for python 3.7")
-
-
 @pytest.mark.markers
 @flaky
 def test_package_environment_markers(PipenvInstance, pypi):
@@ -130,9 +126,9 @@ funcsigs = "*"
 
 @pytest.mark.lock
 @pytest.mark.complex
+@pytest.mark.py3_only
+@pytest.mark.lte_py36
 @flaky
-@py3_only
-@skip_py37
 def test_resolver_unique_markers(PipenvInstance, pypi):
     """vcrpy has a dependency on `yarl` which comes with a marker
     of 'python version in "3.4, 3.5, 3.6" - this marker duplicates itself:

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -238,6 +238,29 @@ class TestUtils:
         os.remove(output)
 
     @pytest.mark.utils
+    @pytest.mark.parametrize('line, expected', [
+        ("python", True),
+        ("python3.7", True),
+        ("python2.7", True),
+        ("python2", True),
+        ("python3", True),
+        ("pypy3", True),
+        ("anaconda3-5.3.0", True),
+        ("which", False),
+        ("vim", False),
+        ("miniconda", True),
+        ("micropython", True),
+        ("ironpython", True),
+        ("jython3.5", True),
+        ("2", True),
+        ("2.7", True),
+        ("3.7", True),
+        ("3", True)
+    ])
+    def test_is_python_command(self, line, expected):
+        assert pipenv.utils.is_python_command(line) == expected
+
+    @pytest.mark.utils
     def test_new_line_end_of_toml_file(this):
         # toml file that needs clean up
         toml = """


### PR DESCRIPTION
Fix python path discovery if not called `python`

- Begin a refactor of `delegator.run` invocation to ensure we capture
  and handle failures with our own exception wrappers
- Additoinally capture output and error logging and command information
  when running in verbose mode (should avoid significant repitition in
  the codebase)
- Refactor `which` and `system_which` to fallback to pythonfinder's
implementation
- Abstract `is_python_command` to identify whether we are looking for
  python, this enables us to rely on `pythonfinder.Finder.find_all_python_versions()`
  to ensure we aren't skipping python versions
- Should be resilient to environments where there is no `which` utility
- Fixes #2783 
- Fixes #3363
- Fixes #3513 
- Fixes #3533