### PR TITLE
Expand user's home directory in PIPENV_PIPFILE

### DIFF
--- a/news/3889.behavior.rst
+++ b/news/3889.behavior.rst
@@ -1,0 +1,1 @@
+Expand the user's home directory in PIPENV_PIPFILE environment variable

--- a/pipenv/environments.py
+++ b/pipenv/environments.py
@@ -157,7 +157,7 @@ Spinners are identitcal to the node.js spinners and can be found at
 https://github.com/sindresorhus/cli-spinners
 """
 
-PIPENV_PIPFILE = os.environ.get("PIPENV_PIPFILE")
+PIPENV_PIPFILE = os.path.expanduser(os.environ.get("PIPENV_PIPFILE")) if os.environ.get("PIPENV_PIPFILE") else None
 """If set, this specifies a custom Pipfile location.
 
 When running pipenv from a location other than the same directory where the

--- a/pipenv/project.py
+++ b/pipenv/project.py
@@ -98,7 +98,7 @@ def preferred_newlines(f):
 
 if PIPENV_PIPFILE:
     if not os.path.isfile(PIPENV_PIPFILE):
-        raise RuntimeError("Given PIPENV_PIPFILE is not found!")
+        raise RuntimeError("Given PIPENV_PIPFILE ({}) is not found!".format(PIPENV_PIPFILE))
 
     else:
         PIPENV_PIPFILE = _normalized(PIPENV_PIPFILE)


### PR DESCRIPTION
I tried to run pipenv run from another directory. That, however, failed, because it couldn't find my Pipfile. 

### The fix

I went for expanding the tilde in environments.py after having tried to expand it in the [check](https://github.com/pypa/pipenv/blob/c3a9e8d028ae2835ed92ce0318d297d29d856f9c/pipenv/project.py#L100). That failed with a double expansion later. Expanding very early seems to be the cleanest approach to me. 

### The checklist

* [ ] Associated issue
* [ ] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

<!--
### If this is a patch to the `vendor` directory…

Please try to refrain from submitting patches directly to `vendor` or `patched`, but raise your issue to the upstream project instead, and inform Pipenv to upgrade when the upstream project accepts the fix.

A pull request to upgrade vendor packages is strongly discouraged, unless there is a very good reason (e.g. you need to test Pipenv’s integration to a new vendor feature). Pipenv audits and performs vendor upgrades regularly, generally before a new release is about to drop.

If your patch is not or cannot be accepted by upstream, but is essential to Pipenv (make sure to discuss this with maintainers!), please remember to attach a patch file in `tasks/vendoring/patched`, so this divergence from upstream can be recorded and replayed afterwards.
-->
