### PR TITLE
Fix compatibility with click version 8

### DIFF
--- a/pipenv/cli/command.py
+++ b/pipenv/cli/command.py
@@ -5,7 +5,7 @@ import os
 import sys
 
 from click import (
-    argument, echo, edit, group, option, pass_context, secho, version_option, Choice
+    argument, echo, edit, group, option, pass_context, secho, types, version_option, Choice
 )
 
 from ..__version__ import __version__
@@ -459,7 +459,8 @@ def run(state, command, args):
 @option(
     "--unused",
     nargs=1,
-    default=False,
+    default="",
+    type=types.STRING,
     help="Given a code path, show potentially unused dependencies.",
 )
 @option(

--- a/pipenv/cli/options.py
+++ b/pipenv/cli/options.py
@@ -235,9 +235,10 @@ def python_option(f):
         if value is not None:
             state.python = validate_python_path(ctx, param, value)
         return value
-    return option("--python", default=False, nargs=1, callback=callback,
+    return option("--python", default="", nargs=1, callback=callback,
                   help="Specify which version of Python virtualenv should use.",
-                  expose_value=False, allow_from_autoenv=False)(f)
+                  expose_value=False, allow_from_autoenv=False,
+                  type=click.types.STRING)(f)
 
 
 def pypi_mirror_option(f):
@@ -318,8 +319,9 @@ def requirementstxt_option(f):
         if value:
             state.installstate.requirementstxt = value
         return value
-    return option("--requirements", "-r", nargs=1, default=False, expose_value=False,
-                  help="Import a requirements.txt file.", callback=callback)(f)
+    return option("--requirements", "-r", nargs=1, default="", expose_value=False,
+                  help="Import a requirements.txt file.", callback=callback,
+                  type=click.types.STRING)(f)
 
 
 def emit_requirements_flag(f):
@@ -358,9 +360,9 @@ def code_option(f):
         if value:
             state.installstate.code = value
         return value
-    return option("--code", "-c", nargs=1, default=False, help="Install packages "
+    return option("--code", "-c", nargs=1, default="", help="Install packages "
                   "automatically discovered from import statements.", callback=callback,
-                  expose_value=False)(f)
+                  expose_value=False, type=click.types.STRING)(f)
 
 
 def deploy_option(f):


### PR DESCRIPTION
In the new version of click, if an option has no type and a default value is of type bool, the default type is bool and the required value for the option is also bool which is not correct for options like --code, --requirements, or --python.

Click 7:
```
# pipenv install --help | egrep "TEXT|BOOLEAN"
  -c, --code TEXT                 Install packages automatically discovered
  -e, --editable TEXT             An editable Python package URL or path,
  -r, --requirements TEXT         Import a requirements.txt file.
  --extra-index-url TEXT          URLs to the extra PyPI compatible indexes to
  -i, --index TEXT                Target PyPI-compatible package index url.
  --python TEXT                   Specify which version of Python virtualenv
  --pypi-mirror TEXT              Specify a PyPI mirror.
```

Click 8:
```
# pipenv install --help | egrep "TEXT|BOOLEAN"
  -c, --code BOOLEAN              Install packages automatically discovered
  -e, --editable TEXT             An editable Python package URL or path,
  -r, --requirements BOOLEAN      Import a requirements.txt file.
  --extra-index-url TEXT          URLs to the extra PyPI compatible indexes to
  -i, --index TEXT                Target PyPI-compatible package index url.
  --python BOOLEAN                Specify which version of Python virtualenv
  --pypi-mirror TEXT              Specify a PyPI mirror.
```

As you can see above, the new behavior is not a problem for some of the options because --index and --editable have a specific type, --extra-index-url has a string as a default value, etc.

This change should not affect pipenv in any way and should make it more compatible with the new version of click which pipenv surely vendor soon.

Also, explicit is better than implicit :smiley: 