### PR TITLE
Bugfix: resolver takes the wrong section to validate constraints

### DIFF
--- a/news/4527.bugfix.rst
+++ b/news/4527.bugfix.rst
@@ -1,0 +1,1 @@
+Fix a bug that the resolver takes wrong section to validate constraints.

--- a/pipenv/resolver.py
+++ b/pipenv/resolver.py
@@ -670,7 +670,7 @@ def parse_packages(packages, pre, clear, system, requirements_dir=None):
         print(json.dumps([]))
 
 
-def resolve_packages(pre, clear, verbose, system, write, requirements_dir, packages):
+def resolve_packages(pre, clear, verbose, system, write, requirements_dir, packages, dev):
     from pipenv.utils import create_mirror_source, resolve_deps, replace_pypi_sources
     pypi_mirror_source = (
         create_mirror_source(os.environ["PIPENV_PYPI_MIRROR"])
@@ -709,9 +709,9 @@ def resolve_packages(pre, clear, verbose, system, write, requirements_dir, packa
         requirements_dir=requirements_dir,
     )
     if keep_outdated:
-        results = clean_outdated(results, resolver, project)
+        results = clean_outdated(results, resolver, project, dev)
     else:
-        results = clean_results(results, resolver, project)
+        results = clean_results(results, resolver, project, dev)
     if write:
         with open(write, "w") as fh:
             if not results:
@@ -726,7 +726,7 @@ def resolve_packages(pre, clear, verbose, system, write, requirements_dir, packa
             print(json.dumps([]))
 
 
-def _main(pre, clear, verbose, system, write, requirements_dir, packages, parse_only=False):
+def _main(pre, clear, verbose, system, write, requirements_dir, packages, parse_only=False, dev=False):
     os.environ["PIPENV_REQUESTED_PYTHON_VERSION"] = ".".join([str(s) for s in sys.version_info[:3]])
     os.environ["PIP_PYTHON_PATH"] = str(sys.executable)
     if parse_only:
@@ -738,7 +738,7 @@ def _main(pre, clear, verbose, system, write, requirements_dir, packages, parse_
             requirements_dir=requirements_dir,
         )
     else:
-        resolve_packages(pre, clear, verbose, system, write, requirements_dir, packages)
+        resolve_packages(pre, clear, verbose, system, write, requirements_dir, packages, dev)
 
 
 def main():
@@ -756,7 +756,8 @@ def main():
     os.environ["PYTHONUNBUFFERED"] = str("1")
     parsed = handle_parsed_args(parsed)
     _main(parsed.pre, parsed.clear, parsed.verbose, parsed.system, parsed.write,
-          parsed.requirements_dir, parsed.packages, parse_only=parsed.parse_only)
+          parsed.requirements_dir, parsed.packages, parse_only=parsed.parse_only,
+          dev=parsed.dev)
 
 
 if __name__ == "__main__":

--- a/tests/integration/test_lock.py
+++ b/tests/integration/test_lock.py
@@ -775,3 +775,15 @@ def test_lock_package_with_wildcard_version(PipenvInstance):
         assert "six" in p.lockfile["default"]
         assert "version" in p.lockfile["default"]["six"]
         assert p.lockfile["default"]["six"]["version"] == "==1.11.0"
+
+
+@pytest.mark.lock
+@pytest.mark.install
+def test_default_lock_overwrite_dev_lock(PipenvInstance):
+    with PipenvInstance(chdir=True) as p:
+        c = p.pipenv("install 'click==6.7'")
+        assert c.ok
+        c = p.pipenv("install -d flask")
+        assert c.ok
+        assert p.lockfile["default"]["click"]["version"] == "==6.7"
+        assert p.lockfile["develop"]["click"]["version"] == "==6.7"


### PR DESCRIPTION
The resolver misses the argument `dev`.

Fix #4527


### The checklist

* [x] Associated issue
* [x] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

<!--
### If this is a patch to the `vendor` directory...

Please try to refrain from submitting patches directly to `vendor` or `patched`, but raise your issue to the upstream project instead, and inform Pipenv to upgrade when the upstream project accepts the fix.

A pull request to upgrade vendor packages is strongly discouraged, unless there is a very good reason (e.g. you need to test Pipenv’s integration to a new vendor feature). Pipenv audits and performs vendor upgrades regularly, generally before a new release is about to drop.

If your patch is not or cannot be accepted by upstream, but is essential to Pipenv (make sure to discuss this with maintainers!), please remember to attach a patch file in `tasks/vendoring/patched`, so this divergence from upstream can be recorded and replayed afterwards.
-->
