### PR TITLE
Fix unhashable type error in --selective-upgrade

### DIFF
--- a/news/3384.bugfix.rst
+++ b/news/3384.bugfix.rst
@@ -1,0 +1,1 @@
+Fix unhashable type error during install --selective-upgrade

--- a/news/3384.bugfix.rst
+++ b/news/3384.bugfix.rst
@@ -1,1 +1,1 @@
-Fix unhashable type error during install --selective-upgrade
+Fix unhashable type error during ``$ pipenv install --selective-upgrade``

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -1829,7 +1829,7 @@ def do_install(
                 if not is_star(section[package__name]) and is_star(package__val):
                     # Support for VCS dependencies.
                     package_args[i] = convert_deps_to_pip(
-                        {package.name: section[package__name]}, project=project, r=False
+                        {package__name: section[package__name]}, project=project, r=False
                     )[0]
             except KeyError:
                 pass

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -1829,7 +1829,7 @@ def do_install(
                 if not is_star(section[package__name]) and is_star(package__val):
                     # Support for VCS dependencies.
                     package_args[i] = convert_deps_to_pip(
-                        {packages: section[package__name]}, project=project, r=False
+                        {package.name: section[package__name]}, project=project, r=False
                     )[0]
             except KeyError:
                 pass


### PR DESCRIPTION
### The issue

pipenv install PACKAGE_NAME --selective-upgrade crashes with unhashable type: 'list

```
Traceback (most recent call last):
  File "/usr/local/bin/pipenv", line 11, in <module>
    sys.exit(cli())
  File "/usr/local/lib/python3.7/site-packages/pipenv/vendor/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/pipenv/vendor/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.7/site-packages/pipenv/vendor/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.7/site-packages/pipenv/vendor/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.7/site-packages/pipenv/vendor/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/pipenv/vendor/click/decorators.py", line 64, in new_func
    return ctx.invoke(f, obj, *args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/pipenv/vendor/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/pipenv/vendor/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/pipenv/cli/command.py", line 249, in install
    editable_packages=state.installstate.editables,
  File "/usr/local/lib/python3.7/site-packages/pipenv/core.py", line 1855, in do_install
    {packages: section[package__name]}, project=project, r=False
TypeError: unhashable type: 'list'
```

`packages` variable can not have type list. It looks like we should pass only a package name instead.

### The fix

Get the package name and pass it into the function.