### PR TITLE
Doc: advanced.rst: Use "pytest" as the new recommended entrypoint for…

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -467,7 +467,7 @@ and the corresponding Makefile::
         pipenv install --dev
 
     test:
-        pipenv run py.test tests
+        pipenv run pytest tests
 
 
 Tox Automation Project
@@ -483,7 +483,7 @@ and external testing::
     deps = pipenv
     commands=
         pipenv install --dev
-        pipenv run py.test tests
+        pipenv run pytest tests
 
     [testenv:flake8-py3]
     basepython = python3.4
@@ -492,7 +492,7 @@ and external testing::
         pipenv run flake8 --version
         pipenv run flake8 setup.py docs project test
 
-Pipenv will automatically use the virtualenv provided by ``tox``. If ``pipenv install --dev`` installs e.g. ``pytest``, then installed command ``py.test`` will be present in given virtualenv and can be called directly by ``py.test tests`` instead of ``pipenv run py.test tests``.
+Pipenv will automatically use the virtualenv provided by ``tox``. If ``pipenv install --dev`` installs e.g. ``pytest``, then installed command ``pytest`` will be present in given virtualenv and can be called directly by ``pytest tests`` instead of ``pipenv run pytest tests``.
 
 You might also want to add ``--ignore-pipfile`` to ``pipenv install``, as to
 not accidentally modify the lock-file on each test run. This causes Pipenv

--- a/news/3759.doc.rst
+++ b/news/3759.doc.rst
@@ -1,0 +1,1 @@
+Updated the documentation with the new ``pytest`` entrypoint.


### PR DESCRIPTION
… Pytest

According to https://github.com/pytest-dev/pytest/issues/1629 the recommended entrypoint for `pytest` is `pytest`. Usage of `py.test` has been deprecated for 2 years now.

Thank you for contributing to Pipenv!


### The issue

What is the thing you want to fix? Is it associated with an issue on GitHub? Please mention it.

Always consider opening an issue first to describe your problem, so we can discuss what is the best way to amend it.  Note that if you do not describe the goal of this change or link to a related issue, the maintainers may close the PR without further review.

If your pull request makes a non-insignificant change to Pipenv, such as the user interface or intended functionality, please file a PEEP. 

    https://github.com/pypa/pipenv/blob/master/peeps/PEEP-000.md

### The fix

How does this pull request fix your problem? Did you consider any alternatives? Why is this the *best* solution, in your opinion?


### The checklist

* [ ] Associated issue
* [ ] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

<!--
### If this is a patch to the `vendor` directory…

Please try to refrain from submitting patches directly to `vendor` or `patched`, but raise your issue to the upstream project instead, and inform Pipenv to upgrade when the upstream project accepts the fix.

A pull request to upgrade vendor packages is strongly discouraged, unless there is a very good reason (e.g. you need to test Pipenv’s integration to a new vendor feature). Pipenv audits and performs vendor upgrades regularly, generally before a new release is about to drop.

If your patch is not or cannot be accepted by upstream, but is essential to Pipenv (make sure to discuss this with maintainers!), please remember to attach a patch file in `tasks/vendoring/patched`, so this divergence from upstream can be recorded and replayed afterwards.
-->
