### PR TITLE
Ensure we always respect --site-packages

### DIFF
--- a/news/3718.bugfix.rst
+++ b/news/3718.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a bug which sometimes caused pipenv to fail to respect the ``--site-packages`` flag when passed with ``pipenv install``.

--- a/pipenv/cli/command.py
+++ b/pipenv/cli/command.py
@@ -70,7 +70,7 @@ def cli(
     man=False,
     support=None,
     help=False,
-    site_packages=False,
+    site_packages=None,
     **kwargs
 ):
     # Handle this ASAP to make shell startup fast.

--- a/pipenv/cli/command.py
+++ b/pipenv/cli/command.py
@@ -313,9 +313,11 @@ def lock(
     """Generates Pipfile.lock."""
     from ..core import ensure_project, do_init, do_lock
     # Ensure that virtualenv is available.
+    # Note that we don't pass clear on to ensure_project as it is also
+    # handled in do_lock
     ensure_project(
         three=state.three, python=state.python, pypi_mirror=state.pypi_mirror,
-        warn=(not state.quiet), site_packages=state.site_packages, clear=state.clear
+        warn=(not state.quiet), site_packages=state.site_packages,
     )
     if state.installstate.requirementstxt:
         do_init(

--- a/pipenv/cli/command.py
+++ b/pipenv/cli/command.py
@@ -18,7 +18,7 @@ from .options import (
     general_options, install_options, lock_options, pass_state,
     pypi_mirror_option, python_option, requirementstxt_option,
     skip_lock_option, sync_options, system_option, three_option,
-    uninstall_options, verbose_option
+    uninstall_options, verbose_option, site_packages_option
 )
 
 
@@ -217,6 +217,7 @@ def cli(
 @system_option
 @code_option
 @deploy_option
+@site_packages_option
 @skip_lock_option
 @install_options
 @pass_state
@@ -249,6 +250,7 @@ def install(
         extra_index_url=state.extra_index_urls,
         packages=state.installstate.packages,
         editable_packages=state.installstate.editables,
+        site_packages=state.site_packages
     )
     if retcode:
         ctx.abort()
@@ -310,11 +312,10 @@ def lock(
 ):
     """Generates Pipfile.lock."""
     from ..core import ensure_project, do_init, do_lock
-
     # Ensure that virtualenv is available.
     ensure_project(
         three=state.three, python=state.python, pypi_mirror=state.pypi_mirror,
-        warn=(not state.quiet)
+        warn=(not state.quiet), site_packages=state.site_packages, clear=state.clear
     )
     if state.installstate.requirementstxt:
         do_init(
@@ -475,8 +476,10 @@ def update(
         do_sync,
         project,
     )
-
-    ensure_project(three=state.three, python=state.python, warn=True, pypi_mirror=state.pypi_mirror)
+    ensure_project(
+        three=state.three, python=state.python, pypi_mirror=state.pypi_mirror,
+        warn=(not state.quiet), site_packages=state.site_packages, clear=state.clear
+    )
     if not outdated:
         outdated = bool(dry_run)
     if outdated:
@@ -505,12 +508,13 @@ def update(
                     err=True,
                 )
                 ctx.abort()
-
     do_lock(
+        ctx=ctx,
         clear=state.clear,
         pre=state.installstate.pre,
         keep_outdated=state.installstate.keep_outdated,
         pypi_mirror=state.pypi_mirror,
+        write=not state.quiet,
     )
     do_sync(
         ctx=ctx,

--- a/pipenv/cli/options.py
+++ b/pipenv/cli/options.py
@@ -61,7 +61,7 @@ class State(object):
         self.python = None
         self.two = None
         self.three = None
-        self.site_packages = False
+        self.site_packages = None
         self.clear = False
         self.system = False
         self.installstate = InstallState()
@@ -263,9 +263,9 @@ def site_packages_option(f):
         state = ctx.ensure_object(State)
         state.site_packages = value
         return value
-    return option("--site-packages", is_flag=True, default=False, type=click.types.BOOL,
-                  help="Enable site-packages for the virtualenv.", callback=callback,
-                  expose_value=False, show_envvar=True)(f)
+    return option("--site-packages/--no-site-packages", is_flag=True, default=None,
+                  type=click.types.BOOL, help="Enable site-packages for the virtualenv.",
+                  callback=callback, expose_value=False, show_envvar=True)(f)
 
 
 def clear_option(f):

--- a/pipenv/cli/options.py
+++ b/pipenv/cli/options.py
@@ -261,11 +261,12 @@ def quiet_option(f):
 def site_packages_option(f):
     def callback(ctx, param, value):
         state = ctx.ensure_object(State)
+        validate_bool_or_none(ctx, param, value)
         state.site_packages = value
         return value
     return option("--site-packages/--no-site-packages", is_flag=True, default=None,
-                  type=click.types.BOOL, help="Enable site-packages for the virtualenv.",
-                  callback=callback, expose_value=False, show_envvar=True)(f)
+                  help="Enable site-packages for the virtualenv.", callback=callback,
+                  expose_value=False, show_envvar=True)(f)
 
 
 def clear_option(f):
@@ -354,6 +355,12 @@ def validate_python_path(ctx, param, value):
         if os.path.isabs(value) and not os.path.isfile(value):
             raise BadParameter("Expected Python at path %s does not exist" % value)
     return value
+
+
+def validate_bool_or_none(ctx, param, value):
+    if value is not None:
+        return click.types.BOOL(value)
+    return False
 
 
 def validate_pypi_mirror(ctx, param, value):

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -1861,6 +1861,7 @@ def do_install(
     deploy=False,
     keep_outdated=False,
     selective_upgrade=False,
+    site_packages=False,
 ):
     from .environments import PIPENV_VIRTUALENV, PIPENV_USE_SYSTEM
     from .vendor.pip_shims.shims import PipError
@@ -1888,6 +1889,7 @@ def do_install(
         deploy=deploy,
         skip_requirements=skip_requirements,
         pypi_mirror=pypi_mirror,
+        site_packages=site_packages,
     )
     # Don't attempt to install develop and default packages if Pipfile is missing
     if not project.pipfile_exists and not (package_args or dev) and not code:

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -466,7 +466,7 @@ def ensure_python(three=None, python=None):
     return path_to_python
 
 
-def ensure_virtualenv(three=None, python=None, site_packages=False, pypi_mirror=None):
+def ensure_virtualenv(three=None, python=None, site_packages=None, pypi_mirror=None):
     """Creates a virtualenv, if one doesn't exist."""
     from .environments import PIPENV_USE_SYSTEM
 
@@ -500,7 +500,7 @@ def ensure_virtualenv(three=None, python=None, site_packages=False, pypi_mirror=
             cleanup_virtualenv(bare=False)
             sys.exit(1)
     # If --three, --two, or --python were passed…
-    elif (python) or (three is not None) or (site_packages is not False):
+    elif (python) or (three is not None) or (site_packages is not None):
         USING_DEFAULT_PYTHON = False
         # Ensure python is installed before deleting existing virtual env
         python = ensure_python(three=three, python=python)
@@ -536,7 +536,7 @@ def ensure_project(
     validate=True,
     system=False,
     warn=True,
-    site_packages=False,
+    site_packages=None,
     deploy=False,
     skip_requirements=False,
     pypi_mirror=None,
@@ -891,7 +891,7 @@ def convert_three_to_python(three, python):
         return python
 
 
-def do_create_virtualenv(python=None, site_packages=False, pypi_mirror=None):
+def do_create_virtualenv(python=None, site_packages=None, pypi_mirror=None):
     """Creates a virtualenv."""
 
     click.echo(
@@ -1861,7 +1861,7 @@ def do_install(
     deploy=False,
     keep_outdated=False,
     selective_upgrade=False,
-    site_packages=False,
+    site_packages=None,
 ):
     from .environments import PIPENV_VIRTUALENV, PIPENV_USE_SYSTEM
     from .vendor.pip_shims.shims import PipError


### PR DESCRIPTION
Ensure we always respect --site-packages

- Sometimes we fail to respect `--site-packages` when it is passed with
`--install`
- This resolves that and ensures we always pass it to `ensure_project`
- Fixes #3718