### PR TITLE
Parse package names from functions in setup.py

### DIFF
--- a/news/4292.bugfix.rst
+++ b/news/4292.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed an issue with resolving packages with names defined by function calls in ``setup.py``.

--- a/news/4292.vendor.rst
+++ b/news/4292.vendor.rst
@@ -1,0 +1,1 @@
+Updated requirementslib to version ``1.5.11``.

--- a/pipenv/vendor/requirementslib/__init__.py
+++ b/pipenv/vendor/requirementslib/__init__.py
@@ -10,7 +10,7 @@ from .models.lockfile import Lockfile
 from .models.pipfile import Pipfile
 from .models.requirements import Requirement
 
-__version__ = "1.5.10"
+__version__ = "1.5.11"
 
 
 logger = logging.getLogger(__name__)

--- a/pipenv/vendor/requirementslib/models/setup_info.py
+++ b/pipenv/vendor/requirementslib/models/setup_info.py
@@ -974,6 +974,16 @@ class Analyzer(ast.NodeVisitor):
         keys = list(setup.keys())
         if len(keys) == 1 and keys[0] is None:
             _, setup = setup.popitem()
+        keys = list(setup.keys())
+        for k in keys:
+            # XXX: Remove unresolved functions from the setup dictionary
+            if isinstance(setup[k], dict):
+                if not setup[k]:
+                    continue
+                key = next(iter(setup[k].keys()))
+                val = setup[k][key]
+                if key in function_names and val is None or val == {}:
+                    setup.pop(k)
         return setup
 
 
@@ -1204,6 +1214,16 @@ def ast_parse_setup_py(path):
     keys = list(setup.keys())
     if len(keys) == 1 and keys[0] is None:
         _, setup = setup.popitem()
+    keys = list(setup.keys())
+    for k in keys:
+        # XXX: Remove unresolved functions from the setup dictionary
+        if isinstance(setup[k], dict):
+            if not setup[k]:
+                continue
+            key = next(iter(setup[k].keys()))
+            val = setup[k][key]
+            if key in function_names and val is None or val == {}:
+                setup.pop(k)
     return setup
 
 

--- a/pipenv/vendor/vendor.txt
+++ b/pipenv/vendor/vendor.txt
@@ -26,7 +26,7 @@ requests==2.23.0
     idna==2.9
     urllib3==1.25.9
     certifi==2020.4.5.1
-requirementslib==1.5.10
+requirementslib==1.5.11
     attrs==19.3.0
     distlib==0.3.0
     packaging==20.3


### PR DESCRIPTION
- Upstream update to parse package names from unresolveable function
  calls in `setup.py`
- Fixes #4292

Signed-off-by: Dan Ryan <dan.ryan@canonical.com>