### PR TITLE
Create .dockerignore to speedup docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+./examples
+./tests
+./docs
+./news
+./pipenv
+./.git
+./.buildkite
+./peeps
+./.github
+./tasks
+./.azure-pipelines


### PR DESCRIPTION
Just ignore all directories to speed up docker build.

### The issue

Docker build is slow, because it loads everything in its context.

### The fix

Add a .dockerignore file.
