### PR TITLE
Update documentation to reflect accurate pyup use

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ Pipenv: Python Development Workflow for Humans
 [![Azure Pipelines Build Status](https://dev.azure.com/pypa/pipenv/_apis/build/status/Pipenv%20CI?branchName=master)](https://dev.azure.com/pypa/pipenv/_build/latest?definitionId=16&branchName=master)
 [![image](https://img.shields.io/pypi/pyversions/pipenv.svg)](https://python.org/pypi/pipenv)
 
+
 ------------------------------------------------------------------------
+[[ ~ Dependency Scanning by PyUp.io ~ ]](https://pyup.io)
 
 **Pipenv** is a tool that aims to bring the best of all packaging worlds
 (bundler, composer, npm, cargo, yarn, etc.) to the Python world.

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -237,16 +237,12 @@ Example::
 
 .. note::
 
-   In order to enable this functionality while maintaining its permissive
-   copyright license, `pipenv` embeds an API client key for the backend
-   Safety API operated by pyup.io rather than including a full copy of the
-   CC-BY-NC-SA licensed Safety-DB database. This embedded client key is
-   shared across all `pipenv check` users, and hence will be subject to
-   API access throttling based on overall usage rather than individual
-   client usage.
+   Access to the ``safety`` database happens via an API call which retrieves
+   results which are updated on a monthly basis and made available to the
+   community for free by `pyup.io`.
 
-   You can also use your own safety API key by setting the
-   environment variable ``PIPENV_PYUP_API_KEY``.
+   For more up-to-date vulnerability data, you may also use your own safety
+   API key by setting the environment variable ``PIPENV_PYUP_API_KEY``.
 
 
 ☤ Community Integrations

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -237,9 +237,12 @@ Example::
 
 .. note::
 
-   Access to the ``safety`` database happens via an API call which retrieves
-   results which are updated on a monthly basis and made available to the
-   community for free by `pyup.io`.
+   Each month, `PyUp.io` updates the ``safety`` database of
+   insecure Python packages and `makes it available to the
+   community for free <https://pyup.io/safety/>`__. Pipenv
+   makes an API call to retrieve those results and use them
+   each time you run ``pipenv check`` to show you vulnerable
+   dependencies.
 
    For more up-to-date vulnerability data, you may also use your own safety
    API key by setting the environment variable ``PIPENV_PYUP_API_KEY``.

--- a/news/4210.trivial.rst
+++ b/news/4210.trivial.rst
@@ -1,0 +1,1 @@
+Updated PyUp.io information to reflect current situation.


### PR DESCRIPTION
- Remove bits about CC-BY-SA licensing
- Remove bits about using an embedded API key
- Add a little flair to the readme to acknowledge pyup