### PR TITLE
Update pyenv docs to avoid using shim

### DIFF
--- a/docs/diagnose.rst
+++ b/docs/diagnose.rst
@@ -58,14 +58,9 @@ distributions, with version name like ``3.6.4`` or similar.
 ------------------------------------------------------------------
 
 Pipenv by default uses the Python it is installed against to create the
-virtualenv. You can set the ``--python`` option, or
-``$PYENV_ROOT/shims/python`` to let it consult pyenv when choosing the
-interpreter. See :ref:`specifying_versions` for more information.
-
-If you want Pipenv to automatically “do the right thing”, you can set the
-environment variable ``PIPENV_PYTHON`` to ``$PYENV_ROOT/shims/python``. This
-will make Pipenv use pyenv’s active Python version to create virtual
-environments by default.
+virtualenv. You can set the ``--python`` option to ``$(pyenv which python)``
+to use your current pyenv interpreter. See :ref:`specifying_versions` for more
+information.
 
 .. _unknown-local-diagnose:
 

--- a/news/4534.doc.rst
+++ b/news/4534.doc.rst
@@ -1,0 +1,1 @@
+Fix suggested pyenv setup to avoid using shimmed interpreter


### PR DESCRIPTION
### The issue

Fixes #4534 

### The fix

Fixes the issue by using the absolute path to the desired Python version, rather than relying on the shim.

### The checklist

* [x] Associated issue
* [x] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.