### PR TITLE
Sidebar: Update git-legit to new url address

### DIFF
--- a/docs/_templates/sidebarintro.html
+++ b/docs/_templates/sidebarintro.html
@@ -56,7 +56,7 @@
     <li><a href="http://python-requests.org/">Requests: HTTP for Humans</a></li>
     <li><a href="https://github.com/kennethreitz/maya">Maya: Datetimes for Humans</a></li>
     <li><a href="https://github.com/kennethreitz/records">Records: SQL for Humans</a></li>
-    <li><a href="http://www.git-legit.org">Legit: Git for Humans</a></li>
+    <li><a href="https://frostming.github.io/legit">Legit: Git for Humans</a></li>
     <li><a href="http://docs.python-tablib.org/en/latest/">Tablib: Tabular Datasets</a></li>
 </ul>
 
@@ -75,4 +75,3 @@
   <li><a href="https://pipenv-ja.readthedocs.io/ja/translate-ja/">日本語</a></li>
   <li><a href="https://pipenv-es.readthedocs.io/es/latest/">Español</a></li>
 </ul>
-

--- a/docs/_templates/sidebarlogo.html
+++ b/docs/_templates/sidebarlogo.html
@@ -59,7 +59,7 @@
     <li><a href="http://python-guide.org">The Python Guide</a></li>
     <li><a href="http://python-requests.org/">Requests: HTTP for Humans</a></li>
     <li><a href="https://github.com/kennethreitz/records">Records: SQL for Humans</a></li>
-    <li><a href="http://www.git-legit.org">Legit: Git for Humans</a></li>
+    <li><a href="https://frostming.github.io/legit">Legit: Git for Humans</a></li>
     <li><a href="http://docs.python-tablib.org/en/latest/">Tablib: Tabular Datasets</a></li>
     <li><a href="http://markdownplease.com">Markdown, Please!</a></li>
 </ul>
@@ -79,4 +79,3 @@
   <li><a href="http://pipenv-ja.readthedocs.io/ja/translate-ja/">日本語</a></li>
   <li><a href="https://pipenv-es.readthedocs.io/es/latest/">Español</a></li>
 </ul>
-


### PR DESCRIPTION
Thank you for contributing to Pipenv!


### The issue

As issued at https://github.com/pypa/pipenv/issues/3913, git-legit address is returning users to a poker site.

### The fix

Update git-legit to correct new address.

