### PR TITLE
Bugfix: editable packages matched the wrong metadata directory

### DIFF
--- a/news/4480.bugfix.rst
+++ b/news/4480.bugfix.rst
@@ -1,0 +1,1 @@
+Fix a bug that dist-info inside ``venv`` directory will be mistaken as the editable package's metadata.

--- a/news/4480.vendor.rst
+++ b/news/4480.vendor.rst
@@ -1,0 +1,1 @@
+Update ``requirementslib`` from ``1.5.13`` to ``1.5.14``.

--- a/pipenv/vendor/requirementslib/__init__.py
+++ b/pipenv/vendor/requirementslib/__init__.py
@@ -10,7 +10,7 @@ from .models.lockfile import Lockfile
 from .models.pipfile import Pipfile
 from .models.requirements import Requirement
 
-__version__ = "1.5.13"
+__version__ = "1.5.14"
 
 
 logger = logging.getLogger(__name__)

--- a/pipenv/vendor/requirementslib/models/setup_info.py
+++ b/pipenv/vendor/requirementslib/models/setup_info.py
@@ -465,6 +465,18 @@ class ScandirCloser(object):
             pass
 
 
+def _is_venv_dir(path):
+    # type: (AnyStr) -> bool
+    if os.name == "nt":
+        return os.path.isfile(os.path.join(path, "Scripts/python.exe")) or os.path.isfile(
+            os.path.join(path, "Scripts/activate")
+        )
+    else:
+        return os.path.isfile(os.path.join(path, "bin/python")) or os.path.isfile(
+            os.path.join(path, "bin/activate")
+        )
+
+
 def iter_metadata(path, pkg_name=None, metadata_type="egg-info"):
     # type: (AnyStr, Optional[AnyStr], AnyStr) -> Generator
     if pkg_name is not None:
@@ -472,6 +484,9 @@ def iter_metadata(path, pkg_name=None, metadata_type="egg-info"):
     dirs_to_search = [path]
     while dirs_to_search:
         p = dirs_to_search.pop(0)
+        # Skip when the directory is like a venv
+        if _is_venv_dir(p):
+            continue
         with contextlib.closing(ScandirCloser(p)) as path_iterator:
             for entry in path_iterator:
                 if entry.is_dir():

--- a/pipenv/vendor/vendor.txt
+++ b/pipenv/vendor/vendor.txt
@@ -26,7 +26,7 @@ requests==2.23.0
     idna==2.9
     urllib3==1.25.9
     certifi==2020.4.5.1
-requirementslib==1.5.13
+requirementslib==1.5.14
     attrs==19.3.0
     distlib==0.3.0
     packaging==20.3


### PR DESCRIPTION
### The fix

Fix #4480 

### The checklist

* [x] Associated issue
* [x] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

<!--
### If this is a patch to the `vendor` directory...

Please try to refrain from submitting patches directly to `vendor` or `patched`, but raise your issue to the upstream project instead, and inform Pipenv to upgrade when the upstream project accepts the fix.

A pull request to upgrade vendor packages is strongly discouraged, unless there is a very good reason (e.g. you need to test Pipenv’s integration to a new vendor feature). Pipenv audits and performs vendor upgrades regularly, generally before a new release is about to drop.

If your patch is not or cannot be accepted by upstream, but is essential to Pipenv (make sure to discuss this with maintainers!), please remember to attach a patch file in `tasks/vendoring/patched`, so this divergence from upstream can be recorded and replayed afterwards.
-->
