### PR TITLE
handle python major and minor version correctly in create_pipfile

### DIFF
--- a/news/4379.bugfix.rst
+++ b/news/4379.bugfix.rst
@@ -1,0 +1,1 @@
+Handle Python major and minor versions correctly in Pipfile creation.

--- a/pipenv/project.py
+++ b/pipenv/project.py
@@ -756,8 +756,8 @@ class Project(object):
             else:
                 required_python = self.which("python")
         version = python_version(required_python) or PIPENV_DEFAULT_PYTHON_VERSION
-        if version and len(version) >= 3:
-            data[u"requires"] = {"python_version": version[: len("2.7")]}
+        if version and len(version.split(".")) > 2:
+            data[u"requires"] = {"python_version": ".".join(version.split(".")[:2])}
         self.write_toml(data)
 
     @classmethod


### PR DESCRIPTION
### The issue

#4379 

### The fix

Handle python major and minor version correctly in create_pipfile function.
The previous code only handles one digit of the minor version. This change handles the major minor version correctly.

### The checklist

* [x] Associated issue
* [x] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

<!--
### If this is a patch to the `vendor` directory…

Please try to refrain from submitting patches directly to `vendor` or `patched`, but raise your issue to the upstream project instead, and inform Pipenv to upgrade when the upstream project accepts the fix.

A pull request to upgrade vendor packages is strongly discouraged, unless there is a very good reason (e.g. you need to test Pipenv’s integration to a new vendor feature). Pipenv audits and performs vendor upgrades regularly, generally before a new release is about to drop.

If your patch is not or cannot be accepted by upstream, but is essential to Pipenv (make sure to discuss this with maintainers!), please remember to attach a patch file in `tasks/vendoring/patched`, so this divergence from upstream can be recorded and replayed afterwards.
-->
