### PR TITLE
Enable output of script line for 'run' in verbose mode

### DIFF
--- a/news/3348.feature.rst
+++ b/news/3348.feature.rst
@@ -1,0 +1,1 @@
+Added support for ``--verbose`` output to ``pipenv run``.

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -2303,6 +2303,8 @@ def do_run(command, args, three=None, python=False, pypi_mirror=None):
     inline_activate_virtual_environment()
     try:
         script = project.build_script(command, args)
+        cmd_string = ' '.join([script.command] + script.args)
+        logging.getLogger("pip").info("Run: '{0}'".format(cmd_string))
     except ScriptEmptyError:
         click.echo("Can't run script {0!r}-it's empty?", err=True)
     if os.name == "nt":

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -2305,7 +2305,7 @@ def do_run(command, args, three=None, python=False, pypi_mirror=None):
         script = project.build_script(command, args)
         cmd_string = ' '.join([script.command] + script.args)
         if environments.is_verbose():
-            click.echo(crayons.normal("Run: {0}".format(cmd_string)), err=True)
+            click.echo(crayons.normal("$ {0}".format(cmd_string)), err=True)
     except ScriptEmptyError:
         click.echo("Can't run script {0!r}-it's empty?", err=True)
     if os.name == "nt":

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -2304,7 +2304,8 @@ def do_run(command, args, three=None, python=False, pypi_mirror=None):
     try:
         script = project.build_script(command, args)
         cmd_string = ' '.join([script.command] + script.args)
-        logging.getLogger("pip").info("Run: '{0}'".format(cmd_string))
+        if environments.is_verbose():
+            click.echo(crayons.normal("Run: {0}".format(cmd_string)), err=True)
     except ScriptEmptyError:
         click.echo("Can't run script {0!r}-it's empty?", err=True)
     if os.name == "nt":


### PR DESCRIPTION
### The issue

There is no simple way to see the what is the command line that's used for `pipenv run`

### The fix

Output the command line to the log as `info`, so it's output when run in verbose mode.

### The checklist

* [ ] Associated issue
* [x] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

<!--
### If this is a patch to the `vendor` directory…

Please try to refrain from submitting patches directly to `vendor` or `patched`, but raise your issue to the upstream project instead, and inform Pipenv to upgrade when the upstream project accepts the fix.

A pull request to upgrade vendor packages is strongly discouraged, unless there is a very good reason (e.g. you need to test Pipenv’s integration to a new vendor feature). Pipenv audits and performs vendor upgrades regularly, generally before a new release is about to drop.

If your patch is not or cannot be accepted by upstream, but is essential to Pipenv (make sure to discuss this with maintainers!), please remember to attach a patch file in `tasks/vendoring/patched`, so this divergence from upstream can be recorded and replayed afterwards.
-->

Seeking early feedback.