### PR TITLE
Fixed enclosing by double-quotes for arguments with symbols & < > |

### DIFF
--- a/pipenv/cmdparse.py
+++ b/pipenv/cmdparse.py
@@ -94,5 +94,5 @@ class Script(object):
         """
         return " ".join(itertools.chain(
             [_quote_if_contains(self.command, r'[\s^()]')],
-            (_quote_if_contains(arg, r'[\s^]') for arg in self.args),
+            (_quote_if_contains(arg, r'[\s^&<>|]') for arg in self.args),
         ))

--- a/pipenv/cmdparse.py
+++ b/pipenv/cmdparse.py
@@ -72,6 +72,10 @@ class Script(object):
         * Whitespaces.
         * Carets (^). (pypa/pipenv#3307)
         * Parentheses in the command. (pypa/pipenv#3168)
+        * Ampersand (&). (pypa/pipenv#4133)
+        * Greater-than (>). (pypa/pipenv#4133)
+        * Less-than (<). (pypa/pipenv#4133)
+        * Vertical line (|). (pypa/pipenv#4133)
 
         Carets introduce a difficult situation since they are essentially
         "lossy" when parsed. Consider this in cmd.exe::


### PR DESCRIPTION
#4133 
Fixed enclosing by double-quotes for script arguments.

