### PR TITLE
Resort imports for pipenv, tasks, tests and docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,6 +18,7 @@
 #
 import os
 
+
 # Path hackery to get current version number.
 here = os.path.abspath(os.path.dirname(__file__))
 

--- a/pipenv/__init__.py
+++ b/pipenv/__init__.py
@@ -10,6 +10,7 @@ import warnings
 
 from .__version__ import __version__
 
+
 PIPENV_ROOT = os.path.abspath(os.path.dirname(os.path.realpath(__file__)))
 PIPENV_VENDOR = os.sep.join([PIPENV_ROOT, "vendor"])
 PIPENV_PATCHED = os.sep.join([PIPENV_ROOT, "patched"])
@@ -20,6 +21,7 @@ sys.path.insert(0, PIPENV_PATCHED)
 
 from pipenv.vendor.urllib3.exceptions import DependencyWarning
 from pipenv.vendor.vistir.compat import ResourceWarning, fs_str
+
 warnings.filterwarnings("ignore", category=DependencyWarning)
 warnings.filterwarnings("ignore", category=ResourceWarning)
 warnings.filterwarnings("ignore", category=UserWarning)

--- a/pipenv/__main__.py
+++ b/pipenv/__main__.py
@@ -1,4 +1,5 @@
 from .cli import cli
 
+
 if __name__ == "__main__":
     cli()

--- a/pipenv/_compat.py
+++ b/pipenv/_compat.py
@@ -9,11 +9,16 @@ import functools
 import importlib
 import io
 import os
-import six
 import sys
 import warnings
+
+import six
 import vistir
-from .vendor.vistir.compat import NamedTemporaryFile, Path, ResourceWarning, TemporaryDirectory
+
+from .vendor.vistir.compat import (
+    NamedTemporaryFile, Path, ResourceWarning, TemporaryDirectory
+)
+
 
 # Backport required for earlier versions of Python.
 if sys.version_info < (3, 3):

--- a/pipenv/cli/__init__.py
+++ b/pipenv/cli/__init__.py
@@ -1,3 +1,4 @@
 # -*- coding=utf-8 -*-
 from __future__ import absolute_import
+
 from .command import cli

--- a/pipenv/cli/command.py
+++ b/pipenv/cli/command.py
@@ -4,23 +4,23 @@ from __future__ import absolute_import
 import os
 import sys
 
-import crayons
-import delegator
-
 from click import (
     argument, echo, edit, group, option, pass_context, secho, version_option
 )
 
 import click_completion
+import crayons
+import delegator
 
 from click_didyoumean import DYMCommandCollection
 
 from ..__version__ import __version__
 from .options import (
     CONTEXT_SETTINGS, PipenvGroup, code_option, common_options, deploy_option,
-    general_options, install_options, lock_options, pass_state, skip_lock_option,
-    pypi_mirror_option, python_option, requirementstxt_option, sync_options,
-    system_option, three_option, verbose_option, uninstall_options
+    general_options, install_options, lock_options, pass_state,
+    pypi_mirror_option, python_option, requirementstxt_option,
+    skip_lock_option, sync_options, system_option, three_option,
+    uninstall_options, verbose_option
 )
 
 

--- a/pipenv/cli/options.py
+++ b/pipenv/cli/options.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import
 import os
 
 import click.types
+
 from click import (
     BadParameter, Group, Option, argument, echo, make_pass_decorator, option
 )

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -1,62 +1,42 @@
 # -*- coding=utf-8 -*-
 
+import json as simplejson
 import logging
 import os
-import sys
 import shutil
+import sys
 import time
-import json as simplejson
+import warnings
+
 import click
+import six
+import urllib3.util as urllib3_util
+import vistir
+
 import click_completion
 import crayons
-import dotenv
 import delegator
+import dotenv
 import pipfile
-import vistir
-import warnings
-import six
 
-import urllib3.util as urllib3_util
-
+from . import environments, exceptions, pep508checker, progress
+from ._compat import fix_utf8
 from .cmdparse import Script
+from .environments import (
+    PIPENV_CACHE_DIR, PIPENV_COLORBLIND, PIPENV_DEFAULT_PYTHON_VERSION,
+    PIPENV_DONT_USE_PYENV, PIPENV_HIDE_EMOJIS, PIPENV_MAX_SUBPROCESS,
+    PIPENV_PYUP_API_KEY, PIPENV_SHELL_FANCY, PIPENV_SKIP_VALIDATION,
+    PIPENV_YES, SESSION_IS_INTERACTIVE
+)
 from .project import Project, SourceNotFound
 from .utils import (
-    convert_deps_to_pip,
-    is_required_version,
-    proper_case,
-    pep423_name,
-    venv_resolve_deps,
-    escape_grouped_arguments,
-    python_version,
-    find_windows_executable,
-    prepare_pip_source_args,
-    is_valid_url,
-    is_pypi_url,
-    create_mirror_source,
-    download_file,
-    is_pinned,
-    is_star,
-    parse_indexes,
-    escape_cmd,
-    create_spinner,
-    get_canonical_names
+    convert_deps_to_pip, create_mirror_source, create_spinner, download_file,
+    escape_cmd, escape_grouped_arguments, find_windows_executable,
+    get_canonical_names, is_pinned, is_pypi_url, is_required_version, is_star,
+    is_valid_url, parse_indexes, pep423_name, prepare_pip_source_args,
+    proper_case, python_version, venv_resolve_deps
 )
-from . import environments, pep508checker, progress
-from .environments import (
-    PIPENV_COLORBLIND,
-    PIPENV_SHELL_FANCY,
-    PIPENV_SKIP_VALIDATION,
-    PIPENV_HIDE_EMOJIS,
-    PIPENV_YES,
-    PIPENV_DEFAULT_PYTHON_VERSION,
-    PIPENV_MAX_SUBPROCESS,
-    PIPENV_DONT_USE_PYENV,
-    SESSION_IS_INTERACTIVE,
-    PIPENV_CACHE_DIR,
-    PIPENV_PYUP_API_KEY,
-)
-from ._compat import fix_utf8
-from . import exceptions
+
 
 # Packages that should be ignored later.
 BAD_PACKAGES = (

--- a/pipenv/environment.py
+++ b/pipenv/environment.py
@@ -3,22 +3,24 @@
 import contextlib
 import importlib
 import json
-import os
-import sys
 import operator
-import pkg_resources
+import os
 import site
-import six
+import sys
 
 from distutils.sysconfig import get_python_lib
 from sysconfig import get_paths
 
-from cached_property import cached_property
-
+import pkg_resources
+import six
 import vistir
+
 import pipenv
 
+from cached_property import cached_property
+
 from .utils import normalize_path
+
 
 BASE_WORKING_SET = pkg_resources.WorkingSet(sys.path)
 

--- a/pipenv/environments.py
+++ b/pipenv/environments.py
@@ -2,9 +2,11 @@
 
 import os
 import sys
+
 from appdirs import user_cache_dir
-from .vendor.vistir.misc import fs_str
+
 from ._compat import fix_utf8
+from .vendor.vistir.misc import fs_str
 
 
 # HACK: avoid resolver.py uses the wrong byte code files.

--- a/pipenv/exceptions.py
+++ b/pipenv/exceptions.py
@@ -3,27 +3,21 @@
 import itertools
 import sys
 
-from traceback import format_exception
 from pprint import pformat
+from traceback import format_exception
 
 import six
 
+from . import environments
 from ._compat import fix_utf8
 from .patched import crayons
-from . import environments
-from .vendor.click.utils import echo as click_echo
 from .vendor.click._compat import get_text_stderr
 from .vendor.click.exceptions import (
-    Abort,
-    BadOptionUsage,
-    BadParameter,
-    ClickException,
-    Exit,
-    FileError,
-    MissingParameter,
-    UsageError,
+    Abort, BadOptionUsage, BadParameter, ClickException, Exit, FileError,
+    MissingParameter, UsageError
 )
 from .vendor.click.types import Path
+from .vendor.click.utils import echo as click_echo
 
 
 def handle_exception(exc_type, exception, traceback, hook=sys.excepthook):

--- a/pipenv/pep508checker.py
+++ b/pipenv/pep508checker.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
-import sys
+import json
 import os
 import platform
-import json
+import sys
 
 
 def format_full_version(info):

--- a/pipenv/progress.py
+++ b/pipenv/progress.py
@@ -12,8 +12,11 @@ from __future__ import absolute_import
 import os
 import sys
 import time
+
 import crayons
+
 from .environments import PIPENV_COLORBLIND, PIPENV_HIDE_EMOJIS
+
 
 STREAM = sys.stderr
 MILL_TEMPLATE = "%s %s %i/%i\r"

--- a/pipenv/project.py
+++ b/pipenv/project.py
@@ -1,53 +1,40 @@
 # -*- coding: utf-8 -*-
+import base64
+import fnmatch
+import glob
+import hashlib
 import io
 import json
+import operator
 import os
 import re
 import sys
-import glob
-import base64
-import fnmatch
-import hashlib
-from first import first
-from cached_property import cached_property
-import operator
-import pipfile
-import pipfile.api
+
 import six
-import vistir
 import toml
 import tomlkit
+import vistir
 
-from .environment import Environment
+from first import first
+
+import pipfile
+import pipfile.api
+
+from cached_property import cached_property
+
 from .cmdparse import Script
-from .utils import (
-    pep423_name,
-    proper_case,
-    find_requirements,
-    is_editable,
-    cleanup_toml,
-    convert_toml_outline_tables,
-    is_installable_file,
-    is_valid_url,
-    get_url_name,
-    normalize_drive,
-    python_version,
-    safe_expandvars,
-    is_star,
-    get_workon_home,
-    is_virtual_environment,
-    looks_like_dir,
-    get_canonical_names
-)
+from .environment import Environment
 from .environments import (
-    PIPENV_MAX_DEPTH,
-    PIPENV_PIPFILE,
-    PIPENV_VENV_IN_PROJECT,
-    PIPENV_TEST_INDEX,
-    PIPENV_PYTHON,
-    PIPENV_DEFAULT_PYTHON_VERSION,
-    PIPENV_IGNORE_VIRTUALENVS,
+    PIPENV_DEFAULT_PYTHON_VERSION, PIPENV_IGNORE_VIRTUALENVS, PIPENV_MAX_DEPTH,
+    PIPENV_PIPFILE, PIPENV_PYTHON, PIPENV_TEST_INDEX, PIPENV_VENV_IN_PROJECT,
     is_in_virtualenv
+)
+from .utils import (
+    cleanup_toml, convert_toml_outline_tables, find_requirements,
+    get_canonical_names, get_url_name, get_workon_home, is_editable,
+    is_installable_file, is_star, is_valid_url, is_virtual_environment,
+    looks_like_dir, normalize_drive, pep423_name, proper_case, python_version,
+    safe_expandvars
 )
 
 

--- a/pipenv/pyenv.py
+++ b/pipenv/pyenv.py
@@ -1,9 +1,8 @@
 import operator
 import re
 
-from .vendor import attr, delegator
-
 from .environments import PIPENV_INSTALL_TIMEOUT
+from .vendor import attr, delegator
 
 
 @attr.s

--- a/pipenv/resolver.py
+++ b/pipenv/resolver.py
@@ -1,7 +1,8 @@
-import os
-import sys
 import json
 import logging
+import os
+import sys
+
 
 os.environ["PIP_PYTHON_PATH"] = str(sys.executable)
 

--- a/pipenv/shells.py
+++ b/pipenv/shells.py
@@ -5,10 +5,10 @@ import signal
 import subprocess
 import sys
 
-from .environments import PIPENV_SHELL_EXPLICIT, PIPENV_SHELL, PIPENV_EMULATOR
-from .vendor.vistir.compat import get_terminal_size, Path
-from .vendor.vistir.contextmanagers import temp_environ
+from .environments import PIPENV_EMULATOR, PIPENV_SHELL, PIPENV_SHELL_EXPLICIT
 from .vendor import shellingham
+from .vendor.vistir.compat import Path, get_terminal_size
+from .vendor.vistir.contextmanagers import temp_environ
 
 
 ShellDetectionFailure = shellingham.ShellDetectionFailure

--- a/pipenv/utils.py
+++ b/pipenv/utils.py
@@ -7,35 +7,39 @@ import re
 import shutil
 import stat
 import sys
-import toml
-import tomlkit
 import warnings
 
-import crayons
-import parse
+from contextlib import contextmanager
+from distutils.spawn import find_executable
+
 import six
+import toml
+import tomlkit
 
 from click import echo as click_echo
 from first import first
+from six.moves import Mapping, Sequence, Set
+from six.moves.urllib.parse import urlparse
+from urllib3 import util as urllib3_util
+from vistir.compat import ResourceWarning
 from vistir.misc import fs_str
+
+import crayons
+import parse
+
+from . import environments
+from .pep508checker import lookup
+
 
 six.add_move(six.MovedAttribute("Mapping", "collections", "collections.abc"))  # noqa
 six.add_move(six.MovedAttribute("Sequence", "collections", "collections.abc"))  # noqa
 six.add_move(six.MovedAttribute("Set", "collections", "collections.abc"))  # noqa
-from six.moves import Mapping, Sequence, Set
 
-from vistir.compat import ResourceWarning
 
 
 logging.basicConfig(level=logging.ERROR)
 
-from distutils.spawn import find_executable
-from contextlib import contextmanager
-from . import environments
-from .pep508checker import lookup
 
-from six.moves.urllib.parse import urlparse
-from urllib3 import util as urllib3_util
 
 
 specifiers = [k for k in lookup.keys()]

--- a/pipenv/utils.py
+++ b/pipenv/utils.py
@@ -18,6 +18,9 @@ import tomlkit
 
 from click import echo as click_echo
 from first import first
+six.add_move(six.MovedAttribute("Mapping", "collections", "collections.abc"))  # noqa
+six.add_move(six.MovedAttribute("Sequence", "collections", "collections.abc"))  # noqa
+six.add_move(six.MovedAttribute("Set", "collections", "collections.abc"))  # noqa
 from six.moves import Mapping, Sequence, Set
 from six.moves.urllib.parse import urlparse
 from urllib3 import util as urllib3_util
@@ -31,16 +34,7 @@ from . import environments
 from .pep508checker import lookup
 
 
-six.add_move(six.MovedAttribute("Mapping", "collections", "collections.abc"))  # noqa
-six.add_move(six.MovedAttribute("Sequence", "collections", "collections.abc"))  # noqa
-six.add_move(six.MovedAttribute("Set", "collections", "collections.abc"))  # noqa
-
-
-
 logging.basicConfig(level=logging.ERROR)
-
-
-
 
 specifiers = [k for k in lookup.keys()]
 # List of version control systems we support.

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -1,14 +1,16 @@
 # -*- coding=utf-8 -*-
-# Copyied from pip's vendoring process
+# Copied from pip's vendoring process
 # see https://github.com/pypa/pip/blob/95bcf8c5f6394298035a7332c441868f3b0169f4/tasks/__init__.py
-import invoke
 import re
 
-from . import vendoring, release
-from .vendoring import vendor_passa
 from pathlib import Path
 
-ROOT = Path(".").parent.parent.absolute()
+import invoke
 
+from . import release, vendoring
+from .vendoring import vendor_passa
+
+
+ROOT = Path(".").parent.parent.absolute()
 
 ns = invoke.Collection(vendoring, release, release.clean_mdchangelog, vendor_passa.vendor_passa)

--- a/tasks/release.py
+++ b/tasks/release.py
@@ -1,7 +1,7 @@
 # -*- coding=utf-8 -*-
 import datetime
-import pathlib
 import os
+import pathlib
 import re
 import sys
 

--- a/tasks/vendoring/__init__.py
+++ b/tasks/vendoring/__init__.py
@@ -1,22 +1,28 @@
 # -*- coding=utf-8 -*-
-""""Vendoring script, python 3.5 needed"""
 # Taken from pip
 # see https://github.com/pypa/pip/blob/95bcf8c5f6394298035a7332c441868f3b0169f4/tasks/vendoring/__init__.py
-from pipenv.vendor.vistir.compat import NamedTemporaryFile, TemporaryDirectory
-from pipenv.vendor.vistir.contextmanagers import open_file
-from pathlib import Path
-from pipenv.utils import mkdir_p
+""""Vendoring script, python 3.5 needed"""
+
 import io
-from urllib3.util import parse_url as urllib3_parse
-import bs4
-# from tempfile import TemporaryDirectory
-import tarfile
-import zipfile
 import re
 import shutil
 import sys
+# from tempfile import TemporaryDirectory
+import tarfile
+import zipfile
+
+from pathlib import Path
+
+import bs4
 import invoke
 import requests
+
+from urllib3.util import parse_url as urllib3_parse
+
+from pipenv.utils import mkdir_p
+from pipenv.vendor.vistir.compat import NamedTemporaryFile, TemporaryDirectory
+from pipenv.vendor.vistir.contextmanagers import open_file
+
 
 TASK_NAME = 'update'
 

--- a/tasks/vendoring/vendor_passa.py
+++ b/tasks/vendoring/vendor_passa.py
@@ -1,6 +1,6 @@
-from pipenv._compat import TemporaryDirectory
 import invoke
 
+from pipenv._compat import TemporaryDirectory
 
 from . import _get_git_root, _get_vendor_dir, log
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -5,16 +5,15 @@ import warnings
 
 import pytest
 
-from pipenv._compat import TemporaryDirectory, Path
-from pipenv.exceptions import VirtualenvActivationException
-from pipenv.utils import temp_environ
-from pipenv.vendor import delegator
-from pipenv.vendor import requests
-from pipenv.vendor import toml
-from pipenv.vendor import tomlkit
-from pytest_pypi.app import prepare_packages as prepare_pypi_packages, prepare_fixtures
 from vistir.compat import ResourceWarning, fs_str
 from vistir.path import mkdir_p
+
+from pipenv._compat import Path, TemporaryDirectory
+from pipenv.exceptions import VirtualenvActivationException
+from pipenv.utils import temp_environ
+from pipenv.vendor import delegator, requests, toml, tomlkit
+from pytest_pypi.app import prepare_fixtures
+from pytest_pypi.app import prepare_packages as prepare_pypi_packages
 
 
 warnings.simplefilter("default", category=ResourceWarning)

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -5,7 +5,9 @@ import os
 import re
 
 import pytest
+
 from flaky import flaky
+
 from pipenv.utils import normalize_drive
 
 

--- a/tests/integration/test_dot_venv.py
+++ b/tests/integration/test_dot_venv.py
@@ -1,11 +1,11 @@
 import os
 
-from pipenv._compat import TemporaryDirectory, Path
-from pipenv.project import Project
-from pipenv.utils import temp_environ, normalize_drive, get_windows_path
-from pipenv.vendor import delegator
-
 import pytest
+
+from pipenv._compat import Path, TemporaryDirectory
+from pipenv.project import Project
+from pipenv.utils import get_windows_path, normalize_drive, temp_environ
+from pipenv.vendor import delegator
 
 
 @pytest.mark.dotvenv

--- a/tests/integration/test_install_basic.py
+++ b/tests/integration/test_install_basic.py
@@ -1,13 +1,13 @@
 import os
 
-from pipenv.utils import temp_environ
-from pipenv._compat import TemporaryDirectory, Path
-from pipenv.vendor import delegator
-from pipenv.project import Project
-
 import pytest
 
 from flaky import flaky
+
+from pipenv._compat import Path, TemporaryDirectory
+from pipenv.project import Project
+from pipenv.utils import temp_environ
+from pipenv.vendor import delegator
 
 
 @pytest.mark.install

--- a/tests/integration/test_install_markers.py
+++ b/tests/integration/test_install_markers.py
@@ -1,13 +1,13 @@
 import os
 import sys
 
-from pipenv.patched import pipfile
-from pipenv.project import Project
-from pipenv.utils import temp_environ
-
 import pytest
 
 from flaky import flaky
+
+from pipenv.patched import pipfile
+from pipenv.project import Project
+from pipenv.utils import temp_environ
 
 
 py3_only = pytest.mark.skipif(sys.version_info < (3, 0), reason="requires Python3")

--- a/tests/integration/test_install_twists.py
+++ b/tests/integration/test_install_twists.py
@@ -1,13 +1,14 @@
 import os
 import shutil
-from pipenv.project import Project
-from pipenv._compat import Path
-from pipenv.vendor import delegator
-from pipenv.utils import mkdir_p, temp_environ
 
 import pytest
 
 from flaky import flaky
+
+from pipenv._compat import Path
+from pipenv.project import Project
+from pipenv.utils import mkdir_p, temp_environ
+from pipenv.vendor import delegator
 
 
 @pytest.mark.extras

--- a/tests/integration/test_install_uri.py
+++ b/tests/integration/test_install_uri.py
@@ -1,7 +1,11 @@
-import pytest
 import os
+
+import pytest
+
 from flaky import flaky
+
 import delegator
+
 from pipenv._compat import Path
 
 

--- a/tests/integration/test_lock.py
+++ b/tests/integration/test_lock.py
@@ -1,10 +1,11 @@
-import pytest
 import os
 import sys
 
-from pipenv.utils import temp_environ
+import pytest
 
 from flaky import flaky
+
+from pipenv.utils import temp_environ
 
 
 @pytest.mark.lock

--- a/tests/integration/test_pipenv.py
+++ b/tests/integration/test_pipenv.py
@@ -4,15 +4,16 @@ XXX: Try our best to reduce tests in this file.
 """
 
 import os
+
 from tempfile import mkdtemp
 
 import mock
 import pytest
 
-from pipenv.utils import temp_environ
-from pipenv.project import Project
-from pipenv.vendor import delegator
 from pipenv._compat import Path
+from pipenv.project import Project
+from pipenv.utils import temp_environ
+from pipenv.vendor import delegator
 
 
 @pytest.mark.code

--- a/tests/integration/test_project.py
+++ b/tests/integration/test_project.py
@@ -1,11 +1,13 @@
 # -*- coding=utf-8 -*-
 import io
-import pytest
 import os
 import tarfile
+
+import pytest
+
+from pipenv.patched import pipfile
 from pipenv.project import Project
 from pipenv.utils import temp_environ
-from pipenv.patched import pipfile
 
 
 @pytest.mark.project

--- a/tests/integration/test_run.py
+++ b/tests/integration/test_run.py
@@ -1,9 +1,9 @@
 import os
 
+import pytest
+
 from pipenv.project import Project
 from pipenv.utils import temp_environ
-
-import pytest
 
 
 @pytest.mark.run

--- a/tests/integration/test_sync.py
+++ b/tests/integration/test_sync.py
@@ -1,8 +1,8 @@
 import os
 
-from pipenv.utils import temp_environ
-
 import pytest
+
+from pipenv.utils import temp_environ
 
 
 @pytest.mark.sync

--- a/tests/integration/test_uninstall.py
+++ b/tests/integration/test_uninstall.py
@@ -1,9 +1,9 @@
 import os
 import shutil
 
-from pipenv.utils import temp_environ
-
 import pytest
+
+from pipenv.utils import temp_environ
 
 
 @pytest.mark.run

--- a/tests/integration/test_windows.py
+++ b/tests/integration/test_windows.py
@@ -1,9 +1,9 @@
 import os
 
-from pipenv.project import Project
-from pipenv._compat import Path
-
 import pytest
+
+from pipenv._compat import Path
+from pipenv.project import Project
 
 
 # This module is run only on Windows.

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -1,10 +1,10 @@
 import os
 
-import pytest
 import mock
+import pytest
 
 from pipenv._compat import TemporaryDirectory
-from pipenv.core import warn_in_virtualenv, load_dot_env
+from pipenv.core import load_dot_env, warn_in_virtualenv
 from pipenv.utils import temp_environ
 
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,8 +1,11 @@
 # -*- coding: utf-8 -*-
 import os
+
 import pytest
-from mock import patch, Mock
+
 from first import first
+from mock import Mock, patch
+
 import pipenv.utils
 import pythonfinder.utils
 


### PR DESCRIPTION
### The issue

Currently in codebase some methods are imported but not used and imports are not in good order. Since we are using ```isort``` in https://github.com/pypa/pipenv/blob/d63ed0537e4dc0b0967e7f9e1116cafd98485e62/Pipfile#L21 and in https://github.com/pypa/pipenv/blob/master/setup.cfg#L22_L31, it will be nice to resort the imports to make our code cleaner and easier to read.

### The fix

This PR resorts the imports for ```pipenv```, ```tasks```, ```tests``` and ```docs``` via ```isort```. The ```vendor``` and ```patched``` are excluded.

### The checklist

* [ ] Associated issue
* [ ] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

<!--
### If this is a patch to the `vendor` directory…

Please try to refrain from submitting patches directly to `vendor` or `patched`, but raise your issue to the upstream project instead, and inform Pipenv to upgrade when the upstream project accepts the fix.

A pull request to upgrade vendor packages is strongly discouraged, unless there is a very good reason (e.g. you need to test Pipenv’s integration to a new vendor feature). Pipenv audits and performs vendor upgrades regularly, generally before a new release is about to drop.

If your patch is not or cannot be accepted by upstream, but is essential to Pipenv (make sure to discuss this with maintainers!), please remember to attach a patch file in `tasks/vendoring/patched`, so this divergence from upstream can be recorded and replayed afterwards.
-->
