### PR TITLE
#4279: Stop test_ssh_vcs_install from failing

### DIFF
--- a/news/4279.trivial.rst
+++ b/news/4279.trivial.rst
@@ -1,0 +1,2 @@
+Remove expection of ``version`` key in ``test_ssh_vcs_install`` to prevent it
+from failing.

--- a/tests/integration/test_install_uri.py
+++ b/tests/integration/test_install_uri.py
@@ -59,7 +59,6 @@ def test_ssh_vcs_install(PipenvInstance):
         assert p.lockfile["default"]["six"] == {
             "git": "ssh://git@github.com/benjaminp/six.git",
             "ref": "15e31431af97e5e64b80af0a3f598d382bcdd49a",
-            "version": "==1.11.0"
         }
 
 


### PR DESCRIPTION
Remove expectation of `version` key in `test_ssh_vcs_install` to
stop it from failing.

Mirrors similar change to `test_git_vcs_install` in
243b4fd0df552b7430fbaa5dadbaa4d7b322127f.

Thank you for contributing to Pipenv!


### The issue

Fixes #4279.

### The fix

Mirror 243b4fd0df552b7430fbaa5dadbaa4d7b322127f.


### The checklist

* [x] Associated issue
* [x] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.