### PR TITLE
Update index.rst

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -48,15 +48,19 @@ You can quickly play with Pipenv right in your browser:
 Install Pipenv Today!
 ---------------------
 
-If you're on MacOS, you can install Pipenv easily with Homebrew. You can also use Linuxbrew on Linux using the same command::
+If you already have Python and pip, you can easily install Pipenv into your home directory::
 
-    $ brew install pipenv
+    $ pip install --user pipenv
 
 Or, if you're using Fedora 28::
 
     $ sudo dnf install pipenv
 
-Otherwise, refer to the :ref:`installing-pipenv` chapter for instructions.
+It's possible to install Pipenv with Homebrew on MacOS, or with Linuxbrew on Linux systems. However, **this is now discouraged**, because updates to the brewed Python distribution will break Pipenv, and perhaps all virtual environments managed by it. You'll then need to re-install Pipenv at least. If you want to give it a try despite this warning, use::
+
+    $ brew install pipenv
+
+More detailed installation instructions can be found in the :ref:`installing-pipenv` chapter.
 
 ✨🍰✨
 


### PR DESCRIPTION
Closes #4462

### The fix

Installation via Homebrew is no longer the first suggestion on the homepage. (The installation page discourages this method.) Instead, the 'pragmatic installation' of Pipenv is suggested.

The Fedora 28+ installation method is retained ( I have no experience of this).

Homebrew instructions are kept here too, but with caveats. It might be better to remove these altogether, but Homebrew users might wish to experiment first.

### The checklist

* No associated issues.
* A news fragment in the `news/` directory would be overkill.
