### PR TITLE
Load the pip version from the correct prefix

### DIFF
--- a/news/3506.feature.rst
+++ b/news/3506.feature.rst
@@ -1,0 +1,1 @@
+``pipenv install`` and ``pipenv sync`` will no longer attempt to install satisfied dependencies during installation.

--- a/news/4220.bugfix.rst
+++ b/news/4220.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a bug which caused pipenv to search non-existent virtual environments for ``pip`` when installing using ``--system``.

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -1335,8 +1335,10 @@ def get_pip_args(
     no_deps=False,  # type: bool,
     selective_upgrade=False,  # type: bool
     src_dir=None,  # type: Optional[str]
+    allow_global=False,  # type: bool
 ):
     # type: (...) -> List[str]
+    from .environment import Environment
     from .vendor.packaging.version import parse as parse_version
     arg_map = {
         "pre": ["--pre"],
@@ -1352,9 +1354,10 @@ def get_pip_args(
         ],
         "src_dir": src_dir,
     }
-    if project.environment.pip_version >= parse_version("19.0"):
+    environment = project.get_environment(allow_global=allow_global)
+    if environment.pip_version >= parse_version("19.0"):
         arg_map["no_use_pep517"].append("--no-use-pep517")
-    if project.environment.pip_version < parse_version("19.1"):
+    if environment.pip_version < parse_version("19.1"):
         arg_map["no_use_pep517"].append("--no-build-isolation")
     arg_set = []
     for key in arg_map.keys():
@@ -1495,7 +1498,7 @@ def pip_install(
     pip_args = get_pip_args(
         pre=pre, verbose=environments.is_verbose(), upgrade=True,
         selective_upgrade=selective_upgrade, no_use_pep517=not use_pep517,
-        no_deps=no_deps, require_hashes=not ignore_hashes
+        no_deps=no_deps, require_hashes=not ignore_hashes, allow_global=allow_global
     )
     pip_command.extend(pip_args)
     if r:

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -1338,7 +1338,6 @@ def get_pip_args(
     allow_global=False,  # type: bool
 ):
     # type: (...) -> List[str]
-    from .environment import Environment
     from .vendor.packaging.version import parse as parse_version
     arg_map = {
         "pre": ["--pre"],
@@ -1354,10 +1353,9 @@ def get_pip_args(
         ],
         "src_dir": src_dir,
     }
-    environment = project.get_environment(allow_global=allow_global)
-    if environment.pip_version >= parse_version("19.0"):
+    if project.environment.pip_version >= parse_version("19.0"):
         arg_map["no_use_pep517"].append("--no-use-pep517")
-    if environment.pip_version < parse_version("19.1"):
+    if project.environment.pip_version < parse_version("19.1"):
         arg_map["no_use_pep517"].append("--no-build-isolation")
     arg_set = []
     for key in arg_map.keys():

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -1335,7 +1335,6 @@ def get_pip_args(
     no_deps=False,  # type: bool,
     selective_upgrade=False,  # type: bool
     src_dir=None,  # type: Optional[str]
-    allow_global=False,  # type: bool
 ):
     # type: (...) -> List[str]
     from .vendor.packaging.version import parse as parse_version
@@ -1496,7 +1495,7 @@ def pip_install(
     pip_args = get_pip_args(
         pre=pre, verbose=environments.is_verbose(), upgrade=True,
         selective_upgrade=selective_upgrade, no_use_pep517=not use_pep517,
-        no_deps=no_deps, require_hashes=not ignore_hashes, allow_global=allow_global
+        no_deps=no_deps, require_hashes=not ignore_hashes,
     )
     pip_command.extend(pip_args)
     if r:

--- a/pipenv/patched/crayons.py
+++ b/pipenv/patched/crayons.py
@@ -12,8 +12,8 @@ import os
 import re
 import sys
 
-import shellingham
-import colorama
+from pipenv.vendor import shellingham
+from pipenv.vendor import colorama
 
 PY3 = sys.version_info[0] >= 3
 

--- a/pipenv/vendor/vendor.txt
+++ b/pipenv/vendor/vendor.txt
@@ -38,7 +38,7 @@ six==1.14.0
 semver==2.9.0
 toml==0.10.1
 cached-property==1.5.1
-vistir==0.5.1
+vistir==0.5.2
 pip-shims==0.5.2
     contextlib2==0.6.0.post1
     funcsigs==1.0.2

--- a/pipenv/vendor/vistir/misc.py
+++ b/pipenv/vendor/vistir/misc.py
@@ -207,11 +207,14 @@ class SubprocessStreamWrapper(object):
         stdout_allowed=False,  # type: bool
     ):
         # type: (...) -> None
+        stdout_encoding = None
+        stderr_encoding = None
+        preferred_encoding = getpreferredencoding()
         if subprocess is not None:
             stdout_encoding = self.get_subprocess_encoding(subprocess, "stdout")
             stderr_encoding = self.get_subprocess_encoding(subprocess, "stderr")
-        self.stdout_encoding = stdout_encoding or PREFERRED_ENCODING
-        self.stderr_encoding = stderr_encoding or PREFERRED_ENCODING
+        self.stdout_encoding = stdout_encoding or preferred_encoding
+        self.stderr_encoding = stderr_encoding or preferred_encoding
         self.stdout_lines = []
         self.text_stdout_lines = []
         self.stderr_lines = []

--- a/tasks/vendoring/patches/patched/crayons.patch
+++ b/tasks/vendoring/patches/patched/crayons.patch
@@ -8,8 +8,9 @@ index 455d3e90..de735daf 100644
  
 -PY3 = sys.version_info[0] >= 3
 -
-+import shellingham
- import colorama
+-import colorama
++from pipenv.vendor import shellingham
++from pipenv.vendor import colorama
  
 +PY3 = sys.version_info[0] >= 3
 +


### PR DESCRIPTION
- Respect `--system` when it is supplied during install
- Fixes #4220