### PR TITLE
Lacking sphinxcontrib-spelling module

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -20,6 +20,7 @@ six==1.11.0
 snowballstemmer==1.2.1
 Sphinx==1.6.3
 sphinx-click==1.3.0
+sphinxcontrib-spelling==4.2.1
 sphinxcontrib-websupport==1.1.0
 urllib3==1.24.1
 virtualenv==16.1.0


### PR DESCRIPTION
### The issue

Documentation (located under the `./docs` directory) build fails with "exception: No module named 'sphinxcontrib.spelling'" error.
sphinxcontrib-spelling was added by https://github.com/pypa/pipenv/commit/2f460a9128ee5c880dcbc52fd2b8de3fe393720a 3days ago.

Reproducing processes:
```
pip install -r docs/requirement.txt
cd docs
make html
```

### The fix

Insert an entry of sphinxcontrib-spelling

### The checklist

* [x] Associated issue
* [x] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

<!--
### If this is a patch to the `vendor` directory…

Please try to refrain from submitting patches directly to `vendor` or `patched`, but raise your issue to the upstream project instead, and inform Pipenv to upgrade when the upstream project accepts the fix.

A pull request to upgrade vendor packages is strongly discouraged, unless there is a very good reason (e.g. you need to test Pipenv’s integration to a new vendor feature). Pipenv audits and performs vendor upgrades regularly, generally before a new release is about to drop.

If your patch is not or cannot be accepted by upstream, but is essential to Pipenv (make sure to discuss this with maintainers!), please remember to attach a patch file in `tasks/vendoring/patched`, so this divergence from upstream can be recorded and replayed afterwards.
-->
