### PR TITLE
Fix #4225 - virtualenv name when PIPENV_PYTHON set to filepath

### DIFF
--- a/news/4225.bugfix.rst
+++ b/news/4225.bugfix.rst
@@ -1,0 +1,1 @@
+Fix a bug where setting PIPENV_PYTHON to file path breaks environment name

--- a/pipenv/project.py
+++ b/pipenv/project.py
@@ -443,7 +443,13 @@ class Project(object):
     def virtualenv_name(self):
         # type: () -> str
         sanitized, encoded_hash = self._get_virtualenv_hash(self.name)
-        suffix = "-{0}".format(PIPENV_PYTHON) if PIPENV_PYTHON else ""
+        suffix = ""
+        if PIPENV_PYTHON:
+            if os.path.isabs(PIPENV_PYTHON):
+                suffix = "-{0}".format(os.path.basename(PIPENV_PYTHON))
+            else:
+                suffix = "-{0}".format(PIPENV_PYTHON)
+
         # If the pipfile was located at '/home/user/MY_PROJECT/Pipfile',
         # the name of its virtualenv will be 'my-project-wyUfYPqE'
         return sanitized + "-" + encoded_hash + suffix


### PR DESCRIPTION
### The issue

Fixing #4225

### The fix

If PIPENV_PYTHON is a path, only the last bit of the path gets included in the suffix, thus making sure that the environment name contains no incorrect characters. If it's a python version, the suffix is the version as previously intended. If PIPENV_PYTHON is not set, there is no suffix to the environment name.

I couldn't figure out an appropriate way to write tests for this since there don't seem to be tests created for the original function and new tests would depend on my pyenv setup, but if anyone knows how to test this effectively please let me know.
