### PR TITLE
Fix link to GIF in README.md, add descriptive alt text

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ well as adds/removes packages from your `Pipfile` as you
 install/uninstall packages. It also generates the ever-important
 `Pipfile.lock`, which is used to produce deterministic builds.
 
-![image](https://s3.amazonaws.com/media.kennethreitz.com/pipenv.gif)
+![GIF demonstrating Pipenv's usage](https://gist.githubusercontent.com/jlusk/855d611bbcfa2b159839db73d07f6ce9/raw/7f5743401809f7e630ee8ff458faa980e19924a0/pipenv.gif)
 
 The problems that Pipenv seeks to solve are multi-faceted:
 

--- a/news/3911.doc.rst
+++ b/news/3911.doc.rst
@@ -1,0 +1,1 @@
+Fix link to GIF in README.md demonstrating Pipenv's usage, and add descriptive alt text.


### PR DESCRIPTION
This PR will fix #3911.

### The issue

https://s3.amazonaws.com/media.kennethreitz.com/pipenv.gif seems to 404 (as described in issue #3911)

### The fix

This PR changes the GIF's link to what is currently used in Pipenv's documentation (https://docs.pipenv.org/en/latest/)

### The checklist

* [X] Associated issue (#3911)
* [X] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.