### PR TITLE
Add homebrew as an install option in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,11 @@ Or, if you\'re using FreeBSD:
 
     # pkg install py36-pipenv
 
+Or, if you\'re using OSX:
+
+    # brew install pipenv
+
+
 When none of the above is an option, it is recommended to use [Pipx](https://pypi.org/p/pipx):
 
     $ pipx install pipenv

--- a/news/4613.doc.rst
+++ b/news/4613.doc.rst
@@ -1,0 +1,1 @@
+Add ``brew install pipenv`` to the readme for consistency with the sphinx docs.


### PR DESCRIPTION

### The issue

There is documentation inconsistency between this repo's README.md and [the sphinx docs](https://pipenv.pypa.io/en/latest/#install-pipenv-today) around installation options.


### The fix

Add a line item for brew installation to the readme installation list.  `brew` is a very common package management utility for OSX.

### The checklist

* [ ] Associated issue
* [x] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

<!--
### If this is a patch to the `vendor` directory...

Please try to refrain from submitting patches directly to `vendor` or `patched`, but raise your issue to the upstream project instead, and inform Pipenv to upgrade when the upstream project accepts the fix.

A pull request to upgrade vendor packages is strongly discouraged, unless there is a very good reason (e.g. you need to test Pipenv’s integration to a new vendor feature). Pipenv audits and performs vendor upgrades regularly, generally before a new release is about to drop.

If your patch is not or cannot be accepted by upstream, but is essential to Pipenv (make sure to discuss this with maintainers!), please remember to attach a patch file in `tasks/vendoring/patched`, so this divergence from upstream can be recorded and replayed afterwards.
-->
