### PR TITLE
Remove duplicate skip-lock option

### DIFF
--- a/pipenv/cli/command.py
+++ b/pipenv/cli/command.py
@@ -261,7 +261,6 @@ def install(
     short_help="Un-installs a provided package and removes it from Pipfile.",
     context_settings=subcommand_context
 )
-@option("--skip-lock/--lock", is_flag=True, default=False, help="Lock afterwards.")
 @option(
     "--all-dev",
     is_flag=True,
@@ -280,7 +279,6 @@ def install(
 def uninstall(
     ctx,
     state,
-    skip_lock=False,
     all_dev=False,
     all=False,
     **kwargs


### PR DESCRIPTION
### The issue

This duplicate ```--skip-lock``` is introduced in https://github.com/pypa/pipenv/commit/714ff657ca6d0888b932cdffc6fc768e7c9cb6ca to make sure ```--skip-lock``` is respected. Then it is removed in https://github.com/pypa/pipenv/pull/3112/files for fixing a bug.

With this PR, duplicate skip-lock option is removed. Locking behavior is by default for ```pipenv uninstall```. Locking can be skipped by providing ```--skip-lock``` option.

### The checklist

* [ ] Associated issue
* [ ] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

<!--
### If this is a patch to the `vendor` directory…

Please try to refrain from submitting patches directly to `vendor` or `patched`, but raise your issue to the upstream project instead, and inform Pipenv to upgrade when the upstream project accepts the fix.

A pull request to upgrade vendor packages is strongly discouraged, unless there is a very good reason (e.g. you need to test Pipenv’s integration to a new vendor feature). Pipenv audits and performs vendor upgrades regularly, generally before a new release is about to drop.

If your patch is not or cannot be accepted by upstream, but is essential to Pipenv (make sure to discuss this with maintainers!), please remember to attach a patch file in `tasks/vendoring/patched`, so this divergence from upstream can be recorded and replayed afterwards.
-->
