### PR TITLE
Populate source when getting lockfile

### DIFF
--- a/news/3427.bugfix.rst
+++ b/news/3427.bugfix.rst
@@ -1,0 +1,1 @@
+Fix a bug that ``ValidationError`` is thrown when some fields are missing in source section.

--- a/pipenv/project.py
+++ b/pipenv/project.py
@@ -780,7 +780,7 @@ class Project(object):
         return {
             "hash": {"sha256": self.calculate_pipfile_hash()},
             "pipfile-spec": PIPFILE_SPEC_CURRENT,
-            "sources": sources,
+            "sources": [self.populate_source(s) for s in sources],
             "requires": self.parsed_pipfile.get("requires", {})
         }
 

--- a/tests/integration/test_lock.py
+++ b/tests/integration/test_lock.py
@@ -491,6 +491,7 @@ def test_lockfile_with_empty_dict(PipenvInstance):
 
 
 @pytest.mark.lock
+@pytest.mark.skip_lock
 @pytest.mark.install
 def test_lock_with_incomplete_source(PipenvInstance, pypi):
     with PipenvInstance(pypi=pypi, chdir=True) as p:
@@ -502,6 +503,8 @@ url = "https://test.pypi.org/simple"
 [packages]
 requests = "*"
             """)
+        c = p.pipenv('install --skip-lock')
+        assert c.return_code == 0
         c = p.pipenv('install')
         assert c.return_code == 0
         assert p.lockfile['_meta']['sources']


### PR DESCRIPTION
Thank you for contributing to Pipenv!


### The issue

Fixes #3427 

### The fix

Derive missing fields from existing ones for Pipfile's source.

### The checklist

* [x] Associated issue
* [x] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

<!--
### If this is a patch to the `vendor` directory…

Please try to refrain from submitting patches directly to `vendor` or `patched`, but raise your issue to the upstream project instead, and inform Pipenv to upgrade when the upstream project accepts the fix.

A pull request to upgrade vendor packages is strongly discouraged, unless there is a very good reason (e.g. you need to test Pipenv’s integration to a new vendor feature). Pipenv audits and performs vendor upgrades regularly, generally before a new release is about to drop.

If your patch is not or cannot be accepted by upstream, but is essential to Pipenv (make sure to discuss this with maintainers!), please remember to attach a patch file in `tasks/vendoring/patched`, so this divergence from upstream can be recorded and replayed afterwards.
-->
