### PR TITLE
Fix the broken update --outdated handler

### DIFF
--- a/news/4229.bugfix.rst
+++ b/news/4229.bugfix.rst
@@ -1,0 +1,1 @@
+Fix a bug of ``pipenv update --outdated`` that can't print output correctly.

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -1812,7 +1812,10 @@ def do_outdated(pypi_mirror=None, pre=False, clear=False):
         (pkg.project_name, pkg.parsed_version, pkg.latest_version)
         for pkg in project.environment.get_outdated_packages()
     }
-    reverse_deps = project.environment.reverse_dependencies()
+    reverse_deps = {
+        canonicalize_name(name): deps
+        for name, deps in project.environment.reverse_dependencies().items()
+    }
     for result in installed_packages:
         dep = Requirement.from_line(str(result.as_requirement()))
         packages.update(dep.as_pipfile())
@@ -1842,9 +1845,9 @@ def do_outdated(pypi_mirror=None, pre=False, clear=False):
         version = None
         if name_in_pipfile:
             version = get_version(project.packages[name_in_pipfile])
-            reverse_deps = reverse_deps.get(name_in_pipfile)
-            if isinstance(reverse_deps, Mapping) and "required" in reverse_deps:
-                required = " {0} required".format(reverse_deps["required"])
+            rdeps = reverse_deps.get(canonicalize_name(package))
+            if isinstance(rdeps, Mapping) and "required" in rdeps:
+                required = " {0} required".format(rdeps["required"])
             if version:
                 pipfile_version_text = " ({0} set in Pipfile)".format(version)
             else:


### PR DESCRIPTION
### The issue
Fix #4229 

### The fix

Fixed a hidden bug that `reverse_deps` get overridden in each run of the loop.
Also normalize the package name in `reverse_deps`.

### The checklist

* [x] Associated issue
* [x] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

<!--
### If this is a patch to the `vendor` directory…

Please try to refrain from submitting patches directly to `vendor` or `patched`, but raise your issue to the upstream project instead, and inform Pipenv to upgrade when the upstream project accepts the fix.

A pull request to upgrade vendor packages is strongly discouraged, unless there is a very good reason (e.g. you need to test Pipenv’s integration to a new vendor feature). Pipenv audits and performs vendor upgrades regularly, generally before a new release is about to drop.

If your patch is not or cannot be accepted by upstream, but is essential to Pipenv (make sure to discuss this with maintainers!), please remember to attach a patch file in `tasks/vendoring/patched`, so this divergence from upstream can be recorded and replayed afterwards.
-->
