### PR TITLE
Remove a misleading code comment from docs

### DIFF
--- a/docs/basics.rst
+++ b/docs/basics.rst
@@ -188,7 +188,7 @@ You can specify versions of a package using the `Semantic Versioning scheme <htt
 
 For example, to install requests you can use: ::
 
-    $ pipenv install requests~=1.2   # equivalent to requests~=1.2.0
+    $ pipenv install requests~=1.2
 
 Pipenv will install version ``1.2`` and any minor update, but not ``2.0``.
 

--- a/news/3885.trivial.rst
+++ b/news/3885.trivial.rst
@@ -1,0 +1,1 @@
+Remove a misleading code comment from Specifying Versions documentation.


### PR DESCRIPTION
In the [_Specifying Versions_](https://github.com/pypa/pipenv/blob/master/docs/basics.rst#-specifying-versions-of-a-package) section of the [_Basics_](https://github.com/pypa/pipenv/blob/master/docs/basics.rst) documentation, there is a misleading code comment saying that _requests~=1.2_ is equivalent to _requests~=1.2.0_, which it isn’t. __~=1.2_ is equivalent to _>=1.2,<2.0_, but _~=1.2.0_ is equivalent to _>=1.2.0,<1.3.0_. Fixed by removing the comment.

Reported in a [comment](https://github.com/pypa/pipenv/commit/87551b9d45e6f208fabb36ecdd81ce6d49ca98cf#r34571192) to https://github.com/pypa/pipenv/commit/87551b9d45e6f208fabb36ecdd81ce6d49ca98cf. Accepted by @frostming.

Fixes #3884.

### The checklist

* [x] Associated issue – #3884
* [x] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #. –  [3885.trivial.rst](https://github.com/Glutexo/pipenv/blob/remove_misleading_version_comment/news/3885.trivial.rst)