### PR TITLE
Update basics.rst

### DIFF
--- a/docs/basics.rst
+++ b/docs/basics.rst
@@ -363,7 +363,7 @@ You can install packages with pipenv from git and other version control systems 
 
     <vcs_type>+<scheme>://<location>/<user_or_organization>/<repository>@<branch_or_tag>#egg=<package_name>
 
-The only optional section is the ``@<branch_or_tag>`` section.  When using git over SSH, you may use the shorthand vcs and scheme alias ``git+git@<location>:<user_or_organization>/<repository>@<branch_or_tag>#<package_name>``. Note that this is translated to ``git+ssh://git@<location>`` when parsed.
+The only optional section is the ``@<branch_or_tag>`` section.  When using git over SSH, you may use the shorthand vcs and scheme alias ``git+git@<location>/<user_or_organization>/<repository>@<branch_or_tag>#<package_name>``. Note that this is translated to ``git+ssh://git@<location>`` when parsed.
 
 Note that it is **strongly recommended** that you install any version-controlled dependencies in editable mode, using ``pipenv install -e``, in order to ensure that dependency resolution can be performed with an up to date copy of the repository each time it is performed, and that it includes all known dependencies.
 

--- a/news/3415.trivial
+++ b/news/3415.trivial
@@ -1,0 +1,1 @@
+Changed the schema of VCS additions


### PR DESCRIPTION
### The issue

Changed the scheme in VCS 

Thank you for contributing to Pipenv!
### The fix
With a colon instead of a slash cloning of the repository fails. This is due to the failing of git clone when ssh:// is used, a colon is considered the delimiter for the host's port and not the username. Please see https://github.com/pypa/pipenv/issues/3410 for this.


### The checklist

* [x] Associated issue
* [x] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.
