### PR TITLE
* Replace to getdefaultlocale because there is no getdefaultencoding

### DIFF
--- a/pipenv/vendor/vistir/misc.py
+++ b/pipenv/vendor/vistir/misc.py
@@ -514,7 +514,7 @@ def chunked(n, iterable):
 
 
 try:
-    locale_encoding = locale.getdefaultencoding()[1] or "ascii"
+    locale_encoding = locale.getdefaultlocale()[1] or "ascii"
 except Exception:
     locale_encoding = "ascii"
 


### PR DESCRIPTION
### The issue

According to the existing code, locale_encoding of 302 line is fixed as ascii, and it does not follow system encoding value.
It can be a bug in an area that uses encoding in other languages ​​not English.

### The fix

replace locale.getdefaultlocale with locale.getdefaultencoding because locale.getdefaultencoding is not exist
