### PR TITLE
Replace call to add_stylesheet with add_css_file

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -124,7 +124,7 @@ html_static_path = ['_static']
 
 
 def setup(app):
-    app.add_stylesheet('custom.css')
+    app.add_css_file('custom.css')
 
 
 # -- Options for HTMLHelp output ------------------------------------------

--- a/news/4723.feature.rst
+++ b/news/4723.feature.rst
@@ -1,0 +1,1 @@
+pipenv's documentation can be built using Sphinx 4.x


### PR DESCRIPTION
This way it is possible to build documentation with Sphinx 4.x

Thank you for contributing to Pipenv!

### The issue

Package documentation stopped building with Sphinx 4 as a result of removal of `add_stylesheet` function.
Using `add_css_file` instead makes it possible to build on both Sphinx 3.5.x and Sphinx 4.x

### The fix

Replacement of a function call, no other measurements are needed.


### The checklist

* [x] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.


