### PR TITLE
Small refactoration removing two avoidable indexer iterator

### DIFF
--- a/pipenv/vendor/pipreqs/pipreqs.py
+++ b/pipenv/vendor/pipreqs/pipreqs.py
@@ -348,9 +348,8 @@ def compare_modules(file_, imports):
                specified file.
     """
     modules = parse_requirements(file_)
-
-    imports = [imports[i]["name"] for i in range(len(imports))]
-    modules = [modules[i]["name"] for i in range(len(modules))]
+    imports = [i["name"] for i in imports]
+    modules = [i["name"] for i in modules]
     modules_not_imported = set(modules) - set(imports)
 
     return modules_not_imported


### PR DESCRIPTION
### The issue
The PR is only a tiny code refactoration which is intented to remove what I use to call 'avoidable indexer iterator'.
I just changed two lines of code, turning two operations on this model:
>[imports[i]["name"] for i in range(len(imports))]

To this model:

>[i["name"] for i in imports]

With that we are calling two less methods (range and len) and avoiding the use of the direct indexer imports[i] and made it easier to read.

Thanks.
