### PR TITLE
Fix basic usage docs to reflect lock -r behaviour

### DIFF
--- a/docs/basics.rst
+++ b/docs/basics.rst
@@ -409,5 +409,5 @@ production environments for reproducible builds.
 .. note::
 
     If you'd like a ``requirements.txt`` output of the lockfile, run ``$ pipenv lock -r``.
-    This will include all hashes, however (which is great!). To get a ``requirements.txt``
-    without hashes, use ``$ pipenv run pip freeze``.
+    This will not include hashes, however. To get a ``requirements.txt``
+    you can also use ``$ pipenv run pip freeze``.


### PR DESCRIPTION
The pre-existing basic usage documentation says that "pipenv lock -r" would include hashes in requirements.txt, this is not the behaviour i observe - i didn't find any issue around this - i guess it's either a bug or just the documentation is wrong.

Digging through the code it looks reasonably plain that it just does not include hashes in its output - there is no logic or option there:

https://github.com/pypa/pipenv/blob/master/pipenv/core.py#L849

