### PR TITLE
Remove search link on main page of RTD documentation

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -134,4 +134,3 @@ Indices and tables
 
 * :ref:`genindex`
 * :ref:`modindex`
-* :ref:`search`


### PR DESCRIPTION
Partially and temporarily addresses #1839 while we fix the underlying problem and investigate the search index. Users will temporarily only be able to use the search box in the sidebar.

Please revert this once the index is fixed.

Signed-off-by: Sumana Harihareswara <sh@changeset.nyc>

### The issue

What is the thing you want to fix? Is it associated with an issue on GitHub? Please mention it.

 #1839

* [x] Associated issue
* [x] A news fragment in the `news/` directory to describe this fix with the extension `.trivial`