### PR TITLE
fix(pep425tags): missing `os` package import added

### DIFF
--- a/pipenv/patched/notpip/_internal/pep425tags.py
+++ b/pipenv/patched/notpip/_internal/pep425tags.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 
 import distutils.util
 import logging
+import os
 import platform
 import re
 import sys

--- a/tasks/vendoring/patches/patched/_post-pip-update-pep425tags.patch
+++ b/tasks/vendoring/patches/patched/_post-pip-update-pep425tags.patch
@@ -1,8 +1,16 @@
 diff --git a/pipenv/patched/notpip/_internal/pep425tags.py b/pipenv/patched/notpip/_internal/pep425tags.py
-index 042ba34b..58decc23 100644
+index 369275a8..16d041d9 100644
 --- a/pipenv/patched/notpip/_internal/pep425tags.py
 +++ b/pipenv/patched/notpip/_internal/pep425tags.py
-@@ -170,8 +170,9 @@ def is_linux_armhf():
+@@ -3,6 +3,7 @@ from __future__ import absolute_import
+ 
+ import distutils.util
+ import logging
++import os
+ import platform
+ import re
+ import sys
+@@ -170,8 +171,9 @@ def is_linux_armhf():
          return False
      # hard-float ABI can be detected from the ELF header of the running
      # process
@@ -13,7 +21,7 @@ index 042ba34b..58decc23 100644
              elf_header_raw = f.read(40)  # read 40 first bytes of ELF header
      except (IOError, OSError, TypeError):
          return False
-@@ -205,7 +206,7 @@ def is_manylinux1_compatible():
+@@ -205,7 +207,7 @@ def is_manylinux1_compatible():
          pass
  
      # Check glibc version. CentOS 5 uses glibc 2.5.
@@ -22,7 +30,7 @@ index 042ba34b..58decc23 100644
  
  
  def is_manylinux2010_compatible():
-@@ -223,7 +224,7 @@ def is_manylinux2010_compatible():
+@@ -223,7 +225,7 @@ def is_manylinux2010_compatible():
          pass
  
      # Check glibc version. CentOS 6 uses glibc 2.12.
@@ -31,7 +39,7 @@ index 042ba34b..58decc23 100644
  
  
  def is_manylinux2014_compatible():
-@@ -249,7 +250,7 @@ def is_manylinux2014_compatible():
+@@ -249,7 +251,7 @@ def is_manylinux2014_compatible():
          pass
  
      # Check glibc version. CentOS 7 uses glibc 2.17.


### PR DESCRIPTION
This fixes runtime error on Linux ARM when calling:

```bash
pipenv install [package]
```

- version (current master, installed as work around for other problem in public version):

```bash
pi@rpi4:~/dev/pipenv $ pipenv --version
pipenv, version 2020.04.01.a1
```

This line check on ARM platform:
```py
if platform == "linux_armv7l" and not is_linux_armhf()
```
https://github.com/peterblazejewicz/pipenv/blob/f20c9dc688948db2b4dfd0a6a68398c4bf0c6254/pipenv/patched/notpip/_internal/pep425tags.py#L174

triggers a check using `os`, which was not imported, resulting
in runtime error.

Thanks!

Full stack trace:

```bash
pi@rpi4:~/dev/python-playground $ pipenv install
Pipfile.lock not found, creating…
Locking [dev-packages] dependencies…
Locking [packages] dependencies…
Building requirements...
Resolving dependencies...
✘ Locking Failed! 
Traceback (most recent call last):
  File "/home/pi/dev/pipenv/pipenv/resolver.py", line 807, in <module>
    main()
  File "/home/pi/dev/pipenv/pipenv/resolver.py", line 803, in main
    parsed.requirements_dir, parsed.packages, parse_only=parsed.parse_only)
  File "/home/pi/dev/pipenv/pipenv/resolver.py", line 785, in _main
    resolve_packages(pre, clear, verbose, system, write, requirements_dir, packages)
  File "/home/pi/dev/pipenv/pipenv/resolver.py", line 753, in resolve_packages
    requirements_dir=requirements_dir,
  File "/home/pi/dev/pipenv/pipenv/resolver.py", line 736, in resolve
    req_dir=requirements_dir
  File "/home/pi/dev/pipenv/pipenv/utils.py", line 1377, in resolve_deps
    req_dir=req_dir,
  File "/home/pi/dev/pipenv/pipenv/utils.py", line 1084, in actually_resolve_deps
    resolver.resolve()
  File "/home/pi/dev/pipenv/pipenv/utils.py", line 805, in resolve
    results = self.resolver.resolve(max_rounds=environments.PIPENV_MAX_ROUNDS)
  File "/home/pi/dev/pipenv/pipenv/patched/piptools/resolver.py", line 183, in resolve
    has_changed, best_matches = self._resolve_one_round()
  File "/home/pi/dev/pipenv/pipenv/patched/piptools/resolver.py", line 270, in _resolve_one_round
    best_matches = {self.get_best_match(ireq) for ireq in constraints}
  File "/home/pi/dev/pipenv/pipenv/patched/piptools/resolver.py", line 270, in <setcomp>
    best_matches = {self.get_best_match(ireq) for ireq in constraints}
  File "/home/pi/dev/pipenv/pipenv/patched/piptools/resolver.py", line 332, in get_best_match
    ireq, prereleases=self.prereleases
  File "/home/pi/dev/pipenv/pipenv/patched/piptools/repositories/pypi.py", line 179, in find_best_match
    all_candidates = clean_requires_python(self.find_all_candidates(ireq.name))
  File "/home/pi/dev/pipenv/pipenv/patched/piptools/repositories/pypi.py", line 167, in find_all_candidates
    candidates = self.finder.find_all_candidates(req_name)
  File "/home/pi/dev/pipenv/pipenv/patched/notpip/_internal/index.py", line 842, in find_all_candidates
    links=page_links,
  File "/home/pi/dev/pipenv/pipenv/patched/notpip/_internal/index.py", line 811, in evaluate_links
    candidate = self.get_install_candidate(link_evaluator, link)
  File "/home/pi/dev/pipenv/pipenv/patched/notpip/_internal/index.py", line 789, in get_install_candidate
    is_candidate, result = link_evaluator.evaluate_link(link)
  File "/home/pi/dev/pipenv/pipenv/patched/notpip/_internal/index.py", line 199, in evaluate_link
    supported_tags = self._target_python.get_tags()
  File "/home/pi/dev/pipenv/pipenv/patched/notpip/_internal/models/target_python.py", line 102, in get_tags
    impl=self.implementation,
  File "/home/pi/dev/pipenv/pipenv/patched/notpip/_internal/pep425tags.py", line 407, in get_supported
    if is_manylinux2014_compatible():
  File "/home/pi/dev/pipenv/pipenv/patched/notpip/_internal/pep425tags.py", line 241, in is_manylinux2014_compatible
    if platform == "linux_armv7l" and not is_linux_armhf():
  File "/home/pi/dev/pipenv/pipenv/patched/notpip/_internal/pep425tags.py", line 173, in is_linux_armhf
    sys_executable = os.environ.get('PIP_PYTHON_PATH', sys.executable)
NameError: name 'os' is not defined
```