### PR TITLE
Fix #4615 - Improve sanitization to allow virtualenv paths with () and [] characters to activate

### DIFF
--- a/news/4615.bugfix.rst
+++ b/news/4615.bugfix.rst
@@ -1,1 +1,1 @@
-Fix bug where environment wouldn't activate in paths containing () and [] symbols - Related to #4538
+Fix bug where environment wouldn't activate in paths containing () and [] symbols

--- a/news/4615.bugfix.rst
+++ b/news/4615.bugfix.rst
@@ -1,0 +1,1 @@
+Fix bug where environment wouldn't activate in paths containing () and [] symbols - Related to #4538

--- a/pipenv/project.py
+++ b/pipenv/project.py
@@ -395,7 +395,7 @@ class Project(object):
         #   https://www.gnu.org/software/bash/manual/html_node/Double-Quotes.html
         #   http://www.tldp.org/LDP/abs/html/special-chars.html#FIELDREF
         #   https://github.com/torvalds/linux/blob/2bfe01ef/include/uapi/linux/binfmts.h#L18
-        return re.sub(r'[ &$`!*@"\\\r\n\t]', "_", name)[0:42]
+        return re.sub(r'[ &$`!*@"()\[\]\\\r\n\t]', "_", name)[0:42]
 
     def _get_virtualenv_hash(self, name):
         # type: (str) -> str

--- a/pipenv/shells.py
+++ b/pipenv/shells.py
@@ -50,7 +50,7 @@ def _get_activate_script(cmd, venv):
         command = "."
     # Escape any special characters located within the virtualenv path to allow
     # for proper activation.
-    venv_location = re.sub(r'([ &$])', r"\\\1", str(venv))
+    venv_location = re.sub(r'([ &$()\[\]])', r"\\\1", str(venv))
     # The leading space can make history cleaner in some shells.
     return " {2} {0}/bin/activate{1}".format(venv_location, suffix, command)
 


### PR DESCRIPTION
### The issue

Fixes #4615.
Related to #4538.

### The fix

Added proper character escaping for `()` and `[]` characters in virtualenv paths, by modifying the regex in `_get_activate_script()` in `pipenv/shells.py`.

Also improved sanitization in `_sanitize()` of `Project` class in `pipenv/project.py` to turn `()` and `[]` characters into `_`.

These changes allows virtualenv paths with such characters to properly activate.

### The checklist

* [x] Associated issue
* [x] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.