### PR TITLE
Remove --dev option for uninstall

### DIFF
--- a/pipenv/cli/options.py
+++ b/pipenv/cli/options.py
@@ -342,16 +342,21 @@ def common_options(f):
     return f
 
 
-def install_base_options(f):
+def lock_base_options(f):
     f = common_options(f)
-    f = dev_option(f)
     f = pre_option(f)
     f = keep_outdated_option(f)
     return f
 
 
+def install_base_options(f):
+    f = lock_base_options(f)
+    f = dev_option(f)
+    return f
+
+
 def uninstall_options(f):
-    f = install_base_options(f)
+    f = lock_base_options(f)
     f = skip_lock_option(f)
     f = editable_option(f)
     f = package_arg(f)


### PR DESCRIPTION
### The issue

I think ```pipenv uninstall --dev``` is not working currently. We should either support it or remove it from the CLI.

Discussions are welcomed :)

### The fix

A options group ```lock_base_options``` is introduced, which can also be used in ```lock_options``` instead of current ```install_base_options``` since ```--dev``` is actually also not supported in ```pipenv lock```. But it is another PEEP for that, which I'm going to propose later

### The checklist

* [ ] Associated issue
* [ ] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

<!--
### If this is a patch to the `vendor` directory…

Please try to refrain from submitting patches directly to `vendor` or `patched`, but raise your issue to the upstream project instead, and inform Pipenv to upgrade when the upstream project accepts the fix.

A pull request to upgrade vendor packages is strongly discouraged, unless there is a very good reason (e.g. you need to test Pipenv’s integration to a new vendor feature). Pipenv audits and performs vendor upgrades regularly, generally before a new release is about to drop.

If your patch is not or cannot be accepted by upstream, but is essential to Pipenv (make sure to discuss this with maintainers!), please remember to attach a patch file in `tasks/vendoring/patched`, so this divergence from upstream can be recorded and replayed afterwards.
-->
