### PR TITLE
Use list comprehension instead of filter with lambda function

### DIFF
--- a/pipenv/environment.py
+++ b/pipenv/environment.py
@@ -916,7 +916,7 @@ class Environment(object):
             pathset_base = pip_shims.UninstallPathSet
             pathset_base._permitted = PatchedUninstaller._permitted
             dist = next(
-                iter(filter(lambda d: d.project_name == pkgname, self.get_working_set())),
+                iter(d for d in self.get_working_set() if d.project_name == pkgname),
                 None
             )
             pathset = pathset_base.from_dist(dist)


### PR DESCRIPTION
### The issue

This is not an issue, actually, but just a non-pythonic way to do something.
Since we should be using list comprehensions or generator expressions instead of a `filter` with lambda functions.

References:
- https://www.oreilly.com/library/view/python-cookbook/0596001673/ch01s11.html
- https://www.artima.com/weblogs/viewpost.jsp?thread=98196


### The fix

I just changed the piece of code using `filter` to a generator expression. Really simple change.


### The checklist

* [ ] Associated issue
* [ ] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.
