### PR TITLE
#4278: Don't pin wildcard versions in lockfile

### DIFF
--- a/news/4278.bugfix.rst
+++ b/news/4278.bugfix.rst
@@ -1,0 +1,1 @@
+Fix a bug that caused non-specific versions to be pinned in ``Pipfile.lock``.

--- a/pipenv/utils.py
+++ b/pipenv/utils.py
@@ -1191,7 +1191,7 @@ def get_locked_dep(dep, pipfile_section, prefer_pipfile=True):
     lockfile_name, lockfile_dict = lockfile_entry.copy().popitem()
     lockfile_version = lockfile_dict.get("version", "")
     # Keep pins from the lockfile
-    if prefer_pipfile and lockfile_version != version and version.startswith("=="):
+    if prefer_pipfile and lockfile_version != version and version.startswith("==") and "*" not in version:
         lockfile_dict["version"] = version
     lockfile_entry[lockfile_name] = lockfile_dict
     return lockfile_entry

--- a/tests/integration/test_lock.py
+++ b/tests/integration/test_lock.py
@@ -748,3 +748,16 @@ def test_lock_nested_vcs_direct_url(PipenvInstance):
         assert "git" in p.lockfile["default"]["sibling-package"]
         assert "subdirectory" in p.lockfile["default"]["sibling-package"]
         assert "version" not in p.lockfile["default"]["sibling-package"]
+
+
+@pytest.mark.lock
+@pytest.mark.install
+def test_lock_package_with_wildcard_version(PipenvInstance):
+    with PipenvInstance(chdir=True) as p:
+        c = p.pipenv("install 'six==1.11.*'")
+        assert c.ok
+        assert "six" in p.pipfile["packages"]
+        assert p.pipfile["packages"]["six"] == "==1.11.*"
+        assert "six" in p.lockfile["default"]
+        assert "version" in p.lockfile["default"]["six"]
+        assert p.lockfile["default"]["six"]["version"] == "==1.11.0"


### PR DESCRIPTION
Fixes bug introduced by 552d1274eacbd04c61f46f639bd967d294f25e6a,
which activated the (unused) changes made much earlier in
a08a2da52488fa31b1e74b22211f383566fef16b.

Thank you for contributing to Pipenv!

### The issue

Fixes #4278.

`pipenv.utils.get_locked_dep` uses the version specified in the Pipfile if it starts with `==` without checking whether that version is a wildcard match.

### The fix

Do not use the version in the Pipfile if it is a wildcard match.

### The checklist

* [x] Associated issue
* [x] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.