### PR TITLE
Bug: Abort if penv.install errors

### DIFF
--- a/news/3917.bugfix.rst
+++ b/news/3917.bugfix.rst
@@ -1,0 +1,1 @@
+If penv.install returns error do abort().

--- a/tasks/release.py
+++ b/tasks/release.py
@@ -134,11 +134,14 @@ def build_dists(ctx):
             ).stdout.strip()
             log("Building sdist using %s ...." % executable)
             os.environ["PIPENV_PYTHON"] = py_version
-            ctx.run("pipenv install --dev", env=env)
-            ctx.run(
-                "pipenv run pip install -e . --upgrade --upgrade-strategy=eager", env=env
-            )
-            log("Building wheel using python %s ...." % py_version)
+            try:
+                ctx.run("pipenv install --dev", env=env)
+                ctx.run(
+                  "pipenv run pip install -e . --upgrade --upgrade-strategy=eager", env=env
+                )
+                log("Building wheel using python %s ...." % py_version)
+            except:
+                ctx.abort()
             if py_version == "3.6":
                 ctx.run("pipenv run python setup.py sdist bdist_wheel", env=env)
             else:


### PR DESCRIPTION
### The issue

Fixes https://github.com/pypa/pipenv/issues/3896, problem - 2.

### The fix

abort if penv.install my-package errors.

### The checklist

* [x] Associated issue
* [x] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.
