### PR TITLE
Ensure resolver doesn't compare editable specifiers

### DIFF
--- a/news/3647.bugfix.rst
+++ b/news/3647.bugfix.rst
@@ -1,0 +1,1 @@
+Pipenv will no longer inadvertently set ``editable=True`` on all vcs dependencies.

--- a/news/3656.bugfix.rst
+++ b/news/3656.bugfix.rst
@@ -1,0 +1,2 @@
+The ``--keep-outdated`` argument to ``pipenv install`` and ``pipenv lock`` will now drop specifier constraints when encountering editable dependencies.
+- In addition, ``--keep-outdated`` will retain specifiers that would otherwise be dropped from any entries that have not been updated.

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -1441,7 +1441,7 @@ def pip_install(
         ignore_hashes = True if not requirement.hashes else ignore_hashes
         line = requirement.as_line(include_hashes=not ignore_hashes)
         line = "{0} {1}".format(line, " ".join(src))
-        if environments.is_verbose()
+        if environments.is_verbose():
             click.echo(
                 "Writing first requirement line to temporary file: {0!r}".format(line),
                 err=True
@@ -1634,7 +1634,6 @@ def system_which(command, mult=False):
             result = fallback_which(command, allow_global=True)
     result = [result] if mult else result
     return result
-
 
 
 def format_help(help):

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -1411,15 +1411,20 @@ def pip_install(
             name = requirement.name
             if requirement.extras:
                 name = "{0}{1}".format(name, requirement.extras_as_pip)
-            line = "-e {0}#egg={1}".format(vistir.path.path_to_url(repo.checkout_directory), requirement.name)
+            line = "{0}{1}#egg={2}".format(
+                line,
+                vistir.path.path_to_url(repo.checkout_directory),
+                requirement.name
+            )
             if repo.subdirectory:
                 line = "{0}&subdirectory={1}".format(line, repo.subdirectory)
         else:
             line = requirement.as_line(**line_kwargs)
-        click.echo(
-            "Writing requirement line to temporary file: {0!r}".format(line),
-            err=True
-        )
+        if environments.is_verbose():
+            click.echo(
+                "Writing requirement line to temporary file: {0!r}".format(line),
+                err=True
+            )
         f.write(vistir.misc.to_bytes(line))
         r = f.name
         f.close()
@@ -1436,10 +1441,11 @@ def pip_install(
         ignore_hashes = True if not requirement.hashes else ignore_hashes
         line = requirement.as_line(include_hashes=not ignore_hashes)
         line = "{0} {1}".format(line, " ".join(src))
-        click.echo(
-            "Writing requirement line to temporary file: {0!r}".format(line),
-            err=True
-        )
+        if environments.is_verbose()
+            click.echo(
+                "Writing first requirement line to temporary file: {0!r}".format(line),
+                err=True
+            )
         f.write(vistir.misc.to_bytes(line))
         r = f.name
         f.close()

--- a/pipenv/patched/piptools/utils.py
+++ b/pipenv/patched/piptools/utils.py
@@ -70,7 +70,7 @@ def clean_requires_python(candidates):
     all_candidates = []
     py_version = parse_version(os.environ.get('PIP_PYTHON_VERSION', '.'.join(map(str, sys.version_info[:3]))))
     for c in candidates:
-        if c.requires_python:
+        if getattr(c, "requires_python", None):
             # Old specifications had people setting this to single digits
             # which is effectively the same as '>=digit,<digit+1'
             if c.requires_python.isdigit():

--- a/pipenv/resolver.py
+++ b/pipenv/resolver.py
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import, print_function
 import json
 import logging
 import os

--- a/pipenv/resolver.py
+++ b/pipenv/resolver.py
@@ -189,7 +189,7 @@ class Entry(object):
         if not markers:
             pass
         marker_str = self.marker_to_str(markers)
-        self._entry = self.entry.merge_markers(self.marker_to_str(markers))
+        self._entry = self.entry.merge_markers(marker_str)
         self._markers = self.marker_to_str(self._entry.markers)
         entry_dict = self.entry_dict.copy()
         entry_dict["markers"] = self.marker_to_str(self._entry.markers)

--- a/pipenv/resolver.py
+++ b/pipenv/resolver.py
@@ -148,11 +148,11 @@ class Entry(object):
         expr_list = []
         expr = expr_iterable.copy()
         if isinstance(expr, Literal) or (
-            expr.__class__.__qualname__ == Literal.__qualname__
+            expr.__class__.__name__ == Literal.__name__
         ):
             keys.append(expr.match)
         elif isinstance(expr, MatchFirst) or (
-            expr.__class__.__qualname__ == MatchFirst.__qualname__
+            expr.__class__.__name__ == MatchFirst.__name__
         ):
             expr_list = expr.exprs
         elif isinstance(expr, list):

--- a/pipenv/utils.py
+++ b/pipenv/utils.py
@@ -30,7 +30,7 @@ import crayons
 import parse
 
 from . import environments
-from .exceptions import PipenvUsageError, ResolutionFailure, RequirementError, PipenvCmdError
+from .exceptions import PipenvUsageError, RequirementError, PipenvCmdError
 from .pep508checker import lookup
 from .vendor.urllib3 import util as urllib3_util
 
@@ -375,7 +375,6 @@ class Resolver(object):
     ):
         # type: (...) -> Tuple[Requirement, Dict[str, str], Dict[str, str]]
         from .vendor.requirementslib.models.requirements import Requirement
-        from .exceptions import ResolutionFailure
         if index_lookup is None:
             index_lookup = {}
         if markers_lookup is None:

--- a/pipenv/vendor/requirementslib/models/markers.py
+++ b/pipenv/vendor/requirementslib/models/markers.py
@@ -1,19 +1,36 @@
 # -*- coding: utf-8 -*-
+import itertools
+import operator
+from collections import defaultdict
+
 import attr
-
+import distlib.markers
+import packaging.version
+import six
 from packaging.markers import InvalidMarker, Marker
+from packaging.specifiers import Specifier, SpecifierSet
+from vistir.compat import Mapping, Set, lru_cache
+from vistir.misc import dedup
 
-from ..exceptions import RequirementError
 from .utils import filter_none, validate_markers
+from ..environment import MYPY_RUNNING
+from ..exceptions import RequirementError
+
+from six.moves import reduce  # isort:skip
+
+
+if MYPY_RUNNING:
+    from typing import Optional
+
+
+MAX_VERSIONS = {2: 7, 3: 10}
 
 
 @attr.s
 class PipenvMarkers(object):
     """System-level requirements - see PEP508 for more detail"""
 
-    os_name = attr.ib(
-        default=None, validator=attr.validators.optional(validate_markers)
-    )
+    os_name = attr.ib(default=None, validator=attr.validators.optional(validate_markers))
     sys_platform = attr.ib(
         default=None, validator=attr.validators.optional(validate_markers)
     )
@@ -92,3 +109,487 @@ class PipenvMarkers(object):
             pass
         else:
             return combined_marker
+
+
+@lru_cache(maxsize=128)
+def _tuplize_version(version):
+    return tuple(int(x) for x in filter(lambda i: i != "*", version.split(".")))
+
+
+@lru_cache(maxsize=128)
+def _format_version(version):
+    return ".".join(str(i) for i in version)
+
+
+# Prefer [x,y) ranges.
+REPLACE_RANGES = {">": ">=", "<=": "<"}
+
+
+@lru_cache(maxsize=128)
+def _format_pyspec(specifier):
+    if isinstance(specifier, str):
+        if not any(op in specifier for op in Specifier._operators.keys()):
+            specifier = "=={0}".format(specifier)
+        specifier = Specifier(specifier)
+    version = specifier.version.replace(".*", "")
+    if ".*" in specifier.version:
+        specifier = Specifier("{0}{1}".format(specifier.operator, version))
+    try:
+        op = REPLACE_RANGES[specifier.operator]
+    except KeyError:
+        return specifier
+    curr_tuple = _tuplize_version(version)
+    try:
+        next_tuple = (curr_tuple[0], curr_tuple[1] + 1)
+    except IndexError:
+        next_tuple = (curr_tuple[0], 1)
+    if not next_tuple[1] <= MAX_VERSIONS[next_tuple[0]]:
+        if specifier.operator == "<" and next_tuple[1] - 1 <= MAX_VERSIONS[next_tuple[0]]:
+            op = "<="
+            next_tuple = (next_tuple[0], next_tuple[1] - 1)
+        else:
+            return specifier
+    specifier = Specifier("{0}{1}".format(op, _format_version(next_tuple)))
+    return specifier
+
+
+@lru_cache(maxsize=128)
+def _get_specs(specset):
+    if specset is None:
+        return
+    if isinstance(specset, Specifier):
+        specset = str(specset)
+    if isinstance(specset, str):
+        specset = SpecifierSet(specset.replace(".*", ""))
+    result = []
+    for spec in set(specset):
+        version = spec.version
+        op = spec.operator
+        if op in ("in", "not in"):
+            versions = version.split(",")
+            op = "==" if op == "in" else "!="
+            for ver in versions:
+                result.append((op, _tuplize_version(ver.strip())))
+        else:
+            result.append((spec.operator, _tuplize_version(spec.version)))
+    return result
+
+
+@lru_cache(maxsize=128)
+def _group_by_op(specs):
+    specs = [_get_specs(x) for x in list(specs)]
+    flattened = [(op, version) for spec in specs for op, version in spec]
+    specs = sorted(flattened)
+    grouping = itertools.groupby(specs, key=operator.itemgetter(0))
+    return grouping
+
+
+@lru_cache(maxsize=128)
+def cleanup_pyspecs(specs, joiner="or"):
+    specs = {_format_pyspec(spec) for spec in specs}
+    # for != operator we want to group by version
+    # if all are consecutive, join as a list
+    results = set()
+    for op, versions in _group_by_op(tuple(specs)):
+        versions = [version[1] for version in versions]
+        versions = sorted(dedup(versions))
+        # if we are doing an or operation, we need to use the min for >=
+        # this way OR(>=2.6, >=2.7, >=3.6) picks >=2.6
+        # if we do an AND operation we need to use MAX to be more selective
+        if op in (">", ">="):
+            if joiner == "or":
+                results.add((op, _format_version(min(versions))))
+            else:
+                results.add((op, _format_version(max(versions))))
+        # we use inverse logic here so we will take the max value if we are
+        # using OR but the min value if we are using AND
+        elif op in ("<=", "<"):
+            if joiner == "or":
+                results.add((op, _format_version(max(versions))))
+            else:
+                results.add((op, _format_version(min(versions))))
+        # leave these the same no matter what operator we use
+        elif op in ("!=", "==", "~="):
+            version_list = sorted(
+                "{0}".format(_format_version(version)) for version in versions
+            )
+            version = ", ".join(version_list)
+            if len(version_list) == 1:
+                results.add((op, version))
+            elif op == "!=":
+                results.add(("not in", version))
+            elif op == "==":
+                results.add(("in", version))
+            else:
+                specifier = SpecifierSet(
+                    ",".join(sorted("{0}".format(op, v) for v in version_list))
+                )._specs
+                for s in specifier:
+                    results &= (specifier._spec[0], specifier._spec[1])
+        else:
+            if len(version) == 1:
+                results.add((op, version))
+            else:
+                specifier = SpecifierSet("{0}".format(version))._specs
+                for s in specifier:
+                    results |= (specifier._spec[0], specifier._spec[1])
+    return results
+
+
+def fix_version_tuple(version_tuple):
+    op, version = version_tuple
+    max_major = max(MAX_VERSIONS.keys())
+    if version[0] > max_major:
+        return (op, (max_major, MAX_VERSIONS[max_major]))
+    max_allowed = MAX_VERSIONS[version[0]]
+    if op == "<" and version[1] > max_allowed and version[1] - 1 <= max_allowed:
+        op = "<="
+        version = (version[0], version[1] - 1)
+    return (op, version)
+
+
+@lru_cache(maxsize=128)
+def get_versions(specset, group_by_operator=True):
+    specs = [_get_specs(x) for x in list(tuple(specset))]
+    initial_sort_key = lambda k: (k[0], k[1])
+    initial_grouping_key = operator.itemgetter(0)
+    if not group_by_operator:
+        initial_grouping_key = operator.itemgetter(1)
+        initial_sort_key = operator.itemgetter(1)
+    version_tuples = sorted(
+        set((op, version) for spec in specs for op, version in spec), key=initial_sort_key
+    )
+    version_tuples = [fix_version_tuple(t) for t in version_tuples]
+    op_groups = [
+        (grp, list(map(operator.itemgetter(1), keys)))
+        for grp, keys in itertools.groupby(version_tuples, key=initial_grouping_key)
+    ]
+    versions = [
+        (op, packaging.version.parse(".".join(str(v) for v in val)))
+        for op, vals in op_groups
+        for val in vals
+    ]
+    return versions
+
+
+def _ensure_marker(marker):
+    if not isinstance(marker, Marker):
+        return Marker(str(marker))
+    return marker
+
+
+def gen_marker(mkr):
+    m = Marker("python_version == '1'")
+    m._markers.pop()
+    m._markers.append(mkr)
+    return m
+
+
+def _strip_extra(elements):
+    """Remove the "extra == ..." operands from the list."""
+
+    return _strip_marker_elem("extra", elements)
+
+
+def _strip_pyversion(elements):
+    return _strip_marker_elem("python_version", elements)
+
+
+def _strip_marker_elem(elem_name, elements):
+    """Remove the supplied element from the marker.
+
+    This is not a comprehensive implementation, but relies on an important
+    characteristic of metadata generation: The element's operand is always
+    associated with an "and" operator. This means that we can simply remove the
+    operand and the "and" operator associated with it.
+    """
+
+    extra_indexes = []
+    preceding_operators = ["and"] if elem_name == "extra" else ["and", "or"]
+    for i, element in enumerate(elements):
+        if isinstance(element, list):
+            cancelled = _strip_marker_elem(elem_name, element)
+            if cancelled:
+                extra_indexes.append(i)
+        elif isinstance(element, tuple) and element[0].value == elem_name:
+            extra_indexes.append(i)
+    for i in reversed(extra_indexes):
+        del elements[i]
+        if i > 0 and elements[i - 1] in preceding_operators:
+            # Remove the "and" before it.
+            del elements[i - 1]
+        elif elements:
+            # This shouldn't ever happen, but is included for completeness.
+            # If there is not an "and" before this element, try to remove the
+            # operator after it.
+            del elements[0]
+    return not elements
+
+
+def _get_stripped_marker(marker, strip_func):
+    """Build a new marker which is cleaned according to `strip_func`"""
+
+    if not marker:
+        return None
+    marker = _ensure_marker(marker)
+    elements = marker._markers
+    strip_func(elements)
+    if elements:
+        return marker
+    return None
+
+
+def get_without_extra(marker):
+    """Build a new marker without the `extra == ...` part.
+
+    The implementation relies very deep into packaging's internals, but I don't
+    have a better way now (except implementing the whole thing myself).
+
+    This could return `None` if the `extra == ...` part is the only one in the
+    input marker.
+    """
+
+    return _get_stripped_marker(marker, _strip_extra)
+
+
+def get_without_pyversion(marker):
+    """Built a new marker without the `python_version` part.
+
+    This could return `None` if the `python_version` section is the only section in the
+    marker.
+    """
+
+    return _get_stripped_marker(marker, _strip_pyversion)
+
+
+def _markers_collect_extras(markers, collection):
+    # Optimization: the marker element is usually appended at the end.
+    for el in reversed(markers):
+        if isinstance(el, tuple) and el[0].value == "extra" and el[1].value == "==":
+            collection.add(el[2].value)
+        elif isinstance(el, list):
+            _markers_collect_extras(el, collection)
+
+
+def _markers_collect_pyversions(markers, collection):
+    local_collection = []
+    marker_format_str = "{0}"
+    for i, el in enumerate(reversed(markers)):
+        if isinstance(el, tuple) and el[0].value == "python_version":
+            new_marker = str(gen_marker(el))
+            local_collection.append(marker_format_str.format(new_marker))
+        elif isinstance(el, six.string_types):
+            local_collection.append(el)
+        elif isinstance(el, list):
+            _markers_collect_pyversions(el, local_collection)
+    if local_collection:
+        local_collection = "{0}".format(" ".join(local_collection))
+        collection.append(local_collection)
+
+
+def _markers_contains_extra(markers):
+    # Optimization: the marker element is usually appended at the end.
+    return _markers_contains_key(markers, "extra")
+
+
+def _markers_contains_pyversion(markers):
+    return _markers_contains_key(markers, "python_version")
+
+
+def _markers_contains_key(markers, key):
+    for element in reversed(markers):
+        if isinstance(element, tuple) and element[0].value == key:
+            return True
+        elif isinstance(element, list):
+            if _markers_contains_key(element, key):
+                return True
+    return False
+
+
+@lru_cache(maxsize=128)
+def get_contained_extras(marker):
+    """Collect "extra == ..." operands from a marker.
+
+    Returns a list of str. Each str is a speficied extra in this marker.
+    """
+    if not marker:
+        return set()
+    extras = set()
+    marker = _ensure_marker(marker)
+    _markers_collect_extras(marker._markers, extras)
+    return extras
+
+
+def get_contained_pyversions(marker):
+    """Collect all `python_version` operands from a marker.
+    """
+
+    collection = []
+    if not marker:
+        return set()
+    marker = _ensure_marker(marker)
+    # Collect the (Variable, Op, Value) tuples and string joiners from the marker
+    _markers_collect_pyversions(marker._markers, collection)
+    marker_str = " ".join(collection)
+    if not marker_str:
+        return set()
+    # Use the distlib dictionary parser to create a dictionary 'trie' which is a bit
+    # easier to reason about
+    marker_dict = distlib.markers.parse_marker(marker_str)[0]
+    version_set = set()
+    pyversions, _ = parse_marker_dict(marker_dict)
+    if isinstance(pyversions, set):
+        version_set.update(pyversions)
+    elif pyversions is not None:
+        version_set.add(pyversions)
+    # Each distinct element in the set was separated by an "and" operator in the marker
+    # So we will need to reduce them with an intersection here rather than a union
+    # in order to find the boundaries
+    versions = set()
+    if version_set:
+        versions = reduce(lambda x, y: x & y, version_set)
+    return versions
+
+
+@lru_cache(maxsize=128)
+def contains_extra(marker):
+    """Check whehter a marker contains an "extra == ..." operand.
+    """
+    if not marker:
+        return False
+    marker = _ensure_marker(marker)
+    return _markers_contains_extra(marker._markers)
+
+
+@lru_cache(maxsize=128)
+def contains_pyversion(marker):
+    """Check whether a marker contains a python_version operand.
+    """
+
+    if not marker:
+        return False
+    marker = _ensure_marker(marker)
+    return _markers_contains_pyversion(marker._markers)
+
+
+def get_specset(marker_list):
+    # type: (List) -> Optional[SpecifierSet]
+    specset = set()
+    _last_str = "and"
+    for marker_parts in marker_list:
+        if isinstance(marker_parts, tuple):
+            variable, op, value = marker_parts
+            if variable.value != "python_version":
+                continue
+            if op.value == "in":
+                values = [v.strip() for v in value.value.split(",")]
+                specset.update(Specifier("=={0}".format(v)) for v in values)
+            elif op.value == "not in":
+                values = [v.strip() for v in value.value.split(",")]
+                bad_versions = ["3.0", "3.1", "3.2", "3.3"]
+                if len(values) >= 2 and any(v in values for v in bad_versions):
+                    values = bad_versions
+                specset.update(
+                    Specifier("!={0}".format(v.strip())) for v in sorted(bad_versions)
+                )
+            else:
+                specset.add(Specifier("{0}{1}".format(op.value, value.value)))
+        elif isinstance(marker_parts, list):
+            specset.update(get_specset(marker_parts))
+        elif isinstance(marker_parts, str):
+            _last_str = marker_parts
+    specifiers = SpecifierSet()
+    specifiers._specs = frozenset(specset)
+    return specifiers
+
+
+def parse_marker_dict(marker_dict):
+    op = marker_dict["op"]
+    lhs = marker_dict["lhs"]
+    rhs = marker_dict["rhs"]
+    # This is where the spec sets for each side land if we have an "or" operator
+    side_spec_list = []
+    side_markers_list = []
+    finalized_marker = ""
+    # And if we hit the end of the parse tree we use this format string to make a marker
+    format_string = "{lhs} {op} {rhs}"
+    specset = SpecifierSet()
+    specs = set()
+    # Essentially we will iterate over each side of the parsed marker if either one is
+    # A mapping instance (i.e. a dictionary) and recursively parse and reduce the specset
+    # Union the "and" specs, intersect the "or"s to find the most appropriate range
+    if any(issubclass(type(side), Mapping) for side in (lhs, rhs)):
+        for side in (lhs, rhs):
+            side_specs = set()
+            side_markers = set()
+            if issubclass(type(side), Mapping):
+                merged_side_specs, merged_side_markers = parse_marker_dict(side)
+                side_specs.update(merged_side_specs)
+                side_markers.update(merged_side_markers)
+            else:
+                marker = _ensure_marker(side)
+                marker_parts = getattr(marker, "_markers", [])
+                if marker_parts[0][0].value == "python_version":
+                    side_specs |= set(get_specset(marker_parts))
+                else:
+                    side_markers.add(str(marker))
+            side_spec_list.append(side_specs)
+            side_markers_list.append(side_markers)
+        if op == "and":
+            # When we are "and"-ing things together, it probably makes the most sense
+            # to reduce them here into a single PySpec instance
+            specs = reduce(lambda x, y: set(x) | set(y), side_spec_list)
+            markers = reduce(lambda x, y: set(x) | set(y), side_markers_list)
+            if not specs and not markers:
+                return specset, finalized_marker
+            if markers and isinstance(markers, (tuple, list, Set)):
+                finalized_marker = Marker(" and ".join([m for m in markers if m]))
+            elif markers:
+                finalized_marker = str(markers)
+            specset._specs = frozenset(specs)
+            return specset, finalized_marker
+        # Actually when we "or" things as well we can also just turn them into a reduced
+        # set using this logic now
+        sides = reduce(lambda x, y: set(x) & set(y), side_spec_list)
+        finalized_marker = " or ".join(side_markers_list)
+        specset._specs = frozenset(sides)
+        return specset, finalized_marker
+    else:
+        # At the tip of the tree we are dealing with strings all around and they just need
+        # to be smashed together
+        specs = set()
+        if lhs == "python_version":
+            format_string = "{lhs}{op}{rhs}"
+            marker = Marker(format_string.format(**marker_dict))
+            marker_parts = getattr(marker, "_markers", [])
+            _set = get_specset(marker_parts)
+            if _set:
+                specs |= set(_set)
+                specset._specs = frozenset(specs)
+        return specset, finalized_marker
+
+
+def format_pyversion(parts):
+    op, val = parts
+    return "python_version {0} '{1}'".format(op, val)
+
+
+def normalize_marker_str(marker):
+    marker_str = ""
+    if not marker:
+        return None
+    if not isinstance(marker, Marker):
+        marker = _ensure_marker(marker)
+    if contains_pyversion(marker):
+        pyversion = get_contained_pyversions(marker)
+        marker = get_without_pyversion(marker)
+        marker_str = ""
+        if pyversion:
+            parts = cleanup_pyspecs(pyversion)
+            marker_str = " and ".join([format_pyversion(pv) for pv in parts])
+        if marker:
+            if marker_str:
+                marker_str = "{0!s} and {1!s}".format(marker_str, marker)
+            else:
+                marker_str = "{0!s}".format(marker)
+    return marker_str

--- a/pipenv/vendor/requirementslib/models/markers.py
+++ b/pipenv/vendor/requirementslib/models/markers.py
@@ -580,16 +580,14 @@ def normalize_marker_str(marker):
         return None
     if not isinstance(marker, Marker):
         marker = _ensure_marker(marker)
-    if contains_pyversion(marker):
-        pyversion = get_contained_pyversions(marker)
-        marker = get_without_pyversion(marker)
-        marker_str = ""
-        if pyversion:
-            parts = cleanup_pyspecs(pyversion)
-            marker_str = " and ".join([format_pyversion(pv) for pv in parts])
-        if marker:
-            if marker_str:
-                marker_str = "{0!s} and {1!s}".format(marker_str, marker)
-            else:
-                marker_str = "{0!s}".format(marker)
-    return marker_str
+    pyversion = get_contained_pyversions(marker)
+    marker = get_without_pyversion(marker)
+    if pyversion:
+        parts = cleanup_pyspecs(pyversion)
+        marker_str = " and ".join([format_pyversion(pv) for pv in parts])
+    if marker:
+        if marker_str:
+            marker_str = "{0!s} and {1!s}".format(marker_str, marker)
+        else:
+            marker_str = "{0!s}".format(marker)
+    return marker_str.replace('"', "'")

--- a/pipenv/vendor/requirementslib/models/markers.py
+++ b/pipenv/vendor/requirementslib/models/markers.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 import itertools
 import operator
-from collections import defaultdict
 
 import attr
 import distlib.markers
@@ -222,17 +221,17 @@ def cleanup_pyspecs(specs, joiner="or"):
                 results.add(("in", version))
             else:
                 specifier = SpecifierSet(
-                    ",".join(sorted("{0}".format(op, v) for v in version_list))
+                    ",".join(sorted("{0}{1}".format(op, v) for v in version_list))
                 )._specs
                 for s in specifier:
-                    results &= (specifier._spec[0], specifier._spec[1])
+                    results.add((s._spec[0], s._spec[1]))
         else:
             if len(version) == 1:
                 results.add((op, version))
             else:
                 specifier = SpecifierSet("{0}".format(version))._specs
                 for s in specifier:
-                    results |= (specifier._spec[0], specifier._spec[1])
+                    results.add((s._spec[0], s._spec[1]))
     return results
 
 
@@ -551,7 +550,9 @@ def parse_marker_dict(marker_dict):
         # Actually when we "or" things as well we can also just turn them into a reduced
         # set using this logic now
         sides = reduce(lambda x, y: set(x) & set(y), side_spec_list)
-        finalized_marker = " or ".join(side_markers_list)
+        finalized_marker = " or ".join(
+            [normalize_marker_str(m) for m in side_markers_list]
+        )
         specset._specs = frozenset(sides)
         return specset, finalized_marker
     else:

--- a/pipenv/vendor/requirementslib/models/markers.py
+++ b/pipenv/vendor/requirementslib/models/markers.py
@@ -377,8 +377,6 @@ def _markers_collect_pyversions(markers, collection):
         if isinstance(el, tuple) and el[0].value == "python_version":
             new_marker = str(gen_marker(el))
             local_collection.append(marker_format_str.format(new_marker))
-        elif isinstance(el, six.string_types):
-            local_collection.append(el)
         elif isinstance(el, list):
             _markers_collect_pyversions(el, local_collection)
     if local_collection:

--- a/pipenv/vendor/requirementslib/models/pipfile.py
+++ b/pipenv/vendor/requirementslib/models/pipfile.py
@@ -7,22 +7,21 @@ import os
 import sys
 
 import attr
-import tomlkit
-
 import plette.models.base
 import plette.pipfiles
-
+import tomlkit
 from vistir.compat import FileNotFoundError, Path
 
-from ..exceptions import RequirementError
-from ..utils import is_editable, is_vcs, merge_items
 from .project import ProjectFile
 from .requirements import Requirement
-from .utils import optional_instance_of, get_url_name
-
+from .utils import get_url_name, optional_instance_of, tomlkit_value_to_python
 from ..environment import MYPY_RUNNING
+from ..exceptions import RequirementError
+from ..utils import is_editable, is_vcs, merge_items
+
 if MYPY_RUNNING:
     from typing import Union, Any, Dict, Iterable, Mapping, List, Text
+
     package_type = Dict[Text, Dict[Text, Union[List[Text], Text]]]
     source_type = Dict[Text, Union[Text, bool]]
     sources_type = Iterable[source_type]
@@ -46,7 +45,7 @@ def patch_plette():
 
     def validate(cls, data):
         # type: (Any, Dict[Text, Any]) -> None
-        if not cerberus:    # Skip validation if Cerberus is not available.
+        if not cerberus:  # Skip validation if Cerberus is not available.
             return
         schema = cls.__SCHEMA__
         key = id(schema)
@@ -156,10 +155,12 @@ class Pipfile(object):
     path = attr.ib(validator=is_path, type=Path)
     projectfile = attr.ib(validator=is_projectfile, type=ProjectFile)
     _pipfile = attr.ib(type=PipfileLoader)
-    _pyproject = attr.ib(default=attr.Factory(tomlkit.document), type=tomlkit.toml_document.TOMLDocument)
+    _pyproject = attr.ib(
+        default=attr.Factory(tomlkit.document), type=tomlkit.toml_document.TOMLDocument
+    )
     build_system = attr.ib(default=attr.Factory(dict), type=dict)
-    requirements = attr.ib(default=attr.Factory(list), type=list)
-    dev_requirements = attr.ib(default=attr.Factory(list), type=list)
+    _requirements = attr.ib(default=attr.Factory(list), type=list)
+    _dev_requirements = attr.ib(default=attr.Factory(list), type=list)
 
     @path.default
     def _get_path(self):
@@ -188,7 +189,9 @@ class Pipfile(object):
             deps.update(self.pipfile._data["dev-packages"])
             if only:
                 return deps
-        return merge_items([deps, self.pipfile._data["packages"]])
+        return tomlkit_value_to_python(
+            merge_items([deps, self.pipfile._data["packages"]])
+        )
 
     def get(self, k):
         # type: (Text) -> Any
@@ -213,6 +216,7 @@ class Pipfile(object):
             if "-" in k:
                 section, _, pkg_type = k.rpartition("-")
                 vals = getattr(pipfile.get(section, {}), "_data", {})
+                vals = tomlkit_value_to_python(vals)
                 if pkg_type == "vcs":
                     retval = {k: v for k, v in vals.items() if is_vcs(v)}
                 elif pkg_type == "editable":
@@ -254,11 +258,7 @@ class Pipfile(object):
         :return: A project file with the model and location for interaction
         :rtype: :class:`~requirementslib.models.project.ProjectFile`
         """
-        pf = ProjectFile.read(
-            path,
-            PipfileLoader,
-            invalid_ok=True
-        )
+        pf = ProjectFile.read(path, PipfileLoader, invalid_ok=True)
         return pf
 
     @classmethod
@@ -303,18 +303,10 @@ class Pipfile(object):
 
         projectfile = cls.load_projectfile(path, create=create)
         pipfile = projectfile.model
-        dev_requirements = [
-            Requirement.from_pipfile(k, getattr(v, "_data", v)) for k, v in pipfile.get("dev-packages", {}).items()
-        ]
-        requirements = [
-            Requirement.from_pipfile(k, getattr(v, "_data", v)) for k, v in pipfile.get("packages", {}).items()
-        ]
         creation_args = {
             "projectfile": projectfile,
             "pipfile": pipfile,
-            "dev_requirements": dev_requirements,
-            "requirements": requirements,
-            "path": Path(projectfile.location)
+            "path": Path(projectfile.location),
         }
         return cls(**creation_args)
 
@@ -332,6 +324,30 @@ class Pipfile(object):
     def packages(self):
         # type: () -> List[Requirement]
         return self.requirements
+
+    @property
+    def dev_requirements(self):
+        # type: () -> List[Requirement]
+        if not self._dev_requirements:
+            packages = tomlkit_value_to_python(self.pipfile.get("dev-packages", {}))
+            self._dev_requirements = [
+                Requirement.from_pipfile(k, v)
+                for k, v in packages.items()
+                if v is not None
+            ]
+        return self._dev_requirements
+
+    @property
+    def requirements(self):
+        # type: () -> List[Requirement]
+        if not self._requirements:
+            packages = tomlkit_value_to_python(self.pipfile.get("packages", {}))
+            self._requirements = [
+                Requirement.from_pipfile(k, v)
+                for k, v in packages.items()
+                if v is not None
+            ]
+        return self._requirements
 
     def _read_pyproject(self):
         # type: () -> None

--- a/pipenv/vendor/requirementslib/models/requirements.py
+++ b/pipenv/vendor/requirementslib/models/requirements.py
@@ -45,7 +45,6 @@ from .markers import (
     contains_pyversion,
     format_pyversion,
     get_contained_pyversions,
-    get_without_pyversion,
     normalize_marker_str,
 )
 from .setup_info import SetupInfo, _prepare_wheel_building_kwargs
@@ -3260,7 +3259,7 @@ class Requirement(object):
         if getattr(line, "_requirement", None) is not None:
             line._requirement.marker = new_marker
         if getattr(line, "_ireq", None) is not None and line._ireq.req:
-            line._ireq.req.marker
+            line._ireq.req.marker = new_marker
         new_ireq = getattr(self, "ireq", None)
         if new_ireq and new_ireq.req:
             new_ireq.req.marker = new_marker

--- a/tasks/vendoring/patches/patched/piptools.patch
+++ b/tasks/vendoring/patches/patched/piptools.patch
@@ -607,7 +607,7 @@ index 9b4b4c2..8875543 100644
 +    all_candidates = []
 +    py_version = parse_version(os.environ.get('PIP_PYTHON_VERSION', '.'.join(map(str, sys.version_info[:3]))))
 +    for c in candidates:
-+        if c.requires_python:
++        if getattr(c, "requires_python", None):
 +            # Old specifications had people setting this to single digits
 +            # which is effectively the same as '>=digit,<digit+1'
 +            if c.requires_python.isdigit():

--- a/tests/integration/test_lock.py
+++ b/tests/integration/test_lock.py
@@ -1,3 +1,4 @@
+json
 import os
 import sys
 
@@ -120,6 +121,21 @@ def test_keep_outdated_doesnt_upgrade_pipfile_pins(PipenvInstance, pypi):
         assert "urllib3" in p.lockfile["default"]
         assert p.lockfile["default"]["requests"]["version"] == "==2.18.4"
         assert p.lockfile["default"]["urllib3"]["version"] == "==1.21.1"
+
+
+def test_keep_outdated_keeps_markers_not_removed(PipenvInstance, pypi):
+    with PipenvInstance(chdir=True, pypi=pypi) as p:
+        c = p.pipenv("install tablib")
+        assert c.ok
+        lockfile = Path(p.lockfile_location)
+        lockfile_content = lockfile.read_text()
+        lockfile_json = json.loads(lockfile_content)
+        assert "tablib" in lockfile_json["default"]
+        lockfile_json["default"]["tablib"]["markers"] = "python_version >= '2.7'"
+        lockfile.write_text(json.dumps(lockfile_json))
+        c = p.pipenv("lock")
+        assert c.ok
+        assert p.lockfile["default"]["tablib"].get("markers", "") = "python_version >= '2.7'"
 
 
 @pytest.mark.lock

--- a/tests/integration/test_lock.py
+++ b/tests/integration/test_lock.py
@@ -135,7 +135,7 @@ def test_keep_outdated_keeps_markers_not_removed(PipenvInstance, pypi):
         assert "tablib" in lockfile_json["default"]
         lockfile_json["default"]["tablib"]["markers"] = "python_version >= '2.7'"
         lockfile.write_text(json.dumps(lockfile_json))
-        c = p.pipenv("lock")
+        c = p.pipenv("lock --keep-outdated")
         assert c.ok
         assert p.lockfile["default"]["tablib"].get("markers", "") == "python_version >= '2.7'"
 

--- a/tests/integration/test_lock.py
+++ b/tests/integration/test_lock.py
@@ -8,6 +8,7 @@ import pytest
 
 from flaky import flaky
 from vistir.compat import Path
+from vistir.misc import to_text
 from pipenv.utils import temp_environ
 
 
@@ -134,7 +135,7 @@ def test_keep_outdated_keeps_markers_not_removed(PipenvInstance, pypi):
         lockfile_json = json.loads(lockfile_content)
         assert "tablib" in lockfile_json["default"]
         lockfile_json["default"]["tablib"]["markers"] = "python_version >= '2.7'"
-        lockfile.write_text(json.dumps(lockfile_json))
+        lockfile.write_text(to_text(json.dumps(lockfile_json)))
         c = p.pipenv("lock --keep-outdated")
         assert c.ok
         assert p.lockfile["default"]["tablib"].get("markers", "") == "python_version >= '2.7'"

--- a/tests/integration/test_lock.py
+++ b/tests/integration/test_lock.py
@@ -1,4 +1,6 @@
-json
+# -*- coding: utf-8 -*-
+
+import json
 import os
 import sys
 

--- a/tests/integration/test_lock.py
+++ b/tests/integration/test_lock.py
@@ -135,7 +135,7 @@ def test_keep_outdated_keeps_markers_not_removed(PipenvInstance, pypi):
         lockfile.write_text(json.dumps(lockfile_json))
         c = p.pipenv("lock")
         assert c.ok
-        assert p.lockfile["default"]["tablib"].get("markers", "") = "python_version >= '2.7'"
+        assert p.lockfile["default"]["tablib"].get("markers", "") == "python_version >= '2.7'"
 
 
 @pytest.mark.lock

--- a/tests/integration/test_lock.py
+++ b/tests/integration/test_lock.py
@@ -129,7 +129,7 @@ def test_keep_outdated_keeps_markers_not_removed(PipenvInstance, pypi):
     with PipenvInstance(chdir=True, pypi=pypi) as p:
         c = p.pipenv("install tablib")
         assert c.ok
-        lockfile = Path(p.lockfile_location)
+        lockfile = Path(p.lockfile_path)
         lockfile_content = lockfile.read_text()
         lockfile_json = json.loads(lockfile_content)
         assert "tablib" in lockfile_json["default"]


### PR DESCRIPTION
- Don't compare versions of editable dependencies when updating using
  `--keep-outdated` -- editable dependencies will now be updated to
  the latest version
- Ensure we don't drop markers from the lockfile when versions are not
  updated
- Fixes #3656
- Fixes #3659

Signed-off-by: Dan Ryan <dan@danryan.co>
