### PR TITLE
Remove outdated link that points to placeholder site

### DIFF
--- a/docs/_templates/sidebarlogo.html
+++ b/docs/_templates/sidebarlogo.html
@@ -60,7 +60,6 @@
     <li><a href="https://github.com/kennethreitz/records">Records: SQL for Humans</a></li>
     <li><a href="https://frostming.github.io/legit">Legit: Git for Humans</a></li>
     <li><a href="http://docs.python-tablib.org/en/latest/">Tablib: Tabular Datasets</a></li>
-    <li><a href="http://markdownplease.com">Markdown, Please!</a></li>
 </ul>
 
 


### PR DESCRIPTION
### The issue

Outdated link that leads to a placeholder site.

### The fix

Remove the link to the project that apparently no longer exists.
