### PR TITLE
Add initial support for the "pre" option in Pipfile

### DIFF
--- a/pipenv/patched/notpip/_internal/req/constructors.py
+++ b/pipenv/patched/notpip/_internal/req/constructors.py
@@ -207,7 +207,8 @@ def install_req_from_line(
     isolated=False,  # type: bool
     options=None,  # type: Optional[Dict[str, Any]]
     wheel_cache=None,  # type: Optional[WheelCache]
-    constraint=False  # type: bool
+    constraint=False,  # type: bool
+    pre=False  # type: bool
 ):
     # type: (...) -> InstallRequirement
     """Creates an InstallRequirement from a name, which might be a
@@ -305,6 +306,7 @@ def install_req_from_line(
         wheel_cache=wheel_cache,
         constraint=constraint,
         extras=extras,
+        pre=pre,
     )
 
 

--- a/pipenv/patched/notpip/_internal/req/req_file.py
+++ b/pipenv/patched/notpip/_internal/req/req_file.py
@@ -109,6 +109,7 @@ def parse_requirements(
         req_iter = process_line(line, filename, line_number, finder,
                                 comes_from, options, session, wheel_cache,
                                 use_pep517=use_pep517, constraint=constraint)
+
         for req in req_iter:
             yield req
 
@@ -189,8 +190,8 @@ def process_line(
                 req_options[dest] = opts.__dict__[dest]
         yield install_req_from_line(
             args_str, line_comes_from, constraint=constraint,
-            use_pep517=use_pep517,
-            isolated=isolated, options=req_options, wheel_cache=wheel_cache
+            use_pep517=use_pep517, isolated=isolated,
+            options=req_options, wheel_cache=wheel_cache, pre=opts.pre,
         )
 
     # yield an editable requirement

--- a/pipenv/patched/notpip/_internal/req/req_install.py
+++ b/pipenv/patched/notpip/_internal/req/req_install.py
@@ -68,6 +68,7 @@ class InstallRequirement(object):
         comes_from,  # type: Optional[Union[str, InstallRequirement]]
         source_dir=None,  # type: Optional[str]
         editable=False,  # type: bool
+        pre=False,  # type: bool
         link=None,  # type: Optional[Link]
         update=True,  # type: bool
         markers=None,  # type: Optional[Marker]
@@ -88,6 +89,7 @@ class InstallRequirement(object):
         else:
             self.source_dir = None
         self.editable = editable
+        self.pre = pre
 
         self._wheel_cache = wheel_cache
         if link is None and req and req.url:

--- a/pipenv/patched/piptools/resolver.py
+++ b/pipenv/patched/piptools/resolver.py
@@ -24,6 +24,7 @@ class RequirementSummary(object):
     """
     Summary of a requirement's properties for comparison purposes.
     """
+
     def __init__(self, ireq):
         self.req = ireq.req
         self.key = key_from_req(ireq.req)
@@ -259,7 +260,7 @@ class Resolver(object):
             # hitting the index server
             best_match = ireq
         else:
-            best_match = self.repository.find_best_match(ireq, prereleases=self.prereleases)
+            best_match = self.repository.find_best_match(ireq, prereleases=ireq.pre or self.prereleases)
 
         # Format the best match
         log.debug('  found candidate {} (constraint was {})'.format(format_requirement(best_match),

--- a/pipenv/vendor/requirementslib/models/utils.py
+++ b/pipenv/vendor/requirementslib/models/utils.py
@@ -501,6 +501,18 @@ def get_pyproject(path):
     return requires, backend
 
 
+def split_prerelease_from_line(line):
+    # type: (AnyStr) -> Tuple[AnyStr, bool]
+    """Split prerelease from a dependency"""
+    parts = line.split()
+    prerelease = False
+    if '--pre' in parts:
+        prerelease = True
+        pre_pos = parts.index('--pre')
+        line = ' '.join(parts[:pre_pos] + parts[pre_pos+1:])
+    return line, prerelease
+
+
 def split_markers_from_line(line):
     # type: (AnyStr) -> Tuple[AnyStr, Optional[AnyStr]]
     """Split markers from a dependency"""
@@ -801,9 +813,9 @@ def lookup_table(values, key=None, keyval=None, unique=False, use_lists=False):
 
     if keyval is None:
         if key is None:
-            keyval = lambda v: v
+            def keyval(v): return v
         else:
-            keyval = lambda v: (key(v), v)
+            def keyval(v): return (key(v), v)
 
     if unique:
         return dict(keyval(v) for v in values)

--- a/pipenv/vendor/requirementslib/models/utils.py
+++ b/pipenv/vendor/requirementslib/models/utils.py
@@ -813,9 +813,9 @@ def lookup_table(values, key=None, keyval=None, unique=False, use_lists=False):
 
     if keyval is None:
         if key is None:
-            def keyval(v): return v
+            keyval = lambda v: v
         else:
-            def keyval(v): return (key(v), v)
+            keyval = lambda v: (key(v), v)
 
     if unique:
         return dict(keyval(v) for v in values)


### PR DESCRIPTION
### The issue

This PR adds initial support for the `pre` Pipfile option discussed in https://github.com/pypa/pipenv/issues/1760

It touches a lot of vendored dependencies and I'm not sure that this is the right way to do it but seems like this is the smallest possible change.

### The checklist

* [ ] Associated issue
* [ ] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

<!--
### If this is a patch to the `vendor` directory…

Please try to refrain from submitting patches directly to `vendor` or `patched`, but raise your issue to the upstream project instead, and inform Pipenv to upgrade when the upstream project accepts the fix.

A pull request to upgrade vendor packages is strongly discouraged, unless there is a very good reason (e.g. you need to test Pipenv’s integration to a new vendor feature). Pipenv audits and performs vendor upgrades regularly, generally before a new release is about to drop.

If your patch is not or cannot be accepted by upstream, but is essential to Pipenv (make sure to discuss this with maintainers!), please remember to attach a patch file in `tasks/vendoring/patched`, so this divergence from upstream can be recorded and replayed afterwards.
-->
