### PR TITLE
Correct the exception to PipenvUsageError

### DIFF
--- a/news/4321.bugfix.rst
+++ b/news/4321.bugfix.rst
@@ -1,0 +1,1 @@
+Fix a bug that ``pipenv uninstall`` throws an exception that does not exist.

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -2231,10 +2231,7 @@ def do_uninstall(
     ensure_project(three=three, python=python, pypi_mirror=pypi_mirror)
     # Un-install all dependencies, if --all was provided.
     if not any([packages, editable_packages, all_dev, all]):
-        raise exceptions.MissingParameter(
-            crayons.red("No package provided!"),
-            ctx=ctx, param_type="parameter",
-        )
+        raise exceptions.PipenvUsageError("No package provided!", ctx=ctx)
     editable_pkgs = [
         Requirement.from_line("-e {0}".format(p)).name for p in editable_packages if p
     ]

--- a/tests/integration/test_uninstall.py
+++ b/tests/integration/test_uninstall.py
@@ -186,3 +186,14 @@ def test_uninstall_all_dev_with_shared_dependencies(PipenvInstance):
         assert c.return_code == 0
 
         assert "six" in p.lockfile["develop"]
+
+
+@pytest.mark.uninstall
+def test_uninstall_missing_parameters(PipenvInstance):
+    with PipenvInstance() as p:
+        c = p.pipenv("install requests")
+        assert c.return_code == 0
+
+        c = p.pipenv("uninstall")
+        assert c.return_code != 0
+        assert "No package provided!" in c.err


### PR DESCRIPTION
### The issue

Fix #4321 


### The checklist

* [x] Associated issue
* [x] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

<!--
### If this is a patch to the `vendor` directory…

Please try to refrain from submitting patches directly to `vendor` or `patched`, but raise your issue to the upstream project instead, and inform Pipenv to upgrade when the upstream project accepts the fix.

A pull request to upgrade vendor packages is strongly discouraged, unless there is a very good reason (e.g. you need to test Pipenv’s integration to a new vendor feature). Pipenv audits and performs vendor upgrades regularly, generally before a new release is about to drop.

If your patch is not or cannot be accepted by upstream, but is essential to Pipenv (make sure to discuss this with maintainers!), please remember to attach a patch file in `tasks/vendoring/patched`, so this divergence from upstream can be recorded and replayed afterwards.
-->
