### PR TITLE
Correct python_version in pep508checker.py

### DIFF
--- a/news/4602.bugfix.rst
+++ b/news/4602.bugfix.rst
@@ -1,0 +1,1 @@
+Fix a bug where ``pep508checker.py`` did not expect double-digit Python minor versions (e.g. "3.10").

--- a/pipenv/pep508checker.py
+++ b/pipenv/pep508checker.py
@@ -31,7 +31,7 @@ lookup = {
     "platform_release": platform.release(),
     "platform_system": platform.system(),
     "platform_version": platform.version(),
-    "python_version": platform.python_version()[:3],
+    "python_version": ".".join(platform.python_version().split(".")[:2]),
     "python_full_version": platform.python_version(),
     "implementation_name": implementation_name,
     "implementation_version": implementation_version,


### PR DESCRIPTION
### The issue

Fix https://github.com/pypa/pipenv/issues/4602

### The fix

This includes all characters up to the second `"."` (instead of just the first 3 characters),
which should correct version-handling for Python 3.10.

### The checklist

* [x] Associated issue
* [x] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.