### PR TITLE
Move CLI into separate part in docs

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -1,0 +1,8 @@
+.. _cli:
+
+Pipenv CLI Reference
+======================================
+
+.. click:: pipenv:cli
+   :prog: pipenv
+   :show-nested:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -120,6 +120,7 @@ Further Documentation Guides
 
    basics
    advanced
+   cli
    diagnose
 
 Contribution Guides
@@ -130,13 +131,6 @@ Contribution Guides
 
    dev/philosophy
    dev/contributing
-
-☤ Pipenv Usage
---------------
-
-.. click:: pipenv:cli
-   :prog: pipenv
-   :show-nested:
 
 Indices and tables
 ==================

--- a/news/3346.doc.rst
+++ b/news/3346.doc.rst
@@ -1,0 +1,1 @@
+Move CLI docs to its own page.


### PR DESCRIPTION
### The issue

Currently pipenv's doc includes a fully CLI reference in the index. The CLI reference is very long and make page loading slowly.

### The fix

This PR moves the CLI into separate part in docs and add link for it in the index. Check https://pipenv-fork.readthedocs.io/en/latest/index.html and https://pipenv-fork.readthedocs.io/en/latest/cli.html#pipenv for preview! 

![pipenv python dev workflow for humans pipenv 2018 11 27 dev0 documentation](https://user-images.githubusercontent.com/1401630/49339676-14c49e00-f670-11e8-8cb0-706104158807.png)


### The checklist

* [ ] Associated issue
* [ ] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

<!--
### If this is a patch to the `vendor` directory…

Please try to refrain from submitting patches directly to `vendor` or `patched`, but raise your issue to the upstream project instead, and inform Pipenv to upgrade when the upstream project accepts the fix.

A pull request to upgrade vendor packages is strongly discouraged, unless there is a very good reason (e.g. you need to test Pipenv’s integration to a new vendor feature). Pipenv audits and performs vendor upgrades regularly, generally before a new release is about to drop.

If your patch is not or cannot be accepted by upstream, but is essential to Pipenv (make sure to discuss this with maintainers!), please remember to attach a patch file in `tasks/vendoring/patched`, so this divergence from upstream can be recorded and replayed afterwards.
-->
