### PR TITLE
conservative check for known exceptions in subprocess stderr.

### DIFF
--- a/news/2553.behavior.rst
+++ b/news/2553.behavior.rst
@@ -1,0 +1,1 @@
+Make conservative checks of known exceptions when subprocess returns output, so user won't see the whole traceback - just the error.

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -925,9 +925,17 @@ def do_create_virtualenv(python=None, site_packages=False, pypi_mirror=None):
         )
         click.echo(crayons.blue("{0}".format(c.out)), err=True)
         if c.returncode != 0:
-            sp.fail(environments.PIPENV_SPINNER_FAIL_TEXT.format(u"Failed creating virtual environment"))
+            sp.fail(environments.PIPENV_SPINNER_FAIL_TEXT.format("Failed creating virtual environment"))
+            known_exceptions = {
+                "PermissionError": "Permission denied:",
+            }
+            # PermissionError - hide the traceback for better UX
+            for partition in (part
+                              for e, part in known_exceptions.items() if e in c.err):
+                known_exceptions_partition = c.err.rpartition(partition)
+                c.err = "{} {}".format(known_exceptions_partition[1], known_exceptions_partition[2])
             raise exceptions.VirtualenvCreationException(
-                extra=[crayons.blue("{0}".format(c.err)),]
+                extra=[crayons.red("{0}".format(c.err)),]
             )
         else:
 

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -926,16 +926,9 @@ def do_create_virtualenv(python=None, site_packages=False, pypi_mirror=None):
         click.echo(crayons.blue("{0}".format(c.out)), err=True)
         if c.returncode != 0:
             sp.fail(environments.PIPENV_SPINNER_FAIL_TEXT.format("Failed creating virtual environment"))
-            known_exceptions = {
-                "PermissionError": "Permission denied:",
-            }
-            # PermissionError - hide the traceback for better UX
-            for partition in (part
-                              for e, part in known_exceptions.items() if e in c.err):
-                known_exceptions_partition = c.err.rpartition(partition)
-                c.err = "{} {}".format(known_exceptions_partition[1], known_exceptions_partition[2])
+            error = c.err if environments.is_verbose() else exceptions.prettify_exc(c.err)
             raise exceptions.VirtualenvCreationException(
-                extra=[crayons.red("{0}".format(c.err)),]
+                extra=[crayons.red("{0}".format(error)),]
             )
         else:
 


### PR DESCRIPTION
Thank you for contributing to Pipenv!


### The issue

#2553 
### The fix

Conservative checks of known exceptions when subprocess returns output.

### The checklist

* [x] Associated issue
* [x] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.