### PR TITLE
diagnose.rst: Remove outdated -c docs

### DIFF
--- a/docs/diagnose.rst
+++ b/docs/diagnose.rst
@@ -96,18 +96,6 @@ This may be related to your locale setting. See :ref:`unknown-local-diagnose`
 for a possible solution.
 
 
-☤ ``shell`` does not show the virtualenv’s name in prompt
----------------------------------------------------------
-
-This is intentional. You can do it yourself with either shell plugins, or
-clever ``PS1`` configuration. If you really want it back, use
-
-::
-
-    pipenv shell -c
-
-instead (not available on Windows).
-
 ☤ Pipenv does not respect dependencies in setup.py
 --------------------------------------------------
 


### PR DESCRIPTION
Suggested in https://github.com/pypa/pipenv/issues/2910#issuecomment-426484374.

I took the easy way out here by removing these docs altogether. If someone wants to go ahead and document the `--fancy` approach, it would be great. I don't know so much of how it works myself.