### PR TITLE
honor PIPENV_SPINNER environment variable

### DIFF
--- a/news/4045.bugfix.rst
+++ b/news/4045.bugfix.rst
@@ -1,0 +1,1 @@
+Honor PIPENV_SPINNER environment variable

--- a/pipenv/environments.py
+++ b/pipenv/environments.py
@@ -151,6 +151,7 @@ if PIPENV_IS_CI:
     PIPENV_NOSPIN = True
 
 PIPENV_SPINNER = "dots" if not os.name == "nt" else "bouncingBar"
+PIPENV_SPINNER = os.environ.get("PIPENV_SPINNER", PIPENV_SPINNER)
 """Sets the default spinner type.
 
 Spinners are identitcal to the node.js spinners and can be found at


### PR DESCRIPTION
### The issue

Pipenv ignores the `PIPENV_SPINNER` environment variable.

### The fix

For some reason the spinner style was hardcoded to "bouncingBar" if the operating system is Windows and "dots" otherwise. This behaviour is preserved.
If the user sets the `PIPENV_SPINNER` environment variable then its value takes precedence.

### The checklist

* [x] Associated issue (#4045)
* [x] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

