### PR TITLE
Fix pipenv not properly entering remote shares.

### DIFF
--- a/news/4438.bugfix.rst
+++ b/news/4438.bugfix.rst
@@ -1,0 +1,1 @@
+Fix pipenv not properly entering remote shares.


### PR DESCRIPTION
### The issue

#4438 

### The fix

Look for letters in `net use` using `win32net` then change directory using drive letter instead of UNC path.


### The checklist

* [x] Associated issue
* [x] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.
