### PR TITLE
Fixes bug 4305, which no prompts to installs a pyenv python version that doesn't exist

### DIFF
--- a/news/4305.bugfix.rst
+++ b/news/4305.bugfix.rst
@@ -1,0 +1,1 @@
+Fix a bug where Pipenv doesn't realize the session is interactive

--- a/news/4305.trivial.rst
+++ b/news/4305.trivial.rst
@@ -1,0 +1,1 @@
+Print class name instead of the object reference when using installer to install a python version

--- a/pipenv/environments.py
+++ b/pipenv/environments.py
@@ -341,11 +341,7 @@ PIPENV_SHELL = (
 )
 
 # Internal, to tell whether the command line session is interactive.
-try:
-    SESSION_IS_INTERACTIVE = _isatty(sys.stdout.fileno())
-except UnsupportedOperation:
-    SESSION_IS_INTERACTIVE = _isatty(sys.stdout)
-
+SESSION_IS_INTERACTIVE = _isatty(sys.stdout)
 
 # Internal, consolidated verbosity representation as an integer. The default
 # level is 0, increased for wordiness and decreased for terseness.

--- a/pipenv/installers.py
+++ b/pipenv/installers.py
@@ -71,6 +71,9 @@ class Installer(object):
         self.cmd = self._find_installer()
         super(Installer, self).__init__()
 
+    def __str__(self):
+        return self.__class__.__name__
+
     @abstractmethod
     def _find_installer(self):
         pass


### PR DESCRIPTION
### The issue

Fixes bug #4305 introduced in c23e57b4824e0553ea2e91a2a6c59bff811aac39 which no longer identifies if the tty session is interactive. Which prevents pipenv from using pyenv to install a version of python that doesn't exist in pyenv

When this commit migrated to use [vistir._isatty](https://github.com/sarugaku/vistir/blob/7944195b9ab32375e3706d97e2eb36a0aeca772d/src/vistir/misc.py#L1092) it bypassed `os.isatty` which supports `fileno` while `vistir._isatty` does not. Also since `vistir._isatty` swallows all exceptions we no longer need to catch `UnsupportedOperation` 

### The fix

Instead of passing in the `sys.stdout.fileno()` to `vistir._isatty` pass in the stream

### The checklist

* [x] Associated issue
* [x] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). 