### PR TITLE
Remove not accurate claim

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ Pipenv: Python Development Workflow for Humans
 
 **Pipenv** is a tool that aims to bring the best of all packaging worlds
 (bundler, composer, npm, cargo, yarn, etc.) to the Python world.
-*Windows is a first-class citizen, in our world.*
 
 It automatically creates and manages a virtualenv for your projects, as
 well as adds/removes packages from your `Pipfile` as you


### PR DESCRIPTION
### The issue

Readme contains a misleading claim "*Windows is a first-class citizen, in our world.*".
Since claim itself or use of pipenv overall in Windows is not covered by docs by any means.
Removal of this claim should help save time for newcomers to match alternatives with Windows support.
Claim should be restored once docs properly covering work on Windows and claim can be considered as accurate.

### The fix

Removes a claim for better times.
