### PR TITLE
Fix for: --skip-lock: tomlkit.exceptions.NonExistentKey: 'Key "source" does not exist

### DIFF
--- a/news/4141.bugfix.rst
+++ b/news/4141.bugfix.rst
@@ -1,0 +1,1 @@
+Fix a bug where passing --skip-lock when PIPFILE has no [SOURCE] section throws the error: "tomlkit.exceptions.NonExistentKey: 'Key "source" does not exist.'"

--- a/pipenv/project.py
+++ b/pipenv/project.py
@@ -821,8 +821,10 @@ class Project(object):
         from .vendor.plette.lockfiles import PIPFILE_SPEC_CURRENT
         if self.lockfile_exists:
             sources = self.lockfile_content.get("_meta", {}).get("sources", [])
-        else:
+        elif "source" in self.parsed_pipfile:
             sources = [dict(source) for source in self.parsed_pipfile["source"]]
+        else:
+            sources = self.pipfile_sources
         if not isinstance(sources, list):
             sources = [sources]
         return {

--- a/tests/integration/test_project.py
+++ b/tests/integration/test_project.py
@@ -233,8 +233,7 @@ def test_run_in_virtualenv(PipenvInstance):
 
 @pytest.mark.project
 @pytest.mark.sources
-@pytest.mark.needs_internet
-def test_not_sources_in_pipfile(PipenvInstance):
+def test_no_sources_in_pipfile(PipenvInstance):
     with PipenvInstance(chdir=True) as p:
         with open(p.pipfile_path, 'w') as f:
             contents = """

--- a/tests/integration/test_project.py
+++ b/tests/integration/test_project.py
@@ -230,3 +230,18 @@ def test_run_in_virtualenv(PipenvInstance):
         c = p.pipenv("clean --dry-run")
         assert c.return_code == 0
         assert "click" in c.out
+
+@pytest.mark.project
+@pytest.mark.sources
+@pytest.mark.needs_internet
+def test_not_sources_in_pipfile(PipenvInstance):
+    with PipenvInstance(chdir=True) as p:
+        with open(p.pipfile_path, 'w') as f:
+            contents = """
+[packages]
+pytest = "*"
+            """.format(os.environ['PIPENV_TEST_INDEX']).strip()
+            f.write(contents)
+        c = p.pipenv('install --skip-lock')
+        assert c.return_code == 0
+


### PR DESCRIPTION
### The issue
Issue #4141 --skip-lock: tomlkit.exceptions.NonExistentKey: 'Key "source" does not exist.'

### The fix
Following the tip from @uranusjr, I set the sources to [DEFAULT_SOURCE] if the section [Sources] does not exist in PIPFILE.
### The checklist

* [ ] Associated issue
* [ ] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

<!--
### If this is a patch to the `vendor` directory...

Please try to refrain from submitting patches directly to `vendor` or `patched`, but raise your issue to the upstream project instead, and inform Pipenv to upgrade when the upstream project accepts the fix.

A pull request to upgrade vendor packages is strongly discouraged, unless there is a very good reason (e.g. you need to test Pipenv’s integration to a new vendor feature). Pipenv audits and performs vendor upgrades regularly, generally before a new release is about to drop.

If your patch is not or cannot be accepted by upstream, but is essential to Pipenv (make sure to discuss this with maintainers!), please remember to attach a patch file in `tasks/vendoring/patched`, so this divergence from upstream can be recorded and replayed afterwards.
-->