### PR TITLE
Don't check against root directory

### DIFF
--- a/news/4273.bugfix.rst
+++ b/news/4273.bugfix.rst
@@ -1,0 +1,1 @@
+Fix a bug that Pipenv rejects to work under the root directory.

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -126,9 +126,6 @@ def do_clear():
 
     try:
         vistir.path.rmtree(PIPENV_CACHE_DIR, onerror=vistir.path.handle_remove_readonly)
-        vistir.path.rmtree(
-            locations.USER_CACHE_DIR, onerror=vistir.path.handle_remove_readonly
-        )
     except OSError as e:
         # Ignore FileNotFoundError. This is needed for Python 2.7.
         import errno
@@ -136,6 +133,8 @@ def do_clear():
         if e.errno == errno.ENOENT:
             pass
         raise
+    # Other processes may be writing into this directory simultaneously.
+    vistir.path.rmtree(locations.USER_CACHE_DIR, ignore_errors=True)
 
 
 def load_dot_env():

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -126,6 +126,12 @@ def do_clear():
 
     try:
         vistir.path.rmtree(PIPENV_CACHE_DIR, onerror=vistir.path.handle_remove_readonly)
+        # Other processes may be writing into this directory simultaneously.
+        vistir.path.rmtree(
+            locations.USER_CACHE_DIR,
+            ignore_errors=environments.PIPENV_IS_CI,
+            onerror=vistir.path.handle_remove_readonly
+        )
     except OSError as e:
         # Ignore FileNotFoundError. This is needed for Python 2.7.
         import errno
@@ -133,8 +139,6 @@ def do_clear():
         if e.errno == errno.ENOENT:
             pass
         raise
-    # Other processes may be writing into this directory simultaneously.
-    vistir.path.rmtree(locations.USER_CACHE_DIR, ignore_errors=True)
 
 
 def load_dot_env():

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -568,14 +568,6 @@ def ensure_project(
         system = True
     if not project.pipfile_exists and deploy:
         raise exceptions.PipfileNotFound
-    # Fail if working under /
-    if not project.name:
-        click.echo(
-            "{0}: Pipenv is not intended to work under the root directory, "
-            "please choose another path.".format(crayons.red("ERROR")),
-            err=True
-        )
-        sys.exit(1)
     # Skip virtualenv creation when --system was used.
     if not system:
         ensure_virtualenv(

--- a/pipenv/project.py
+++ b/pipenv/project.py
@@ -682,18 +682,10 @@ class Project(object):
 
     def create_pipfile(self, python=None):
         """Creates the Pipfile, filled with juicy defaults."""
-        from .vendor.pip_shims.shims import (
-            ConfigOptionParser, make_option_group, index_group
-        )
+        from .vendor.pip_shims.shims import InstallCommand
         # Inherit the pip's index configuration of install command.
-        config_parser = ConfigOptionParser(name="install")
-        config_parser.add_option_group(make_option_group(index_group, config_parser))
-        install = config_parser.option_groups[0]
-        indexes = (
-            " ".join(install.get_option("--extra-index-url").default)
-            .lstrip("\n")
-            .split("\n")
-        )
+        command = InstallCommand()
+        indexes = command.cmd_opts.get_option("--extra-index-url").default
         sources = [DEFAULT_SOURCE]
         for i, index in enumerate(indexes):
             if not index:

--- a/pipenv/project.py
+++ b/pipenv/project.py
@@ -685,8 +685,8 @@ class Project(object):
         from .vendor.pip_shims.shims import (
             ConfigOptionParser, make_option_group, index_group
         )
-
-        config_parser = ConfigOptionParser(name=self.name)
+        # Inherit the pip's index configuration of install command.
+        config_parser = ConfigOptionParser(name="install")
         config_parser.add_option_group(make_option_group(index_group, config_parser))
         install = config_parser.option_groups[0]
         indexes = (


### PR DESCRIPTION
### The issue

#3386 causes some regression issue #4273 

### The fix

This PR reverts some of the changes of #3386, don't check against root directory but fix the `self.name` reference in `create_pipfile()`.

Sorry for the trouble.

### The checklist

* [x] Associated issue
* [x] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

<!--
### If this is a patch to the `vendor` directory…

Please try to refrain from submitting patches directly to `vendor` or `patched`, but raise your issue to the upstream project instead, and inform Pipenv to upgrade when the upstream project accepts the fix.

A pull request to upgrade vendor packages is strongly discouraged, unless there is a very good reason (e.g. you need to test Pipenv’s integration to a new vendor feature). Pipenv audits and performs vendor upgrades regularly, generally before a new release is about to drop.

If your patch is not or cannot be accepted by upstream, but is essential to Pipenv (make sure to discuss this with maintainers!), please remember to attach a patch file in `tasks/vendoring/patched`, so this divergence from upstream can be recorded and replayed afterwards.
-->
