### PR TITLE
Fix broken documentation links in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,8 +3,8 @@
 Before opening any issues or proposing any pull requests, please do the
 following:
 
-1. Read our [Contributor's Guide](https://docs.pipenv.org/dev/contributing/).
-2. Understand our [development philosophy](https://docs.pipenv.org/dev/philosophy/).
+1. Read our [Contributor's Guide](https://docs.pipenv.org/en/latest/dev/contributing/).
+2. Understand our [development philosophy](https://docs.pipenv.org/en/latest/dev/philosophy/).
 
 To get the greatest chance of helpful responses, please also observe the
 following additional notes.


### PR DESCRIPTION
### The issue
Two broken documentation links in CONTRIBUTING.md

### The fix
Replaced broken urls with correct ones
