### PR TITLE
Create PEEP-006.md

### DIFF
--- a/peeps/PEEP-006.md
+++ b/peeps/PEEP-006.md
@@ -1,0 +1,15 @@
+# PEEP-006: add flag to save exact libraries' versions to Pipfile
+
+PROPOSED
+
+As suggested in [this issue](https://github.com/pypa/pipenv/issues/3441), it would be very convinient if there was a flag like in npm that, when doing `pipenv install`, made that the versions saved to Pipfile were the exact ones used, instead of `"*"`
+
+Copying here some text from that issue that explains the problem a bit better:
+
+> Example:
+> pipenv install scipy would add scipy = "*" to the Pipfile.
+>
+> I would have expected a way to have scipy = "==1.2.0" to the Pipfile instead.
+>
+> I was wondering if this sort of functionality already exists and/or if there is any reason not to go this route.
+


### PR DESCRIPTION
PEEP to add the option to save exact libraries versions to Pipfile

Thank you for contributing to Pipenv!


### The issue

As described in https://github.com/pypa/pipenv/issues/3441, it would be interesting if when installing a certain package with pipenv *without specifying the version*  (`pipenv install scipy`, for example), there was a flag that saved the *exact* version that was installed to the Pipfile. Something like the `--save-exact` flag in npm.


### The fix

Right now this can be accomplished, AFAIK, manually editing the version numbers in Pipfile, but it's quite annoying. 

### The checklist

* [ YES] Associated issue: https://github.com/pypa/pipenv/issues/3441
* [ ] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

<!--
### If this is a patch to the `vendor` directory…

Please try to refrain from submitting patches directly to `vendor` or `patched`, but raise your issue to the upstream project instead, and inform Pipenv to upgrade when the upstream project accepts the fix.

A pull request to upgrade vendor packages is strongly discouraged, unless there is a very good reason (e.g. you need to test Pipenv’s integration to a new vendor feature). Pipenv audits and performs vendor upgrades regularly, generally before a new release is about to drop.

If your patch is not or cannot be accepted by upstream, but is essential to Pipenv (make sure to discuss this with maintainers!), please remember to attach a patch file in `tasks/vendoring/patched`, so this divergence from upstream can be recorded and replayed afterwards.
-->
