### PR TITLE
Pytest 4: Update to get_closest_marker

### DIFF
--- a/news/3724.trivial.rst
+++ b/news/3724.trivial.rst
@@ -1,0 +1,1 @@
+Update pytest configuration to support pytest 4.

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -88,21 +88,21 @@ prepare_fixtures(os.path.join(PYPI_VENDOR_DIR, "fixtures"))
 
 
 def pytest_runtest_setup(item):
-    if item.get_marker('needs_internet') is not None and not WE_HAVE_INTERNET:
+    if item.get_closest_marker('needs_internet') is not None and not WE_HAVE_INTERNET:
         pytest.skip('requires internet')
-    if item.get_marker('needs_github_ssh') is not None and not WE_HAVE_GITHUB_SSH_KEYS:
+    if item.get_closest_marker('needs_github_ssh') is not None and not WE_HAVE_GITHUB_SSH_KEYS:
         pytest.skip('requires github ssh')
-    if item.get_marker('needs_hg') is not None and not WE_HAVE_HG:
+    if item.get_closest_marker('needs_hg') is not None and not WE_HAVE_HG:
         pytest.skip('requires mercurial')
-    if item.get_marker('skip_py27_win') is not None and (
+    if item.get_closest_marker('skip_py27_win') is not None and (
         sys.version_info[:2] <= (2, 7) and os.name == "nt"
     ):
         pytest.skip('must use python > 2.7 on windows')
-    if item.get_marker('py3_only') is not None and (
+    if item.get_closest_marker('py3_only') is not None and (
         sys.version_info < (3, 0)
     ):
         pytest.skip('test only runs on python 3')
-    if item.get_marker('lte_py36') is not None and (
+    if item.get_closest_marker('lte_py36') is not None and (
         sys.version_info >= (3, 7)
     ):
         pytest.skip('test only runs on python < 3.7')


### PR DESCRIPTION
See https://docs.pytest.org/en/latest/mark.html#update-marker-code

### The issue

`get_marker()` was removed form pytest 4. In Fedora, we've already updated to pytest 4.

https://docs.pytest.org/en/latest/deprecations.html#node-get-marker
https://docs.pytest.org/en/latest/mark.html#update-marker-code

### The fix

I've changed all `get_marker()` to `get_closest_marker()`. All are checked for None, so we only ask "is there some", not "give me all".


### The checklist

* [ ] Associated issue - nope, I consider this trivial and self-contained
* [x] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.
