### PR TITLE
Update __init__.py

### DIFF
--- a/pipenv/patched/notpip/__init__.py
+++ b/pipenv/patched/notpip/__init__.py
@@ -4,7 +4,7 @@ if MYPY_CHECK_RUNNING:
     from typing import List, Optional
 
 
-__version__ = "20.0.2"
+__version__ = "21.1.1"
 
 
 def main(args=None):


### PR DESCRIPTION
Updates pip version to fix security issue reported in pipenv check

Thank you for contributing to Pipenv!


### The issue

Using pip <21.1 makes `pipenv check` report a security issue:

```
Pip 21.1 stops splitting on unicode separators in git references, which could be maliciously used to install a different revision on the repository. See: <https://github.com/pypa/pip/issues/9827>. Additionally, pip 21.1 updates urllib3 to 1.26.4 to fix CVE-2021-28363.
```

More info here: https://github.com/pypa/pipenv/issues/4689

### The fix

Pins the latest version of `pip`.


### The checklist

* [ ] Associated issue
* [ ] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

<!--
### If this is a patch to the `vendor` directory...

Please try to refrain from submitting patches directly to `vendor` or `patched`, but raise your issue to the upstream project instead, and inform Pipenv to upgrade when the upstream project accepts the fix.

A pull request to upgrade vendor packages is strongly discouraged, unless there is a very good reason (e.g. you need to test Pipenv’s integration to a new vendor feature). Pipenv audits and performs vendor upgrades regularly, generally before a new release is about to drop.

If your patch is not or cannot be accepted by upstream, but is essential to Pipenv (make sure to discuss this with maintainers!), please remember to attach a patch file in `tasks/vendoring/patched`, so this divergence from upstream can be recorded and replayed afterwards.
-->
