### PR TITLE
#3722 Exclude shared dependencies for --all-dev opt 

### DIFF
--- a/news/3722.behavior.rst
+++ b/news/3722.behavior.rst
@@ -1,0 +1,1 @@
+Prevents ``uninstall --all-dev`` from removing dependencies shared between packages and dev-packages

--- a/tests/integration/test_uninstall.py
+++ b/tests/integration/test_uninstall.py
@@ -150,6 +150,41 @@ def test_uninstall_all_dev(PipenvInstance):
         assert c.return_code == 0
 
 
+@pytest.mark.run
+@pytest.mark.uninstall
+@pytest.mark.install
+def test_uninstall_all_dev_leave_prod_packages(PipenvInstance):
+    with PipenvInstance() as p:
+        c = p.pipenv("install --dev --pre black")
+        assert c.return_code == 0
+
+        c = p.pipenv("install flask")
+        assert c.return_code == 0
+
+        assert "flask" in p.pipfile["packages"]
+        assert "black" in p.pipfile["dev-packages"]
+        assert "flask" in p.lockfile["default"]
+        assert "black" in p.lockfile["develop"]
+        assert "click" in p.lockfile["default"]
+        assert "click" in p.lockfile["develop"]
+
+        c = p.pipenv('run python -c "import click"')
+        assert c.return_code == 0
+
+        c = p.pipenv("uninstall --all-dev")
+        assert c.return_code == 0
+
+        assert p.pipfile["dev-packages"] == {}
+        assert "black" not in p.lockfile["develop"]
+        assert "click" not in p.lockfile["develop"]
+        assert "flask" in p.pipfile["packages"]
+        assert "flask" in p.lockfile["default"]
+        assert "click" in p.lockfile["default"]
+
+        c = p.pipenv('run python -c "import click"')
+        assert c.return_code == 0
+
+
 @pytest.mark.uninstall
 @pytest.mark.run
 def test_normalize_name_uninstall(PipenvInstance):


### PR DESCRIPTION
### The issue

#3722 - Shared dependencies between default and development are being uninstalled when `pipenv uninstall --all-dev` is ran.

### The fix

When the `--all-dev` option is used, pipenv will now filter out any packages from the uninstall list that are common between default and development. This clears the development section of Pipfile and Pipfile.lock without uninstalling or removing common shared dependencies, such as six or click. 

### The checklist

* [x] Associated issue
* [x] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.
