### PR TITLE
Remove Python 2.6 dependencies from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,8 +27,6 @@ required = [
     "setuptools>=36.2.1",
     "virtualenv-clone>=0.2.5",
     "virtualenv",
-    'requests[security];python_version<"2.7"',
-    'ordereddict;python_version<"2.7"',
     'enum34; python_version<"3"',
     'typing; python_version<"3.5"'
 ]


### PR DESCRIPTION
Support for Python 2.6 was removed in (or before) 47604c644bf18bbbb39800833fcf0dd96526f1eb. Therefore, no need to include these dependencies.
