### PR TITLE
Resolve dependencies only for the artifact.

### DIFF
--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -718,7 +718,6 @@ def batch_install(
     if sequential_deps is None:
         sequential_deps = []
     failed = not retry
-    install_deps = not no_deps
     if not failed:
         label = INSTALL_LABEL if not environments.PIPENV_HIDE_EMOJIS else ""
     else:
@@ -738,6 +737,7 @@ def batch_install(
     trusted_hosts = []
     # Install these because
     for dep in deps_list_bar:
+        install_deps = not no_deps
         extra_indexes = []
         if dep.req.req:
             dep.req.req = strip_extras_markers_from_requirement(dep.req.req)
@@ -754,7 +754,6 @@ def batch_install(
             is_artifact = True
         if not project.s.PIPENV_RESOLVE_VCS and is_artifact and not dep.editable:
             install_deps = True
-            no_deps = False
 
         with vistir.contextmanagers.temp_environ():
             if not allow_global:


### PR DESCRIPTION
### The issue

Pipenv tries to resolve dependencies when installing from the lock-file if there is at least one "artifact" in that list. It is at least one of the issues causing https://github.com/pypa/pipenv/issues/1356

### The fix

Try to resolve dependencies only for the artifact


### The checklist

* [ ] Associated issue
* [ ] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

<!--
### If this is a patch to the `vendor` directory…

Please try to refrain from submitting patches directly to `vendor` or `patched`, but raise your issue to the upstream project instead, and inform Pipenv to upgrade when the upstream project accepts the fix.

A pull request to upgrade vendor packages is strongly discouraged, unless there is a very good reason (e.g. you need to test Pipenv’s integration to a new vendor feature). Pipenv audits and performs vendor upgrades regularly, generally before a new release is about to drop.

If your patch is not or cannot be accepted by upstream, but is essential to Pipenv (make sure to discuss this with maintainers!), please remember to attach a patch file in `tasks/vendoring/patched`, so this divergence from upstream can be recorded and replayed afterwards.
-->
