### PR TITLE
Pass lock options to outdated

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -40,7 +40,6 @@ jobs:
         python.architecture: x64
     maxParallel: 4
   steps:
-#   - template: .azure-pipelines/steps/reinstall-pythons.yml
   - template: .azure-pipelines/steps/run-tests.yml
     parameters:
       vmImage: 'Ubuntu-16.04'
@@ -52,7 +51,6 @@ jobs:
     python.version: '3.7'
     python.architecture: x64
   steps:
-    - template: .azure-pipelines/steps/reinstall-pythons.yml
     - template: .azure-pipelines/steps/run-vendor-scripts.yml
       parameters:
         vmImage: 'Ubuntu-16.04'
@@ -64,7 +62,6 @@ jobs:
     python.version: '3.7'
     python.architecture: x64
   steps:
-    - template: .azure-pipelines/steps/reinstall-pythons.yml
     - template: .azure-pipelines/steps/build-package.yml
       parameters:
         vmImage: 'Ubuntu-16.04'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,7 +30,7 @@ jobs:
   strategy:
     matrix:
       Python27:
-        python.version: '2.7'
+        python.version: '2.7.16'
         python.architecture: x64
       Python36:
         python.version: '3.6'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,7 +30,7 @@ jobs:
   strategy:
     matrix:
       Python27:
-        python.version: '2.7.16'
+        python.version: '2.7'
         python.architecture: x64
       Python36:
         python.version: '3.6'
@@ -40,7 +40,7 @@ jobs:
         python.architecture: x64
     maxParallel: 4
   steps:
-  - template: .azure-pipelines/steps/reinstall-pythons.yml
+#   - template: .azure-pipelines/steps/reinstall-pythons.yml
   - template: .azure-pipelines/steps/run-tests.yml
     parameters:
       vmImage: 'Ubuntu-16.04'

--- a/news/3879.bugfix.rst
+++ b/news/3879.bugfix.rst
@@ -1,0 +1,1 @@
+Pass ``--pre`` and ``--clear`` options to ``pipenv update --outdated``.

--- a/pipenv/cli/command.py
+++ b/pipenv/cli/command.py
@@ -484,7 +484,7 @@ def update(
     if not outdated:
         outdated = bool(dry_run)
     if outdated:
-        do_outdated(pypi_mirror=state.pypi_mirror)
+        do_outdated(clear=state.clear, pre=state.installstate.pre, pypi_mirror=state.pypi_mirror)
     packages = [p for p in state.installstate.packages if p]
     editable = [p for p in state.installstate.editables if p]
     if not packages:

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -1772,6 +1772,7 @@ def do_outdated(pypi_mirror=None, pre=False, clear=False):
     from .vendor.requirementslib.models.requirements import Requirement
     from .vendor.requirementslib.models.utils import get_version
     from .vendor.packaging.utils import canonicalize_name
+    from .vendor.vistir.compat import Mapping
     from collections import namedtuple
 
     packages = {}

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -1767,12 +1767,11 @@ def do_py(system=False):
         click.echo(crayons.red("No project found!"))
 
 
-def do_outdated(pypi_mirror=None):
+def do_outdated(pypi_mirror=None, pre=False, clear=False):
     # TODO: Allow --skip-lock here?
     from .vendor.requirementslib.models.requirements import Requirement
     from .vendor.requirementslib.models.utils import get_version
     from .vendor.packaging.utils import canonicalize_name
-    from .vendor.vistir.compat import Mapping
     from collections import namedtuple
 
     packages = {}
@@ -1789,7 +1788,7 @@ def do_outdated(pypi_mirror=None):
         dep = Requirement.from_line(str(result.as_requirement()))
         packages.update(dep.as_pipfile())
     updated_packages = {}
-    lockfile = do_lock(write=False, pypi_mirror=pypi_mirror)
+    lockfile = do_lock(clear=clear, pre=pre, write=False, pypi_mirror=pypi_mirror)
     for section in ("develop", "default"):
         for package in lockfile[section]:
             try:

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -265,3 +265,16 @@ def test_pipenv_three(PipenvInstance):
         c = p.pipenv('--three')
         assert c.return_code == 0
         assert 'Successfully created virtual environment' in c.err
+
+
+@pytest.mark.outdated
+def test_pipenv_outdated_prerelease(PipenvInstance):
+    with PipenvInstance(chdir=True) as p:
+        with open(p.pipfile_path, "w") as f:
+            contents = """
+[packages]
+sqlalchemy = "==1.2.0b3"
+            """.strip()
+            f.write(contents)
+        c = p.pipenv('update --pre --outdated')
+        assert c.return_code == 0

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -273,7 +273,7 @@ def test_pipenv_outdated_prerelease(PipenvInstance):
         with open(p.pipfile_path, "w") as f:
             contents = """
 [packages]
-sqlalchemy = "<1.2.4"
+sqlalchemy = "<=1.2.3"
             """.strip()
             f.write(contents)
         c = p.pipenv('update --pre --outdated')

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -273,7 +273,7 @@ def test_pipenv_outdated_prerelease(PipenvInstance):
         with open(p.pipfile_path, "w") as f:
             contents = """
 [packages]
-sqlalchemy = "==1.2.0b3"
+sqlalchemy = "<1.2.4"
             """.strip()
             f.write(contents)
         c = p.pipenv('update --pre --outdated')

--- a/tests/integration/test_install_basic.py
+++ b/tests/integration/test_install_basic.py
@@ -474,13 +474,3 @@ extras = ["socks"]
         assert 'six = {version = "*"}' in contents
         assert 'requests = {version = "*"' in contents
         assert 'plette = "*"' in contents
-
-
-@pytest.mark.install
-def test_install_prerelease(PipenvInstance):
-    with PipenvInstance(chdir=True) as p:
-        c = p.pipenv("install 'sqlalchemy<=1.2.3'")
-        assert c.return_code != 0
-        c = p.pipenv("install --pre 'sqlalchemy<=1.2.3'")
-        assert c.return_code == 0
-        assert p.lockfile["default"]["sqlalchemy"]["version"] == "1.2.0b3"

--- a/tests/integration/test_install_basic.py
+++ b/tests/integration/test_install_basic.py
@@ -479,8 +479,8 @@ extras = ["socks"]
 @pytest.mark.install
 def test_install_prerelease(PipenvInstance):
     with PipenvInstance(chdir=True) as p:
-        c = p.pipenv("install sqlalchemy==1.2.0b3")
+        c = p.pipenv("install 'sqlalchemy<1.2.4'")
         assert c.return_code != 0
-        c = p.pipenv("install --pre sqlalchemy==1.2.0b3")
+        c = p.pipenv("install --pre 'sqlalchemy<1.2.4'")
         assert c.return_code == 0
         assert p.lockfile["default"]["sqlalchemy"]["version"] == "1.2.0b3"

--- a/tests/integration/test_install_basic.py
+++ b/tests/integration/test_install_basic.py
@@ -7,7 +7,6 @@ import pytest
 from flaky import flaky
 
 from pipenv._compat import Path, TemporaryDirectory
-from pipenv.project import Project
 from pipenv.utils import temp_environ
 from pipenv.vendor import delegator
 
@@ -475,3 +474,13 @@ extras = ["socks"]
         assert 'six = {version = "*"}' in contents
         assert 'requests = {version = "*"' in contents
         assert 'plette = "*"' in contents
+
+
+@pytest.mark.install
+def test_install_prerelease(PipenvInstance):
+    with PipenvInstance(chdir=True) as p:
+        c = p.pipenv("install sqlalchemy==1.2.0b3")
+        assert c.return_code != 0
+        c = p.pipenv("install --pre sqlalchemy==1.2.0b3")
+        assert c.return_code == 0
+        assert p.lockfile["default"]["sqlalchemy"]["version"] == "1.2.0b3"

--- a/tests/integration/test_install_basic.py
+++ b/tests/integration/test_install_basic.py
@@ -479,8 +479,8 @@ extras = ["socks"]
 @pytest.mark.install
 def test_install_prerelease(PipenvInstance):
     with PipenvInstance(chdir=True) as p:
-        c = p.pipenv("install 'sqlalchemy<1.2.4'")
+        c = p.pipenv("install 'sqlalchemy<=1.2.3'")
         assert c.return_code != 0
-        c = p.pipenv("install --pre 'sqlalchemy<1.2.4'")
+        c = p.pipenv("install --pre 'sqlalchemy<=1.2.3'")
         assert c.return_code == 0
         assert p.lockfile["default"]["sqlalchemy"]["version"] == "1.2.0b3"


### PR DESCRIPTION
Thank you for contributing to Pipenv!


### The issue

Fix #3879 

### The fix

Pass `--pre` and `--clear` to outdated
Add tests for the pre option.

### The checklist

* [x] Associated issue
* [x] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

<!--
### If this is a patch to the `vendor` directory…

Please try to refrain from submitting patches directly to `vendor` or `patched`, but raise your issue to the upstream project instead, and inform Pipenv to upgrade when the upstream project accepts the fix.

A pull request to upgrade vendor packages is strongly discouraged, unless there is a very good reason (e.g. you need to test Pipenv’s integration to a new vendor feature). Pipenv audits and performs vendor upgrades regularly, generally before a new release is about to drop.

If your patch is not or cannot be accepted by upstream, but is essential to Pipenv (make sure to discuss this with maintainers!), please remember to attach a patch file in `tasks/vendoring/patched`, so this divergence from upstream can be recorded and replayed afterwards.
-->
