### PR TITLE
simple bug fix in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ class DebCommand(Command):
 
 
 class UploadCommand(Command):
-    """Support setup.py publish."""
+    """Support setup.py upload."""
 
     description = "Build and publish the package."
     user_options = []


### PR DESCRIPTION
### The issue
Just simple fix typo on `setup.py`. in setup function it specifies 'upload' but in UploadCommand's doc-string it say `support setup.py publish`. I just fixed that.

https://github.com/pypa/pipenv/blob/51b46c9f586de3965e55f3bc182f83470b07c101/setup.py#L71
https://github.com/pypa/pipenv/blob/51b46c9f586de3965e55f3bc182f83470b07c101/setup.py#L152