### PR TITLE
Correct the options of update command

### DIFF
--- a/pipenv/cli/command.py
+++ b/pipenv/cli/command.py
@@ -454,7 +454,7 @@ def check(
     "--outdated", is_flag=True, default=False, help=u"List out-of-date dependencies."
 )
 @option("--dry-run", is_flag=True, default=None, help=u"List out-of-date dependencies.")
-@install_options
+@sync_options
 @pass_state
 @pass_context
 def update(


### PR DESCRIPTION
Fixes #3461 

Correct the options of `update` command to reduce confusion.