### PR TITLE
drop python2 from CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,7 +39,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [2.7, 3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8]
         os: [MacOS, Ubuntu, Windows]
 
     steps:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -81,9 +81,6 @@ jobs:
     vmImage: 'Ubuntu-latest'
   strategy:
     matrix:
-      "2.7":
-        python.version: '2.7'
-        python.architecture: x64
       "3.6":
         python.version: '3.6'
         python.architecture: x64
@@ -106,9 +103,6 @@ jobs:
     vmImage: windows-latest
   strategy:
     matrix:
-      "2.7":
-        python.version: '2.7'
-        python.architecture: x64
       "3.6":
         python.version: '3.6'
         python.architecture: x64
@@ -130,9 +124,6 @@ jobs:
     vmImage: macOS-latest
   strategy:
     matrix:
-      "2.7":
-        python.version: '2.7'
-        python.architecture: x64
       "3.6":
         python.version: '3.6'
         python.architecture: x64


### PR DESCRIPTION
### The issue

PIP dropped Python 2 support https://github.com/pypa/pip/issues/6148, therefore pipenv needs to drop Python 2 and make performance improvements.

I would like to volunteer sometime to drop Python 2.

### The fix

Let's drop Python 2 from CI, then we can do other cleanups safely.

### The checklist

* [ ] Associated issue
* [ ] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

<!--
### If this is a patch to the `vendor` directory...

Please try to refrain from submitting patches directly to `vendor` or `patched`, but raise your issue to the upstream project instead, and inform Pipenv to upgrade when the upstream project accepts the fix.

A pull request to upgrade vendor packages is strongly discouraged, unless there is a very good reason (e.g. you need to test Pipenv’s integration to a new vendor feature). Pipenv audits and performs vendor upgrades regularly, generally before a new release is about to drop.

If your patch is not or cannot be accepted by upstream, but is essential to Pipenv (make sure to discuss this with maintainers!), please remember to attach a patch file in `tasks/vendoring/patched`, so this divergence from upstream can be recorded and replayed afterwards.
-->
