### PR TITLE
Update the index names in lock file

### DIFF
--- a/news/3449.bugfix.rst
+++ b/news/3449.bugfix.rst
@@ -1,0 +1,1 @@
+Update the index names in lock file when source name in Pipfile is changed.

--- a/pipenv/project.py
+++ b/pipenv/project.py
@@ -869,7 +869,7 @@ class Project(object):
             source = self.get_source(url=source)
         return source
 
-    def get_source(self, name=None, url=None):
+    def get_source(self, name=None, url=None, pipfile_only=False):
         def find_source(sources, name=None, url=None):
             source = None
             if name:
@@ -879,9 +879,10 @@ class Project(object):
             if source:
                 return first(source)
 
-        found_source = find_source(self.sources, name=name, url=url)
-        if found_source:
-            return found_source
+        if not pipfile_only:
+            found_source = find_source(self.sources, name=name, url=url)
+            if found_source:
+                return found_source
         found_source = find_source(self.pipfile_sources, name=name, url=url)
         if found_source:
             return found_source

--- a/pipenv/project.py
+++ b/pipenv/project.py
@@ -869,7 +869,7 @@ class Project(object):
             source = self.get_source(url=source)
         return source
 
-    def get_source(self, name=None, url=None, pipfile_only=False):
+    def get_source(self, name=None, url=None):
         def find_source(sources, name=None, url=None):
             source = None
             if name:
@@ -879,10 +879,9 @@ class Project(object):
             if source:
                 return first(source)
 
-        if not pipfile_only:
-            found_source = find_source(self.sources, name=name, url=url)
-            if found_source:
-                return found_source
+        found_source = find_source(self.sources, name=name, url=url)
+        if found_source:
+            return found_source
         found_source = find_source(self.pipfile_sources, name=name, url=url)
         if found_source:
             return found_source

--- a/pipenv/utils.py
+++ b/pipenv/utils.py
@@ -236,7 +236,8 @@ def get_resolver_metadata(deps, index_lookup, markers_lookup, project, sources):
         constraints.append(req.constraint_line)
 
         if url:
-            index_lookup[req.name] = project.get_source(url=url).get("name")
+            index_lookup[req.name] = project.get_source(
+                url=url, pipfile_only=True).get("name")
         # strip the marker and re-add it later after resolution
         # but we will need a fallback in case resolution fails
         # eg pypiwin32

--- a/pipenv/utils.py
+++ b/pipenv/utils.py
@@ -234,10 +234,10 @@ def get_resolver_metadata(deps, index_lookup, markers_lookup, project, sources):
         dep = " ".join(remainder)
         req = Requirement.from_line(dep)
         constraints.append(req.constraint_line)
-
         if url:
-            index_lookup[req.name] = project.get_source(
-                url=url, pipfile_only=True).get("name")
+            source = first(s for s in sources if url.startswith(s.get("url")))
+            if source:
+                index_lookup[req.name] = source.get("name")
         # strip the marker and re-add it later after resolution
         # but we will need a fallback in case resolution fails
         # eg pypiwin32
@@ -837,7 +837,7 @@ def convert_deps_to_pip(deps, project=None, r=True, include_index=True):
 
     dependencies = []
     for dep_name, dep in deps.items():
-        indexes = project.sources if hasattr(project, "sources") else []
+        indexes = project.pipfile_sources if hasattr(project, "pipfile_sources") else []
         new_dep = Requirement.from_pipfile(dep_name, dep)
         if new_dep.index:
             include_index = True

--- a/pipenv/utils.py
+++ b/pipenv/utils.py
@@ -235,7 +235,8 @@ def get_resolver_metadata(deps, index_lookup, markers_lookup, project, sources):
         req = Requirement.from_line(dep)
         constraints.append(req.constraint_line)
         if url:
-            source = first(s for s in sources if url.startswith(s.get("url")))
+            source = first(
+                s for s in sources if s.get("url") and url.startswith(s["url"]))
             if source:
                 index_lookup[req.name] = source.get("name")
         # strip the marker and re-add it later after resolution

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -129,7 +129,7 @@ class _Pipfile(object):
     def __init__(self, path):
         self.path = path
         self.document = tomlkit.document()
-        self.document["sources"] = tomlkit.aot()
+        self.document["source"] = tomlkit.aot()
         self.document["requires"] = tomlkit.table()
         self.document["packages"] = tomlkit.table()
         self.document["dev_packages"] = tomlkit.table()
@@ -155,7 +155,7 @@ class _Pipfile(object):
         source_table["url"] = os.environ.get("PIPENV_TEST_INDEX")
         source_table["verify_ssl"] = False
         source_table["name"] = "pipenv_test_index"
-        self.document["sources"].append(source_table)
+        self.document["source"].append(source_table)
         return tomlkit.dumps(self.document)
 
     def write(self):

--- a/tests/integration/test_lock.py
+++ b/tests/integration/test_lock.py
@@ -564,3 +564,27 @@ def test_vcs_lock_respects_top_level_pins(PipenvInstance, pypi):
         assert "git" in p.lockfile["default"]["requests"]
         assert "urllib3" in p.lockfile["default"]
         assert p.lockfile["default"]["urllib3"]["version"] == "==1.21.1"
+
+
+@pytest.mark.lock
+def test_lock_after_update_source_name(PipenvInstance, pypi):
+    with PipenvInstance(pypi=pypi, chdir=True) as p:
+        contents = """
+[[source]]
+url = "https://test.pypi.org/simple"
+verify_ssl = true
+name = "test"
+
+[packages]
+six = "*"
+        """.strip()
+        with open(p.pipfile_path, 'w') as f:
+            f.write(contents)
+        c = p.pipenv("lock")
+        assert c.return_code == 0
+        assert p.lockfile["default"]["six"]["index"] == "test"
+        with open(p.pipfile_path, 'w') as f:
+            f.write(contents.replace('name = "test"', 'name = "custom"'))
+        c = p.pipenv("lock")
+        assert c.return_code == 0
+        assert p.lockfile["default"]["six"]["index"] == "custom"


### PR DESCRIPTION
### The issue

When Pipfile source name is changed and do `pipenv lock` the index names in lock file are not updated correctly

### The fix

Only consider sources in Pipfile when locking, since the sources in lock file are not updated yet.
Fixes #3449 

### The checklist

* [x] Associated issue
* [x] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

<!--
### If this is a patch to the `vendor` directory…

Please try to refrain from submitting patches directly to `vendor` or `patched`, but raise your issue to the upstream project instead, and inform Pipenv to upgrade when the upstream project accepts the fix.

A pull request to upgrade vendor packages is strongly discouraged, unless there is a very good reason (e.g. you need to test Pipenv’s integration to a new vendor feature). Pipenv audits and performs vendor upgrades regularly, generally before a new release is about to drop.

If your patch is not or cannot be accepted by upstream, but is essential to Pipenv (make sure to discuss this with maintainers!), please remember to attach a patch file in `tasks/vendoring/patched`, so this divergence from upstream can be recorded and replayed afterwards.
-->
