### PR TITLE
Preserve inline spaces in toml

### DIFF
--- a/news/3362.trivial.rst
+++ b/news/3362.trivial.rst
@@ -1,0 +1,1 @@
+The inline tables won't be rewritten now.

--- a/pipenv/utils.py
+++ b/pipenv/utils.py
@@ -99,11 +99,12 @@ def convert_toml_outline_tables(parsed):
                 table.update(value)
                 section[package] = table
 
+    is_tomlkit_parsed = isinstance(parsed, tomlkit.container.Container)
     for section in ("packages", "dev-packages"):
         table_data = parsed.get(section, {})
         if not table_data:
             continue
-        if isinstance(parsed, tomlkit.container.Container):
+        if is_tomlkit_parsed:
             convert_tomlkit_table(table_data)
         else:
             convert_toml_table(table_data)

--- a/pipenv/utils.py
+++ b/pipenv/utils.py
@@ -83,19 +83,31 @@ def cleanup_toml(tml):
 
 def convert_toml_outline_tables(parsed):
     """Converts all outline tables to inline tables."""
-    if isinstance(parsed, tomlkit.container.Container):
-        empty_inline_table = tomlkit.inline_table
-    else:
-        empty_inline_table = toml.TomlDecoder().get_empty_inline_table
+    def convert_tomlkit_table(section):
+        for key, value in section._body:
+            if not key:
+                continue
+            if hasattr(value, "keys") and not isinstance(value, tomlkit.items.InlineTable):
+                table = tomlkit.inline_table()
+                table.update(value.value)
+                section[key.key] = table
+
+    def convert_toml_table(section):
+        for package, value in section.items():
+            if hasattr(value, "keys") and not isinstance(toml.decoder.InlineTableDict):
+                table = toml.TomlDecoder().get_empty_inline_table()
+                table.update(value)
+                section[package] = table
+
     for section in ("packages", "dev-packages"):
         table_data = parsed.get(section, {})
-        for package, value in table_data.items():
-            if hasattr(value, "keys") and not isinstance(
-                value, (tomlkit.items.InlineTable, toml.decoder.InlineTableDict)
-            ):
-                table = empty_inline_table()
-                table.update(value)
-                table_data[package] = table
+        if not table_data:
+            continue
+        if isinstance(parsed, tomlkit.container.Container):
+            convert_tomlkit_table(table_data)
+        else:
+            convert_toml_table(table_data)
+
     return parsed
 
 

--- a/pipenv/utils.py
+++ b/pipenv/utils.py
@@ -94,7 +94,7 @@ def convert_toml_outline_tables(parsed):
 
     def convert_toml_table(section):
         for package, value in section.items():
-            if hasattr(value, "keys") and not isinstance(toml.decoder.InlineTableDict):
+            if hasattr(value, "keys") and not isinstance(value, toml.decoder.InlineTableDict):
                 table = toml.TomlDecoder().get_empty_inline_table()
                 table.update(value)
                 section[package] = table

--- a/tests/integration/test_install_basic.py
+++ b/tests/integration/test_install_basic.py
@@ -446,3 +446,25 @@ def test_install_package_with_dots(PipenvInstance, pypi):
         c = p.pipenv("install backports.html")
         assert c.ok
         assert "backports.html" in p.pipfile["packages"]
+
+
+@pytest.mark.install
+def test_rewrite_outline_table(PipenvInstance, pypi):
+    with PipenvInstance(pypi=pypi, chdir=True) as p:
+        with open(p.pipfile_path, 'w') as f:
+            contents = """
+[packages]
+six = {version = "*", editable = true}
+
+[packages.requests]
+version = "*"
+            """.strip()
+            f.write(contents)
+        c = p.pipenv("install -e click")
+        assert c.return_code == 0
+        with open(p.pipfile_path) as f:
+            contents = f.read()
+        assert "[packages.requests]" not in contents
+        assert 'six = {version = "*", editable = true}' in contents
+        assert 'requests = {version = "*"}' in contents
+        assert 'click = {' in contents

--- a/tests/integration/test_project.py
+++ b/tests/integration/test_project.py
@@ -150,29 +150,6 @@ six = {{version = "*", index = "pypi"}}
 
 @pytest.mark.install
 @pytest.mark.project
-def test_rewrite_outline_table(PipenvInstance, pypi):
-    with PipenvInstance(pypi=pypi, chdir=True) as p:
-        with open(p.pipfile_path, 'w') as f:
-            contents = """
-[packages]
-six = {version = "*", editable = true}
-
-[packages.requests]
-version = "*"
-            """.strip()
-            f.write(contents)
-        c = p.pipenv("install -e click")
-        assert c.return_code == 0
-        with open(p.pipfile_path) as f:
-            contents = f.read()
-        assert "[packages.requests]" not in contents
-        assert 'six = {version = "*", editable = true}' in contents
-        assert 'requests = {version = "*"}' in contents
-        assert 'click = {' in contents
-
-
-@pytest.mark.install
-@pytest.mark.project
 def test_include_editable_packages(PipenvInstance, pypi, testsroot, pathlib_tmpdir):
     file_name = "requests-2.19.1.tar.gz"
     package = pathlib_tmpdir.joinpath("requests-2.19.1")
@@ -190,6 +167,7 @@ def test_include_editable_packages(PipenvInstance, pypi, testsroot, pathlib_tmpd
 
 
 @pytest.mark.project
+@pytest.mark.virtualenv
 def test_run_in_virtualenv(PipenvInstance, pypi, virtualenv):
     with PipenvInstance(chdir=True, pypi=pypi) as p:
         os.environ.pop("PIPENV_IGNORE_VIRTUALENVS", None)

--- a/tests/integration/test_project.py
+++ b/tests/integration/test_project.py
@@ -154,16 +154,21 @@ def test_rewrite_outline_table(PipenvInstance, pypi):
     with PipenvInstance(pypi=pypi, chdir=True) as p:
         with open(p.pipfile_path, 'w') as f:
             contents = """
+[packages]
+six = {version = "*", editable = true}
+
 [packages.requests]
 version = "*"
             """.strip()
             f.write(contents)
-        c = p.pipenv('install click')
+        c = p.pipenv("install -e click")
         assert c.return_code == 0
         with open(p.pipfile_path) as f:
             contents = f.read()
         assert "[packages.requests]" not in contents
+        assert 'six = {version = "*", editable = true}' in contents
         assert 'requests = {version = "*"}' in contents
+        assert 'click = {' in contents
 
 
 @pytest.mark.install


### PR DESCRIPTION
### The issue
In the previous codebase, https://github.com/pypa/pipenv/blob/master/pipenv/utils.py#L94 is always ignored and the table gets rewritten, losing any spaces between inline table keys. The reason behind this is we can't get the real data structure from the `value` here.

### The fix

Get the real data type from `container._body`

### The checklist

* [ ] Associated issue
* [x] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

<!--
### If this is a patch to the `vendor` directory…

Please try to refrain from submitting patches directly to `vendor` or `patched`, but raise your issue to the upstream project instead, and inform Pipenv to upgrade when the upstream project accepts the fix.

A pull request to upgrade vendor packages is strongly discouraged, unless there is a very good reason (e.g. you need to test Pipenv’s integration to a new vendor feature). Pipenv audits and performs vendor upgrades regularly, generally before a new release is about to drop.

If your patch is not or cannot be accepted by upstream, but is essential to Pipenv (make sure to discuss this with maintainers!), please remember to attach a patch file in `tasks/vendoring/patched`, so this divergence from upstream can be recorded and replayed afterwards.
-->
