### PR TITLE
Fix towncrier template

### DIFF
--- a/news/towncrier_template.rst
+++ b/news/towncrier_template.rst
@@ -13,7 +13,7 @@
 
 {% if definitions[category]['showcontent'] %}
 {% for text, values in sections[section][category]|dictsort(by='value') %}
-- {{ text }}{% if category != 'process' %}{{ values|sort|join(',\n  ') }}{% endif %}
+- {{ text }}  {% if category != 'process' %}{{ values|sort|join(',\n  ') }}{% endif %}
 
 {% endfor %}
 {% else %}


### PR DESCRIPTION
Add the missing whitespace between news text and issue number.