### PR TITLE
Bugfix/4387 VCS dependencies always satisfy even if the ref has changed

### DIFF
--- a/news/4387.bugfix.rst
+++ b/news/4387.bugfix.rst
@@ -1,0 +1,1 @@
+Fix a bug that VCS dependencies always satisfy even if the ref has changed.

--- a/pipenv/environment.py
+++ b/pipenv/environment.py
@@ -790,6 +790,8 @@ class Environment(object):
                     vcs_type == req.vcs and commit_id == req.commit_hash
                     and direct_url_metadata["url"] == pipfile_part[req.vcs]
                 )
+            elif req.is_vcs or req.is_file_or_url:
+                return False
             elif req.line_instance.specifiers is not None:
                 return req.line_instance.specifiers.contains(
                     match.version, prereleases=True


### PR DESCRIPTION
Fix #4387


### The checklist

* [x] Associated issue
* [x] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

<!--
### If this is a patch to the `vendor` directory...

Please try to refrain from submitting patches directly to `vendor` or `patched`, but raise your issue to the upstream project instead, and inform Pipenv to upgrade when the upstream project accepts the fix.

A pull request to upgrade vendor packages is strongly discouraged, unless there is a very good reason (e.g. you need to test Pipenv’s integration to a new vendor feature). Pipenv audits and performs vendor upgrades regularly, generally before a new release is about to drop.

If your patch is not or cannot be accepted by upstream, but is essential to Pipenv (make sure to discuss this with maintainers!), please remember to attach a patch file in `tasks/vendoring/patched`, so this divergence from upstream can be recorded and replayed afterwards.
-->
