### PR TITLE
Skip satisfied dependencies during installation

### DIFF
--- a/news/3057.feature.rst
+++ b/news/3057.feature.rst
@@ -1,0 +1,1 @@
+``pipenv install`` and ``pipenv sync`` will no longer attempt to install satisfied dependencies during installation.

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -735,6 +735,9 @@ def batch_install(deps_list, procs, failed_deps_queue,
 
     deps_to_install = deps_list[:]
     deps_to_install.extend(sequential_deps)
+    deps_to_install = [
+        dep for dep in deps_to_install if not project.environment.is_satisfied(dep)
+    ]
     sequential_dep_names = [d.name for d in sequential_deps]
 
     deps_list_bar = progress.bar(

--- a/pipenv/environment.py
+++ b/pipenv/environment.py
@@ -722,8 +722,9 @@ class Environment(object):
             ), None
         )
         if match is not None:
-            if req.editable and req.local and req.line_instance.path and self.find_egg(match):
-                return vistir.compat.samefile(req.line_instance.path, match.location)
+            if req.editable and req.line_instance.is_local and self.find_egg(match):
+                requested_path = req.line_instance.path
+                return requested_path and vistir.compat.samefile(requested_path, match.location)
             elif match.has_metadata("direct_url.json"):
                 direct_url_metadata = json.loads(match.get_metadata("direct_url.json"))
                 commit_id = direct_url_metadata.get("vcs_info", {}).get("commit_id", "")

--- a/pipenv/environment.py
+++ b/pipenv/environment.py
@@ -722,7 +722,7 @@ class Environment(object):
             ), None
         )
         if match is not None:
-            if req.editable and self.find_egg(match):
+            if req.editable and req.local and req.line_instance.path and self.find_egg(match):
                 return vistir.compat.samefile(req.line_instance.path, match.location)
             elif match.has_metadata("direct_url.json"):
                 direct_url_metadata = json.loads(match.get_metadata("direct_url.json"))

--- a/pipenv/environment.py
+++ b/pipenv/environment.py
@@ -723,7 +723,7 @@ class Environment(object):
         )
         if match is not None:
             if req.editable and self.find_egg(match):
-                return req.line_instance.path == match.location
+                return vistir.compat.samefile(req.line_instance.path, match.location)
             elif match.has_metadata("direct_url.json"):
                 direct_url_metadata = json.loads(match.get_metadata("direct_url.json"))
                 commit_id = direct_url_metadata.get("vcs_info", {}).get("commit_id", "")

--- a/tasks/vendoring/patches/vendor/vistir-imports.patch
+++ b/tasks/vendoring/patches/vendor/vistir-imports.patch
@@ -15,30 +15,32 @@ diff --git a/pipenv/vendor/vistir/compat.py b/pipenv/vendor/vistir/compat.py
 index b5904bc7..a44aafbe 100644
 --- a/pipenv/vendor/vistir/compat.py
 +++ b/pipenv/vendor/vistir/compat.py
-@@ -43,7 +43,7 @@ __all__ = [
+@@ -55,7 +55,7 @@ __all__ = [
  if sys.version_info >= (3, 5):  # pragma: no cover
      from pathlib import Path
  else:  # pragma: no cover
 -    from pathlib2 import Path
 +    from pipenv.vendor.pathlib2 import Path
  
- if six.PY3:  # pragma: no cover
+ if sys.version_info >= (3, 4):  # pragma: no cover
      # Only Python 3.4+ is supported
-@@ -53,14 +53,14 @@ if six.PY3:  # pragma: no cover
-     from weakref import finalize
+@@ -85,8 +85,8 @@ if sys.version_info >= (3, 4):  # pragma: no cover
+ 
  else:  # pragma: no cover
      # Only Python 2.7 is supported
 -    from backports.functools_lru_cache import lru_cache
-+    from pipenv.vendor.backports.functools_lru_cache import lru_cache
-     from .backports.functools import partialmethod  # type: ignore
 -    from backports.shutil_get_terminal_size import get_terminal_size
++    from pipenv.vendor.backports.functools_lru_cache import lru_cache
 +    from pipenv.vendor.backports.shutil_get_terminal_size import get_terminal_size
+     from .backports.functools import partialmethod  # type: ignore
      from .backports.surrogateescape import register_surrogateescape
+     from collections import (
+@@ -110,7 +110,7 @@ else:  # pragma: no cover
  
      register_surrogateescape()
      NamedTemporaryFile = _NamedTemporaryFile
 -    from backports.weakref import finalize  # type: ignore
 +    from pipenv.vendor.backports.weakref import finalize  # type: ignore
  
- try:
-     # Introduced Python 3.5
+     try:
+         from os.path import samefile


### PR DESCRIPTION
- Skip satisfied dependencies in the environment during install
  by checking whether the constraint of a specifier is satisfied
- If there is no specifier and a dependency is installed, assume it
  is satisfied
- For editable dependencies, if the dependency in the environment is
  an egg link and points at the same path as the given dep, assume
  it is satisfied
- TODO: Add test
- Fixes #3057 
- Fixes #3506 