### PR TITLE
Allow passing through safety args, to work around pyup unreliability

### DIFF
--- a/news/2825.trivial.rst
+++ b/news/2825.trivial.rst
@@ -1,0 +1,1 @@
+Allow skipping `safety` check, or configuring it to use a local database.

--- a/pipenv/cli/command.py
+++ b/pipenv/cli/command.py
@@ -426,6 +426,26 @@ def run(state, command, args):
     multiple=True,
     help="Ignore specified vulnerability during safety checks.",
 )
+@option(
+    "--safety-cache",
+    "-c",
+    is_flag=True,
+    default=False,
+    help="Enable `safety` package's two-hour cache.",
+)
+@option(
+    "--safety-db",
+    "-d",
+    is_flag=True,
+    default=False,
+    help="Sets `safety` package's --db option: Path to a directory with a local vulnerability database including insecure.json and insecure_full.json.",
+)
+@option(
+    "--no-safety-vulnerability-check",
+    is_flag=True,
+    default=False,
+    help="Skips `safety` check and prints warning. Make sure to run `safety` manually.",
+)
 @common_options
 @system_option
 @argument("args", nargs=-1)
@@ -435,6 +455,9 @@ def check(
     unused=False,
     style=False,
     ignore=None,
+    safety_cache=False,
+    safety_db=None,
+    no_safety_vulnerability_check=False,
     args=None,
     **kwargs
 ):
@@ -447,6 +470,8 @@ def check(
         system=state.system,
         unused=unused,
         ignore=ignore,
+        safety_cache=safety_cache,
+        safety_db=safety_db,
         args=args,
         pypi_mirror=state.pypi_mirror,
     )

--- a/pipenv/cli/command.py
+++ b/pipenv/cli/command.py
@@ -458,7 +458,7 @@ def check(
     safety_cache=False,
     safety_db=None,
     no_safety_vulnerability_check=False,
-    args=None,
+    args=None, # TODO: this argument has been ignored for a while
     **kwargs
 ):
     """Checks for security vulnerabilities and against PEP 508 markers provided in Pipfile."""
@@ -472,7 +472,6 @@ def check(
         ignore=ignore,
         safety_cache=safety_cache,
         safety_db=safety_db,
-        args=args,
         pypi_mirror=state.pypi_mirror,
     )
 

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -2529,7 +2529,9 @@ def do_check(
     system=False,
     unused=False,
     ignore=None,
-    args=None,
+    safety_cache=False,
+    safety_db=None,
+    no_safety_vulnerability_check=False,
     pypi_mirror=None,
 ):
     from pipenv.vendor.vistir.compat import JSONDecodeError
@@ -2544,8 +2546,6 @@ def do_check(
             warn=False,
             pypi_mirror=pypi_mirror,
         )
-    if not args:
-        args = []
     if unused:
         deps_required = [k.lower() for k in project.packages.keys()]
         deps_needed = [k.lower() for k in import_from_code(unused)]
@@ -2615,6 +2615,15 @@ def do_check(
         sys.exit(1)
     else:
         click.echo(crayons.green("Passed!"))
+
+    if no_safety_vulnerability_check:
+        click.echo()
+        click.echo(
+            crayons.yellow("  Skipping vulnerability check, as requested with --no-safety-vulnerability check.", bold=True)
+        )
+        click.echo()
+        return
+
     click.echo(crayons.normal(
         decode_for_output("Checking installed package safety…"), bold=True)
     )
@@ -2657,7 +2666,7 @@ def do_check(
         click.echo("{0}".format(description))
         click.echo()
     else:
-        sys.exit(1)
+        sys.exit(2)
 
 
 def do_graph(bare=False, json=False, json_tree=False, reverse=False):


### PR DESCRIPTION
### The issue

https://github.com/pypa/pipenv/issues/2825

This issue has not been fully solved by the ability to provide a key - pyup sometimes goes down, and it usually takes a long time. Since `pipenv check` is the only would-be-fast way to test if a `pipenv install` is needed, this limits its usability.

### The fix

This pull request adds a couple more arguments to pass through to safety, exposing its existing configuration options. It also adds an option to completely skip invoking `safety`, for cases were package installation checks and package security checks need to be run separately.

Because it's a trivial change, I also changed the return code to `2` on `safety` failure.