### PR TITLE
pipenv is available on all Fedoras

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Or, if you\'re using Debian Buster+:
 
     $ sudo apt install pipenv
 
-Or, if you\'re using Fedora 28:
+Or, if you\'re using Fedora:
 
     $ sudo dnf install pipenv
     


### PR DESCRIPTION
Fedora 28 is EOL.

Thank you for contributing to Pipenv!