### PR TITLE
Let windows user configure to show emojis

### DIFF
--- a/news/3595.feature.rst
+++ b/news/3595.feature.rst
@@ -1,1 +1,1 @@
-Now Windows users can make emojis shown by setting ``PIPENV_HIDE_EMOJIS=0``.
+Added the ability for Windows users to enable emojis by setting ``PIPENV_HIDE_EMOJIS=0``.

--- a/news/3595.feature.rst
+++ b/news/3595.feature.rst
@@ -1,0 +1,1 @@
+Now Windows users can make emojis shown by setting ``PIPENV_HIDE_EMOJIS=0``.

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -678,7 +678,7 @@ def batch_install(deps_list, procs, failed_deps_queue,
     from .vendor.requirementslib.models.utils import strip_extras_markers_from_requirement
     failed = (not retry)
     if not failed:
-        label = INSTALL_LABEL if os.name != "nt" else ""
+        label = INSTALL_LABEL if not PIPENV_HIDE_EMOJIS else ""
     else:
         label = INSTALL_LABEL2
 

--- a/pipenv/environments.py
+++ b/pipenv/environments.py
@@ -13,6 +13,15 @@ from .vendor.vistir.misc import fs_str
 # I hope I can remove this one day.
 os.environ["PYTHONDONTWRITEBYTECODE"] = fs_str("1")
 
+
+def _is_env_truthy(name):
+    """An environment variable is truthy if it exists and isn't one of (0, false, no, off)
+    """
+    if name not in os.environ:
+        return False
+    return os.environ.get(name).lower() not in ("0", "false", "no", "off")
+
+
 PIPENV_IS_CI = bool("CI" in os.environ or "TF_BUILD" in os.environ)
 
 # HACK: Prevent invalid shebangs with Homebrew-installed Python:
@@ -70,18 +79,15 @@ Default is to detect emulators automatically. This should be set if your
 emulator, e.g. Cmder, cannot be detected correctly.
 """
 
-PIPENV_HIDE_EMOJIS = os.environ.get("PIPENV_HIDE_EMOJIS")
+PIPENV_HIDE_EMOJIS = (
+    os.environ.get("PIPENV_HIDE_EMOJIS") is None
+    and (os.name == "nt" or PIPENV_IS_CI)
+    or _is_env_truthy("PIPENV_HIDE_EMOJIS")
+)
 """Disable emojis in output.
 
 Default is to show emojis. This is automatically set on Windows.
 """
-if (PIPENV_HIDE_EMOJIS is None and (os.name == "nt" or PIPENV_IS_CI)) or (
-    PIPENV_HIDE_EMOJIS is not None
-    and PIPENV_HIDE_EMOJIS.lower() not in ('0', 'false', 'no')
-):
-    PIPENV_HIDE_EMOJIS = True
-else:
-    PIPENV_HIDE_EMOJIS = False
 
 PIPENV_IGNORE_VIRTUALENVS = bool(os.environ.get("PIPENV_IGNORE_VIRTUALENVS"))
 """If set, Pipenv will always assign a virtual environment for this project.

--- a/pipenv/environments.py
+++ b/pipenv/environments.py
@@ -70,13 +70,18 @@ Default is to detect emulators automatically. This should be set if your
 emulator, e.g. Cmder, cannot be detected correctly.
 """
 
-PIPENV_HIDE_EMOJIS = bool(os.environ.get("PIPENV_HIDE_EMOJIS"))
+PIPENV_HIDE_EMOJIS = os.environ.get("PIPENV_HIDE_EMOJIS")
 """Disable emojis in output.
 
 Default is to show emojis. This is automatically set on Windows.
 """
-if os.name == "nt" or PIPENV_IS_CI:
+if (PIPENV_HIDE_EMOJIS is None and (os.name == "nt" or PIPENV_IS_CI)) or (
+    PIPENV_HIDE_EMOJIS is not None
+    and PIPENV_HIDE_EMOJIS.lower() not in ('0', 'false', 'no')
+):
     PIPENV_HIDE_EMOJIS = True
+else:
+    PIPENV_HIDE_EMOJIS = False
 
 PIPENV_IGNORE_VIRTUALENVS = bool(os.environ.get("PIPENV_IGNORE_VIRTUALENVS"))
 """If set, Pipenv will always assign a virtual environment for this project.
@@ -295,9 +300,7 @@ def is_in_virtualenv():
     if not pipenv_active and not ignore_virtualenvs:
         virtual_env = os.environ.get("VIRTUAL_ENV")
         use_system = bool(virtual_env)
-    return (use_system or virtual_env) and not (
-        pipenv_active or ignore_virtualenvs
-    )
+    return (use_system or virtual_env) and not (pipenv_active or ignore_virtualenvs)
 
 
 PIPENV_SPINNER_FAIL_TEXT = fix_utf8(u"✘ {0}") if not PIPENV_HIDE_EMOJIS else ("{0}")

--- a/pipenv/progress.py
+++ b/pipenv/progress.py
@@ -21,25 +21,20 @@ from .environments import PIPENV_COLORBLIND, PIPENV_HIDE_EMOJIS
 STREAM = sys.stderr
 MILL_TEMPLATE = "%s %s %i/%i\r"
 DOTS_CHAR = "."
-if os.name != "nt":
-    if PIPENV_HIDE_EMOJIS:
-        if PIPENV_COLORBLIND:
-            BAR_FILLED_CHAR = "="
-            BAR_EMPTY_CHAR = "-"
-        else:
-            BAR_FILLED_CHAR = str(crayons.green("=", bold=True))
-            BAR_EMPTY_CHAR = str(crayons.black("-"))
+if PIPENV_HIDE_EMOJIS:
+    if PIPENV_COLORBLIND:
+        BAR_FILLED_CHAR = "="
+        BAR_EMPTY_CHAR = "-"
     else:
-        if PIPENV_COLORBLIND:
-            BAR_FILLED_CHAR = "▉"
-            BAR_EMPTY_CHAR = " "
-        else:
-            BAR_FILLED_CHAR = str(crayons.green("▉", bold=True))
-            BAR_EMPTY_CHAR = str(crayons.black("▉"))
-
+        BAR_FILLED_CHAR = str(crayons.green("=", bold=True))
+        BAR_EMPTY_CHAR = str(crayons.black("-"))
 else:
-    BAR_FILLED_CHAR = "="
-    BAR_EMPTY_CHAR = "-"
+    if PIPENV_COLORBLIND:
+        BAR_FILLED_CHAR = "▉"
+        BAR_EMPTY_CHAR = " "
+    else:
+        BAR_FILLED_CHAR = str(crayons.green("▉", bold=True))
+        BAR_EMPTY_CHAR = str(crayons.black("▉"))
 
 if (sys.version_info[0] >= 3) and (os.name != "nt"):
     BAR_TEMPLATE = u"  %s%s%s %i/%i — {0}\r".format(crayons.black("%s"))


### PR DESCRIPTION
### The issue

Windows can't be pleased by the emojis.

### The fix

Keep the behavior that emojis are hidden by default for windows users, but can be enabled by setting `PIPENV_HIDE_EMOJIS=0`

### The checklist

* [ ] Associated issue
* [x] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

<!--
### If this is a patch to the `vendor` directory…

Please try to refrain from submitting patches directly to `vendor` or `patched`, but raise your issue to the upstream project instead, and inform Pipenv to upgrade when the upstream project accepts the fix.

A pull request to upgrade vendor packages is strongly discouraged, unless there is a very good reason (e.g. you need to test Pipenv’s integration to a new vendor feature). Pipenv audits and performs vendor upgrades regularly, generally before a new release is about to drop.

If your patch is not or cannot be accepted by upstream, but is essential to Pipenv (make sure to discuss this with maintainers!), please remember to attach a patch file in `tasks/vendoring/patched`, so this divergence from upstream can be recorded and replayed afterwards.
-->
