### PR TITLE
Remove typing dep

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,8 +29,7 @@ required = [
     "virtualenv",
     'requests[security];python_version<"2.7"',
     'ordereddict;python_version<"2.7"',
-    'enum34; python_version<"3"',
-    'typing; python_version<"3.5"'
+    'enum34; python_version<"3"'
 ]
 
 


### PR DESCRIPTION
Thank you for contributing to Pipenv!


### The issue

> User installed pipenv under python2.7, with the dependencies of `typing`(which only works under python2.7), then work in a virtualenv of Python 3.4, which doesn't have `typing` module. However, `pipenv lock` will use the virtualenv interpreter(python3.4) to call `resolver.py`, and import the wrong `typing` module(this is expected because the Pipenv interpreter site-packages is also in `PYTHONPATH`).

> With Python >= 3.5, this isn't a problem because the stdlib `typing` module takes priority to Python 2 `typing` module.

### The fix

Remove `typing` dependency because `typing` imports are well guarded in vendors.

Fixes #3387 

### The checklist

* [x] Associated issue
* [ ] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

<!--
### If this is a patch to the `vendor` directory…

Please try to refrain from submitting patches directly to `vendor` or `patched`, but raise your issue to the upstream project instead, and inform Pipenv to upgrade when the upstream project accepts the fix.

A pull request to upgrade vendor packages is strongly discouraged, unless there is a very good reason (e.g. you need to test Pipenv’s integration to a new vendor feature). Pipenv audits and performs vendor upgrades regularly, generally before a new release is about to drop.

If your patch is not or cannot be accepted by upstream, but is essential to Pipenv (make sure to discuss this with maintainers!), please remember to attach a patch file in `tasks/vendoring/patched`, so this divergence from upstream can be recorded and replayed afterwards.
-->
