### PR TITLE
Allow overriding `PIPENV_INSTALL_TIMEOUT` environment variable

### DIFF
--- a/news/3652.feature.rst
+++ b/news/3652.feature.rst
@@ -1,0 +1,1 @@
+Allow overriding PIPENV_INSTALL_TIMEOUT environment variable (in seconds).

--- a/pipenv/environments.py
+++ b/pipenv/environments.py
@@ -99,7 +99,7 @@ environment, and reuses it if possible. This is usually the desired behavior,
 and enables the user to use any user-built environments with Pipenv.
 """
 
-PIPENV_INSTALL_TIMEOUT = 60 * 15
+PIPENV_INSTALL_TIMEOUT = int(os.environ.get("PIPENV_INSTALL_TIMEOUT", 60 * 15))
 """Max number of seconds to wait for package installation.
 
 Defaults to 900 (15 minutes), a very long arbitrary time.


### PR DESCRIPTION
### The issue

Fixes #3652 where PIPENV_INSTALL_TIMEOUT could not be changed. This was preventing users from setting longer timeouts when `pipenv lock` was taking over 15 minutes.

### The fix

Follows similar format to other environment variables in environments.py to get the environment variable, while keeping the same default.


### The checklist

* [x] Associated issue
* [x] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.
