### PR TITLE
Float wheels to the top of the candidate sort order

### DIFF
--- a/news/4231.bugfix.rst
+++ b/news/4231.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a bug which caused pipenv to prefer source distributions over wheels from ``PyPI`` during the dependency resolution phase.

--- a/pipenv/patched/notpip/_internal/index/package_finder.py
+++ b/pipenv/patched/notpip/_internal/index/package_finder.py
@@ -535,7 +535,7 @@ class CandidateEvaluator(object):
                 )
             if self._prefer_binary:
                 binary_preference = 1
-            tags = self.valid_tags if not ignore_compatibility else None
+            tags = valid_tags
             try:
                 pri = -(wheel.support_index_min(tags=tags))
             except TypeError:

--- a/tasks/vendoring/patches/patched/pip20.patch
+++ b/tasks/vendoring/patches/patched/pip20.patch
@@ -114,7 +114,7 @@ index 02a187c8..f917e645 100644
                      modifying_pip=modifying_pip
                  )
 diff --git a/pipenv/patched/pip/_internal/index/package_finder.py b/pipenv/patched/pip/_internal/index/package_finder.py
-index a74d78db..11128f4d 100644
+index a74d78db..7c9dc1be 100644
 --- a/pipenv/patched/pip/_internal/index/package_finder.py
 +++ b/pipenv/patched/pip/_internal/index/package_finder.py
 @@ -121,6 +121,7 @@ class LinkEvaluator(object):
@@ -201,7 +201,7 @@ index a74d78db..11128f4d 100644
              if self._prefer_binary:
                  binary_preference = 1
 -            pri = -(wheel.support_index_min(valid_tags))
-+            tags = self.valid_tags if not ignore_compatibility else None
++            tags = valid_tags
 +            try:
 +                pri = -(wheel.support_index_min(tags=tags))
 +            except TypeError:


### PR DESCRIPTION
- `ignore_compatibility` is meant to resolve hashes into the lockfile
  after resolution happens
- We still want compatible items to be the ones we actually tell pip to
  install
- Fixes #4231

Signed-off-by: Dan Ryan <dan.ryan@canonical.com>