### PR TITLE
Improve documentation for PIPENV_YES / Automatic Installation of python versions

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -325,6 +325,8 @@ This allows you to easily read the code you're consuming, instead of looking it 
 
 If you have `pyenv <https://github.com/pyenv/pyenv#simple-python-version-management-pyenv>`_ installed and configured, Pipenv will automatically ask you if you want to install a required version of Python if you don't already have it available.
 
+.. note:: If you're operating in a CI environment you should set the `PIPENV_YES` environment variable to enable this functionality.
+
 This is a very fancy feature, and we're very proud of it::
 
     $ cat Pipfile

--- a/pipenv/environments.py
+++ b/pipenv/environments.py
@@ -279,6 +279,9 @@ PIPENV_YES = bool(os.environ.get("PIPENV_YES"))
 
 Default is to prompt the user for an answer if the current command line session
 if interactive.
+
+If operating on CI with `pyenv` configured, this flag *must* be set if you wish `pipenv` to automatically 
+install python versions specified in `[requires]` 
 """
 
 PIPENV_SKIP_LOCK = False


### PR DESCRIPTION
### The issue

When coming to improve our CI infrastructure, It took considerable time to deduce why `pipenv` wasn't giving us a prompt to install python versions specificed in `pipfile` `[requires]` - When reverse shelling into the build agent we would be prompted but not when executing a job remotely. After investigation we found that the `PIPENV_YES` variable must be set for this functionality to work correctly.

### The fix

This PR updates the documentation both for `PIPENV_YES` and also for the `☤ Automatic Python Installation` page to clarify that the environment variable needs setting for `pipenv` and `pyenv` to interact correctly when in a CI environment to make it easier for other Build and Config engineers to get this awesome functionality working :) 
