### PR TITLE
Fix #3630: Add 'needs_internet' marker to tests missing it

### DIFF
--- a/news/3630.trivial.rst
+++ b/news/3630.trivial.rst
@@ -1,0 +1,1 @@
+Add ``needs_internet`` marker to tests missing it.

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -158,6 +158,7 @@ def test_pipenv_check(PipenvInstance):
 
 
 @pytest.mark.cli
+@pytest.mark.needs_internet
 def test_pipenv_clean_pip_no_warnings(PipenvInstance):
     with PipenvInstance(chdir=True) as p:
         with open('setup.py', 'w') as f:
@@ -172,6 +173,7 @@ def test_pipenv_clean_pip_no_warnings(PipenvInstance):
 
 
 @pytest.mark.cli
+@pytest.mark.needs_internet
 def test_pipenv_clean_pip_warnings(PipenvInstance):
     with PipenvInstance(chdir=True) as p:
         with open('setup.py', 'w') as f:

--- a/tests/integration/test_install_markers.py
+++ b/tests/integration/test_install_markers.py
@@ -158,6 +158,7 @@ def test_resolver_unique_markers(PipenvInstance):
 
 @flaky
 @pytest.mark.project
+@pytest.mark.needs_internet
 def test_environment_variable_value_does_not_change_hash(PipenvInstance):
     with PipenvInstance(chdir=True) as p:
         with temp_environ():

--- a/tests/integration/test_lock.py
+++ b/tests/integration/test_lock.py
@@ -617,6 +617,7 @@ def test_lockfile_with_empty_dict(PipenvInstance):
 @pytest.mark.lock
 @pytest.mark.install
 @pytest.mark.skip_lock
+@pytest.mark.needs_internet
 def test_lock_with_incomplete_source(PipenvInstance):
     with PipenvInstance(chdir=True) as p:
         with open(p.pipfile_path, 'w') as f:
@@ -693,6 +694,7 @@ def test_vcs_lock_respects_top_level_pins(PipenvInstance):
 
 
 @pytest.mark.lock
+@pytest.mark.needs_internet
 def test_lock_after_update_source_name(PipenvInstance):
     with PipenvInstance(chdir=True) as p:
         contents = """

--- a/tests/integration/test_project.py
+++ b/tests/integration/test_project.py
@@ -37,6 +37,7 @@ pytz = "*"
 
 @pytest.mark.project
 @pytest.mark.sources
+@pytest.mark.needs_internet
 @pytest.mark.parametrize('lock_first', [True, False])
 def test_get_source(PipenvInstance, lock_first):
     with PipenvInstance(chdir=True) as p:
@@ -121,6 +122,7 @@ def test_maintain_file_line_endings(PipenvInstance, newlines):
 
 @pytest.mark.project
 @pytest.mark.sources
+@pytest.mark.needs_internet
 def test_many_indexes(PipenvInstance):
     with PipenvInstance(chdir=True) as p:
         with open(p.pipfile_path, 'w') as f:
@@ -171,6 +173,7 @@ def test_include_editable_packages(PipenvInstance, testsroot, pathlib_tmpdir):
 
 @pytest.mark.project
 @pytest.mark.virtualenv
+@pytest.mark.needs_internet
 def test_run_in_virtualenv_with_global_context(PipenvInstance, virtualenv):
     with PipenvInstance(chdir=True, venv_root=virtualenv.as_posix(), ignore_virtualenvs=False, venv_in_project=False) as p:
         c = delegator_run(
@@ -209,6 +212,7 @@ def test_run_in_virtualenv_with_global_context(PipenvInstance, virtualenv):
 
 @pytest.mark.project
 @pytest.mark.virtualenv
+@pytest.mark.needs_internet
 def test_run_in_virtualenv(PipenvInstance):
     with PipenvInstance(chdir=True) as p:
         c = p.pipenv('run pip freeze')

--- a/tests/integration/test_sync.py
+++ b/tests/integration/test_sync.py
@@ -24,6 +24,7 @@ def test_sync_error_without_lockfile(PipenvInstance):
 
 @pytest.mark.sync
 @pytest.mark.lock
+@pytest.mark.needs_internet
 def test_mirror_lock_sync(PipenvInstance):
     with temp_environ(), PipenvInstance(chdir=True) as p:
         mirror_url = os.environ.pop('PIPENV_TEST_INDEX', "https://pypi.kennethreitz.org/simple")

--- a/tests/integration/test_windows.py
+++ b/tests/integration/test_windows.py
@@ -71,6 +71,7 @@ def test_local_path_windows_forward_slash(PipenvInstance):
 
 
 @pytest.mark.cli
+@pytest.mark.needs_internet
 def test_pipenv_clean_windows(PipenvInstance):
     with PipenvInstance(chdir=True) as p:
         c = p.pipenv('install requests')


### PR DESCRIPTION
### The issue

#3630

### The fix

Add a `needs_internet` marker to:
* `test_pipenv_clean_pip_no_warnings`
* `test_pipenv_clean_pip_warnings`
* `test_environment_variable_value_does_not_change_hash`
* `test_lock_with_incomplete_source`
* `test_lock_after_update_source_name`
* `test_get_source`
* `test_many_indexes`
* `test_run_in_virtualenv_with_global_context`
* `test_run_in_virtualenv`
* `test_mirror_lock_sync`
* `test_pipenv_clean_windows`

### The checklist

* [x] Associated issue
* [x] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

