### PR TITLE
[doc website] Add a nice search experience

### DIFF
--- a/docs/_templates/sidebarintro.html
+++ b/docs/_templates/sidebarintro.html
@@ -8,12 +8,32 @@
   <iframe src="https://ghbtns.com/github-btn.html?user=pypa&repo=pipenv&type=watch&count=true&size=large"
     allowtransparency="true" frameborder="0" scrolling="0" width="200px" height="35px"></iframe>
 </p>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" />
+<style>
+.algolia-autocomplete{
+  width: 100%;
+  height: 1.5em
+}
+.algolia-autocomplete a{
+  border-bottom: none !important;
+}
+#doc_search{
+  width: 100%;
+  height: 100%;
+}
+</style>
+<input id="doc_search" placeholder="Search the doc" autofocus/>
+<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js" onload="docsearch({
+  apiKey: '0dbb76467f0c180a1344fc46858df17b',
+  indexName: 'pipenv',
+  inputSelector: '#doc_search',
+  debug: false // Set debug to true if you want to inspect the dropdown
+})" async></script>
 
 <p>
   <strong>Pipenv</strong> is a production-ready tool that aims to bring the best of all packaging worlds to the Python world. It harnesses Pipfile, pip, and virtualenv into one single command.
   <p>It features very pretty terminal colors.</p>
 </p>
-
 <h3>Stay Informed</h3>
 <p>Receive updates on new releases and upcoming projects.</p>
 

--- a/docs/_templates/sidebarlogo.html
+++ b/docs/_templates/sidebarlogo.html
@@ -8,6 +8,27 @@
   <iframe src="https://ghbtns.com/github-btn.html?user=pypa&repo=pipenv&type=watch&count=true&size=large"
     allowtransparency="true" frameborder="0" scrolling="0" width="200px" height="35px"></iframe>
 </p>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css" />
+<style>
+  .algolia-autocomplete{
+    width: 100%;
+    height: 1.5em
+  }
+  .algolia-autocomplete a{
+    border-bottom: none !important;
+  }
+  #doc_search{
+    width: 100%;
+    height: 100%;
+  }
+  </style>
+  <input id="doc_search" placeholder="Search the doc" autofocus/>
+  <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js" onload="docsearch({
+    apiKey: '0dbb76467f0c180a1344fc46858df17b',
+    indexName: 'pipenv',
+    inputSelector: '#doc_search',
+    debug: false // Set debug to true if you want to inspect the dropdown
+  })" async></script>
 
 <p>
   <strong>Pipenv</strong> is a production-ready tool that aims to bring the best of all packaging worlds to the Python world. It harnesses Pipfile, pip, and virtualenv into one single command.


### PR DESCRIPTION
👋 team,

TL;DR: Add same search experience as https://docs.python-guide.org/

I'm working at Algolia on the a project called [DocSearch](https://community.algolia.com/docsearch/) which goal is to enhance documentation websites with exhaustive, fast and relevant search. You might have seen DocSearch live already on websites like [Bootstrap](https://getbootstrap.com/), [Brew](https://brew.sh/) or [jQuery](https://jquery.com/).

We use pipenv and we love it, we want to give back to this great project.

I have created [a preview of this PR](https://docsearch-pipenv.netlify.com/) and what DocSearch on the pipenv website could will look like here. Feel free to try it and let us know what you think. Please not the learn-as-you-type experience and the typo tolerance:

[![demo of DocSearch + pipenv](https://cl.ly/90fac125ae36/download/Screen%20Recording%202019-04-17%20at%2011.58%20AM.gif)](https://docsearch-pipenv.netlify.com/)

The way DocSearch works is by crawling your content, pushing the results into an Algolia index, and then requesting this index directly from the website front-end through JavaScript.

We'll take care of crawling your website and populating the Algolia index with the latest changes every 24h for you. You don't need to change anything to your deployment process. The only thing you need to add are the following CSS and JS snippets that will bind the dropdown to your searchbox.

We built DocSearch with the idea of giving back to the Open-Source community. This is why your [crawling configuration](https://github.com/algolia/docsearch-configs/blob/master/configs/pipenv.json) is available on GitHub if you want to change it. We also have our own [documentation](https://community.algolia.com/docsearch/documentation/) to help you tweak the dropdown to your needs. You'll also have access to *analytics on the most searched terms* or those with *no results*. All of this is of course *entirely free*.

Follow realpython/python-guide#932