### PR TITLE
run: re-enable --help option

### DIFF
--- a/news/3844.behavior.rst
+++ b/news/3844.behavior.rst
@@ -1,0 +1,1 @@
+Re-enable ``--help`` option for ``pipenv run`` command.

--- a/pipenv/cli/command.py
+++ b/pipenv/cli/command.py
@@ -392,7 +392,6 @@ def shell(
 
 
 @cli.command(
-    add_help_option=False,
     short_help="Spawns a command installed into the virtualenv.",
     context_settings=subcommand_context_no_interspersion,
 )


### PR DESCRIPTION
This PR re-enables `--help` option for `pipenv run` command.

### The issue

There are a few issues related to this problem:
- https://github.com/pypa/pipenv/issues/1405
- https://github.com/pypa/pipenv/issues/2127
- https://github.com/pypa/pipenv/issues/2843

As you see, it is a reoccurring confusion that `pipenv run` command does not support `--help`. It was disabled in #940 and there was no particular motivation referenced. I believe it deserves to be enabled back.

It is brought up by different members the core team that this is working "as intended" because pipenv forwards everything through to the subcommand, but it is not entirely true, e.g. `pipenv run` for example accepts all virtualenv creation parameters:

```
$ pipenv run --python=3 which python
Creating a virtualenv for this project...
Pipfile: /home/immerrr/Pipfile
Using /home/immerrr/src/pyenv/versions/3.7.0/bin/python3.7m (3.7.0) to create virtualenv...
⠙ Creating virtual environment...Using base prefix '/home/immerrr/src/pyenv/versions/3.7.0'
New python executable in /mnt/extraspace/virtualenvs/immerrr-8YhW2Khy/bin/python3.7m
Not overwriting existing python script /mnt/extraspace/virtualenvs/immerrr-8YhW2Khy/bin/python (you must use /mnt/extraspace/virtualenvs/immerrr-8YhW2Khy/bin/python3.7m)
Installing setuptools, pip, wheel...
done.
Running virtualenv with interpreter /home/immerrr/src/pyenv/versions/3.7.0/bin/python3.7m

✔ Successfully created virtual environment! 
Virtualenv location: /mnt/extraspace/virtualenvs/immerrr-8YhW2Khy
Creating a Pipfile for this project...
/mnt/extraspace/virtualenvs/immerrr-8YhW2Khy/bin/python
```
 
Or even `--verbose`:
```
$ pipenv run --verbose which python
/mnt/extraspace/virtualenvs/immerrr-8YhW2Khy/bin/python
```

The general convention that makes sense to me is that pipenv options end with the first cmdline argument that does not start with a dash. It is also reaffirmed that `pipenv run` is supposed to receive options in the usage generated by click: 
```
$ pipenv run
Usage: pipenv run [OPTIONS] COMMAND [ARGS]...
```

And if you really need to run a command that starts with a dash, you have a `--` separator convention that has you covered:

```
$ pipenv run -- --verbose which python
Error: the command --verbose could not be found within PATH or Pipfile's [scripts].
```

Hence I don't think it makes much sense to keep `--help` disabled maintaining the discrepancy between `run` and the rest of pipenv commands.

### The fix

This PR re-enables `--help` option for `pipenv run` command.

### The checklist

* [x] Associated issue
* [x] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.
