### PR TITLE
Windows install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ Or, if you\'re using Fedora:
 Or, if you\'re using FreeBSD:
 
     # pkg install py36-pipenv
+    
+Or, if you\'re using Windows:
+
+    # pip install --user pipenv
 
 When none of the above is an option, it is recommended to use [Pipx](https://pypi.org/p/pipx):
 


### PR DESCRIPTION
### The issue

The readme doesn't have the command to install on Windows. 

### The fix

Added the command to install on Windows to the readme. 
