### PR TITLE
Fix unnecessary downloads by pipenv lock #3827

### DIFF
--- a/news/3827.bugfix.rst
+++ b/news/3827.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed lengthy delays in `pipenv lock`. Use the hash value from the artifact url when available.

--- a/pipenv/patched/piptools/repositories/pypi.py
+++ b/pipenv/patched/piptools/repositories/pypi.py
@@ -77,11 +77,16 @@ class HashCache(SafeFileCache):
         return hash_value.decode('utf8') if hash_value else None
 
     def _get_file_hash(self, location):
-        h = hashlib.new(FAVORITE_HASH)
-        with open_local_or_remote_file(location, self.session) as fp:
-            for chunk in iter(lambda: fp.read(8096), b""):
-                h.update(chunk)
-        return ":".join([FAVORITE_HASH, h.hexdigest()])
+        if (location.hash is not None
+                and location.hash_name == FAVORITE_HASH):
+            hash_value = location.hash
+        else:
+            h = hashlib.new(FAVORITE_HASH)
+            with open_local_or_remote_file(location, self.session) as fp:
+                for chunk in iter(lambda: fp.read(8096), b""):
+                    h.update(chunk)
+            hash_value = h.hexdigest()
+        return ":".join([FAVORITE_HASH, hash_value])
 
 
 class PyPIRepository(BaseRepository):


### PR DESCRIPTION
Closes #3827

### The issue
`pipenv lock` retrieves all possible artifacts (even for other platforms/arch) in order to calculate to their hash, even when Pypi includes the sha256 hash in the url. This means lengthy downloads (In one case 893MB vs. 50MB), which users experience as pipenv hanging.

### The fix
If the artifact url already contains a hash value, using the *same* hash function which pipenv would have used, we simply extract and use it in directly without downloading anything. It is also stored in the hash cache.

**update**: I don't have any insight into the security model for pipenv, so pointing there may be a TOCTOU issue here. Using the hash from the url does not verify that the artifact itself matches it.
Is this a problem? is Pypi trusted?

### The checklist

* [X] Associated issue
* [X] A news fragment in the `news/` directory 

### If this is a patch to the `vendor` directory…

> Please try to refrain from submitting patches directly to `vendor` or `patched`, but raise your issue to > the upstream project instead, and inform Pipenv to upgrade when the upstream project accepts the fix.
> A pull request to upgrade vendor packages is strongly discouraged

This fixes an existing vendor patch merged in cb895aa94e8e249678b2fd198c86d203399da9f6.

`pipenv/patched/README.md` says "don't touch!" 3 times. So, yeah. I dunno. 

Need to update `pipenv/blob/master/tasks/vendoring/patches/patched/piptools.patch`, but I can't figure out your patch system. Could you please deal with that?  I don't want to spend time on that for this one-off.




