### PR TITLE
4642 fix pipenv lock --pre doesn't include prerelease dependencies

### DIFF
--- a/news/4642.bugfix.rst
+++ b/news/4642.bugfix.rst
@@ -1,0 +1,1 @@
+Fix bug preventing use of pipenv lock --pre

--- a/pipenv/utils.py
+++ b/pipenv/utils.py
@@ -705,7 +705,7 @@ class Resolver(object):
             pip_args.append("--no-use-pep517")
         if build_isolation is False:
             pip_args.append("--no-build-isolation")
-        if pre is True:
+        if self.pre:
             pip_args.append("--pre")
         pip_args.extend(["--cache-dir", environments.PIPENV_CACHE_DIR])
         return pip_args

--- a/pipenv/utils.py
+++ b/pipenv/utils.py
@@ -697,7 +697,7 @@ class Resolver(object):
             self._pip_command = self._get_pip_command()
         return self._pip_command
 
-    def prepare_pip_args(self, use_pep517=False, build_isolation=True, pre=False):
+    def prepare_pip_args(self, use_pep517=False, build_isolation=True):
         pip_args = []
         if self.sources:
             pip_args = prepare_pip_source_args(self.sources, pip_args)
@@ -712,12 +712,11 @@ class Resolver(object):
 
     @property
     def pip_args(self):
-        pre = self.pre
         use_pep517 = environments.get_from_env("USE_PEP517", prefix="PIP")
         build_isolation = environments.get_from_env("BUILD_ISOLATION", prefix="PIP")
         if self._pip_args is None:
             self._pip_args = self.prepare_pip_args(
-                use_pep517=use_pep517, build_isolation=build_isolation, pre=pre
+                use_pep517=use_pep517, build_isolation=build_isolation
             )
         return self._pip_args
 

--- a/pipenv/utils.py
+++ b/pipenv/utils.py
@@ -697,7 +697,7 @@ class Resolver(object):
             self._pip_command = self._get_pip_command()
         return self._pip_command
 
-    def prepare_pip_args(self, use_pep517=False, build_isolation=True):
+    def prepare_pip_args(self, use_pep517=False, build_isolation=True, pre=False):
         pip_args = []
         if self.sources:
             pip_args = prepare_pip_source_args(self.sources, pip_args)
@@ -705,16 +705,19 @@ class Resolver(object):
             pip_args.append("--no-use-pep517")
         if build_isolation is False:
             pip_args.append("--no-build-isolation")
+        if pre is True:
+            pip_args.append("--pre")
         pip_args.extend(["--cache-dir", environments.PIPENV_CACHE_DIR])
         return pip_args
 
     @property
     def pip_args(self):
+        pre = self.pre
         use_pep517 = environments.get_from_env("USE_PEP517", prefix="PIP")
         build_isolation = environments.get_from_env("BUILD_ISOLATION", prefix="PIP")
         if self._pip_args is None:
             self._pip_args = self.prepare_pip_args(
-                use_pep517=use_pep517, build_isolation=build_isolation
+                use_pep517=use_pep517, build_isolation=build_isolation, pre=pre
             )
         return self._pip_args
 


### PR DESCRIPTION
### The issue

#4642 
pipenv lock --pre doesn't actually include prerelease dependencies

### The fix

Used the already existing self.pre variable to append --pre to a built command that ultimately results in prerelease dependencies being included in the locking process. This seems to be consistent with conventions at least within that file, and doesn't require additional fields to be defined.


### The checklist

* [x] Associated issue
* [x] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.
