### PR TITLE
Enable test disabled in travis

### DIFF
--- a/tests/integration/test_install_basic.py
+++ b/tests/integration/test_install_basic.py
@@ -12,7 +12,6 @@ from flaky import flaky
 
 @pytest.mark.install
 @pytest.mark.setup
-@pytest.mark.skip(reason="this doesn't work on travis")
 def test_basic_setup(PipenvInstance, pypi):
     with PipenvInstance(pypi=pypi) as p:
         with PipenvInstance(pipfile=False) as p:


### PR DESCRIPTION
### The issue

Since we are moving from travis to azure, let's re-enable the test disabled in travis.

### The checklist

* [ ] Associated issue
* [ ] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

<!--
### If this is a patch to the `vendor` directory…

Please try to refrain from submitting patches directly to `vendor` or `patched`, but raise your issue to the upstream project instead, and inform Pipenv to upgrade when the upstream project accepts the fix.

A pull request to upgrade vendor packages is strongly discouraged, unless there is a very good reason (e.g. you need to test Pipenv’s integration to a new vendor feature). Pipenv audits and performs vendor upgrades regularly, generally before a new release is about to drop.

If your patch is not or cannot be accepted by upstream, but is essential to Pipenv (make sure to discuss this with maintainers!), please remember to attach a patch file in `tasks/vendoring/patched`, so this divergence from upstream can be recorded and replayed afterwards.
-->
