### PR TITLE
Fix the output of ``pipenv scripts`` under Windows platform

### DIFF
--- a/news/4523.bugfix.rst
+++ b/news/4523.bugfix.rst
@@ -1,0 +1,1 @@
+Fix the output of ``pipenv scripts`` under Windows platform.

--- a/pipenv/cli/command.py
+++ b/pipenv/cli/command.py
@@ -9,6 +9,7 @@ from click import (
 )
 
 from ..__version__ import __version__
+from .._compat import fix_utf8
 from ..exceptions import PipenvOptionsError
 from ..patched import crayons
 from ..vendor import click_completion, delegator
@@ -737,7 +738,7 @@ def scripts():
         "{}  {}".format(name.ljust(first_column_width), script)
         for name, script in scripts.items()
     )
-    echo(os.linesep.join(lines))
+    echo(os.linesep.join(fix_utf8(line) for line in lines))
 
 
 if __name__ == "__main__":

--- a/pipenv/cli/command.py
+++ b/pipenv/cli/command.py
@@ -721,20 +721,23 @@ def clean(ctx, state, dry_run=False, bare=False, user=False):
     context_settings=subcommand_context_no_interspersion,
 )
 @common_options
-@argument("args", nargs=-1)
-@pass_state
-def scripts(state, args):
+def scripts():
     """Lists scripts in current environment config."""
     from ..core import project
-    if not project:
-        echo(u"project not found", err=True)
-        exit(1)
+
+    if not project.pipfile_exists:
+        echo("No Pipfile present at project home.", err=True)
+        sys.exit(1)
     scripts = project.parsed_pipfile.get('scripts', {})
-    rpt = u"command\tscript\n"
-    for k, v in scripts.items():
-        rpt += u"{0}\t{1}".format(k, v)
-    echo(rpt)
-    return 0
+    first_column_width = max(len(word) for word in ["Command"] + list(scripts.keys()))
+    second_column_width = max(len(word) for word in ["Script"] + list(scripts.values()))
+    lines = ["{}  Script".format("Command".ljust(first_column_width))]
+    lines.append("{}  {}".format("-" * first_column_width, "-" * second_column_width))
+    lines.extend(
+        "{}  {}".format(name.ljust(first_column_width), script)
+        for name, script in scripts.items()
+    )
+    echo(os.linesep.join(lines))
 
 
 if __name__ == "__main__":

--- a/pipenv/cli/command.py
+++ b/pipenv/cli/command.py
@@ -738,7 +738,7 @@ def scripts():
         "{0:<{width}}  {1}".format(name, script, width=first_column_width)
         for name, script in scripts.items()
     )
-    echo(os.linesep.join(fix_utf8(line) for line in lines))
+    echo("\n".join(fix_utf8(line) for line in lines))
 
 
 if __name__ == "__main__":

--- a/pipenv/cli/command.py
+++ b/pipenv/cli/command.py
@@ -730,12 +730,12 @@ def scripts():
         echo("No Pipfile present at project home.", err=True)
         sys.exit(1)
     scripts = project.parsed_pipfile.get('scripts', {})
-    first_column_width = max(len(word) for word in ["Command"] + list(scripts.keys()))
+    first_column_width = max(len(word) for word in ["Command"] + list(scripts))
     second_column_width = max(len(word) for word in ["Script"] + list(scripts.values()))
-    lines = ["{}  Script".format("Command".ljust(first_column_width))]
+    lines = ["{0:<{width}}  Script".format("Command", width=first_column_width)]
     lines.append("{}  {}".format("-" * first_column_width, "-" * second_column_width))
     lines.extend(
-        "{}  {}".format(name.ljust(first_column_width), script)
+        "{0:<{width}}  {1}".format(name, script, width=first_column_width)
         for name, script in scripts.items()
     )
     echo(os.linesep.join(fix_utf8(line) for line in lines))

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -1662,6 +1662,7 @@ def format_help(help):
     help = help.replace("  open", str(crayons.red("  open", bold=True)))
     help = help.replace("  run", str(crayons.yellow("  run", bold=True)))
     help = help.replace("  shell", str(crayons.yellow("  shell", bold=True)))
+    help = help.replace("  scripts", str(crayons.yellow("  scripts", bold=True)))
     help = help.replace("  sync", str(crayons.green("  sync", bold=True)))
     help = help.replace("  uninstall", str(crayons.magenta("  uninstall", bold=True)))
     help = help.replace("  update", str(crayons.green("  update", bold=True)))


### PR DESCRIPTION
Fix #4523 

Improve the output of `pipenv scripts`

```bash
$ pipenv scripts
Command  Script
-------  ------
mode1    echo 1
mode2    echo 2
mode3    echo 3
```