### PR TITLE
Refactor: replace shared states with create-on-demand

### DIFF
--- a/.azure-pipelines/steps/run-tests-linux.yml
+++ b/.azure-pipelines/steps/run-tests-linux.yml
@@ -21,10 +21,11 @@ steps:
     # Fix Git SSL errors
     echo "Using pipenv python version: $(PIPENV_DEFAULT_PYTHON_VERSION)"
     git submodule sync && git submodule update --init --recursive
-    pipenv run pytest -n 4 -v --junitxml=junit/test-results.xml tests
+    pipenv run pytest -v -n auto --junitxml=junit/test-results.xml tests
   displayName: Run integration tests
   env:
     PYTHONWARNINGS: ignore:DEPRECATION
     PIPENV_NOSPIN: '1'
+    CI: 1
     PIPENV_DEFAULT_PYTHON_VERSION: ${{ parameters.python_version }}
     GIT_SSH_COMMAND: ssh -o StrictHostKeyChecking=accept-new -o CheckHostIP=no

--- a/.azure-pipelines/steps/run-tests-linux.yml
+++ b/.azure-pipelines/steps/run-tests-linux.yml
@@ -21,7 +21,7 @@ steps:
     # Fix Git SSL errors
     echo "Using pipenv python version: $(PIPENV_DEFAULT_PYTHON_VERSION)"
     git submodule sync && git submodule update --init --recursive
-    pipenv run pytest -v -n auto --junitxml=junit/test-results.xml tests
+    pipenv run pytest -v -n auto --durations=10 --junitxml=junit/test-results.xml tests
   displayName: Run integration tests
   env:
     PYTHONWARNINGS: ignore:DEPRECATION

--- a/.azure-pipelines/steps/run-tests-windows.yml
+++ b/.azure-pipelines/steps/run-tests-windows.yml
@@ -47,11 +47,12 @@ steps:
       git submodule sync
       git submodule update --init --recursive
       $venv = (pipenv --venv)[0]
-      & $venv/Scripts/pytest.exe -ra -n 4 -v --junit-xml=junit/test-results.xml tests/
+      & $venv/Scripts/pytest.exe -ra -n auto -v --junit-xml=junit/test-results.xml tests/
     failOnStderr: false
     displayName: Run integration tests
     env:
       TEMP: 'R:\'
       PYTHONWARNINGS: 'ignore:DEPRECATION'
       PIPENV_NOSPIN: 1
+      CI: 1
       GIT_SSH_COMMAND: ssh -o StrictHostKeyChecking=accept-new -o CheckHostIP=no

--- a/.azure-pipelines/steps/run-tests-windows.yml
+++ b/.azure-pipelines/steps/run-tests-windows.yml
@@ -47,7 +47,7 @@ steps:
       git submodule sync
       git submodule update --init --recursive
       $venv = (pipenv --venv)[0]
-      & $venv/Scripts/pytest.exe -ra -n auto -v --junit-xml=junit/test-results.xml tests/
+      & $venv/Scripts/pytest.exe -ra -n auto -v --durations=10 --junit-xml=junit/test-results.xml tests/
     failOnStderr: false
     displayName: Run integration tests
     env:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -80,4 +80,4 @@ jobs:
         PYTHONIOENCODING: 'utf-8'
         GIT_SSH_COMMAND: ssh -o StrictHostKeyChecking=accept-new -o CheckHostIP=no
       run: |
-        pipenv run pytest -ra -n 4 tests
+        pipenv run pytest -ra -n auto tests

--- a/pipenv/cli/command.py
+++ b/pipenv/cli/command.py
@@ -76,7 +76,7 @@ def cli(
         from .. import shells
 
         try:
-            shell = shells.detect_info()[0]
+            shell = shells.detect_info(state.project)[0]
         except shells.ShellDetectionFailure:
             echo(
                 "Fail to detect shell. Please provide the {} environment "
@@ -103,8 +103,7 @@ def cli(
             return 1
     if envs:
         echo("The following environment variables can be set, to do various things:\n")
-        from .. import environments
-        for key in environments.__dict__:
+        for key in state.project.__dict__:
             if key.startswith("PIPENV"):
                 echo(f"  - {crayons.normal(key, bold=True)}")
         echo(
@@ -115,7 +114,7 @@ def cli(
             )
         )
         return 0
-    warn_in_virtualenv()
+    warn_in_virtualenv(state.project)
     if ctx.invoked_subcommand is None:
         # --where was passed...
         if where:
@@ -153,8 +152,7 @@ def cli(
         # --rm was passed...
         elif rm:
             # Abort if --system (or running in a virtualenv).
-            from ..environments import PIPENV_USE_SYSTEM
-            if PIPENV_USE_SYSTEM:
+            if state.project.s.PIPENV_USE_SYSTEM:
                 echo(
                     crayons.red(
                         "You are attempting to remove a virtualenv that "
@@ -172,7 +170,7 @@ def cli(
                         )
                     )
                 )
-                with create_spinner(text="Running..."):
+                with create_spinner(text="Running...", setting=state.project.s):
                     # Remove the virtualenv.
                     cleanup_virtualenv(state.project, bare=True)
                 return 0

--- a/pipenv/cli/command.py
+++ b/pipenv/cli/command.py
@@ -1,11 +1,6 @@
 import os
 import sys
 
-from click import (
-    Choice, argument, echo, edit, group, option, pass_context, secho, types,
-    version_option
-)
-
 from pipenv.__version__ import __version__
 from pipenv._compat import fix_utf8
 from pipenv.cli.options import (
@@ -18,6 +13,10 @@ from pipenv.exceptions import PipenvOptionsError
 from pipenv.patched import crayons
 from pipenv.utils import subprocess_run
 from pipenv.vendor import click_completion
+from pipenv.vendor.click import (
+    Choice, argument, echo, edit, group, option, pass_context, secho, types,
+    version_option
+)
 
 
 # Enable shell completion.
@@ -626,9 +625,7 @@ def run_open(state, module, *args, **kwargs):
 
         EDITOR=atom pipenv open requests
     """
-    from ..core import (
-        ensure_project, inline_activate_virtual_environment
-    )
+    from ..core import ensure_project, inline_activate_virtual_environment
 
     # Ensure that virtualenv is available.
     ensure_project(

--- a/pipenv/cli/options.py
+++ b/pipenv/cli/options.py
@@ -3,9 +3,12 @@ import os
 import click.types
 
 from click import (
-    BadParameter, BadArgumentUsage, Group, Option, argument, echo, make_pass_decorator, option
+    BadArgumentUsage, BadParameter, Group, Option, argument, echo,
+    make_pass_decorator, option
 )
 from click_didyoumean import DYMMixin
+
+from pipenv.project import Project
 
 from .. import environments
 from ..utils import is_valid_url
@@ -89,6 +92,7 @@ class LockOptions:
 
 
 pass_state = make_pass_decorator(State, ensure=True)
+pass_project = make_pass_decorator(Project, ensure=True)
 
 
 def index_option(f):

--- a/pipenv/cli/options.py
+++ b/pipenv/cli/options.py
@@ -9,9 +9,7 @@ from click import (
 from click_didyoumean import DYMMixin
 
 from pipenv.project import Project
-
-from .. import environments
-from ..utils import is_valid_url
+from pipenv.utils import is_valid_url
 
 
 CONTEXT_SETTINGS = {
@@ -245,11 +243,12 @@ def python_option(f):
 def pypi_mirror_option(f):
     def callback(ctx, param, value):
         state = ctx.ensure_object(State)
+        value = value or state.project.s.PIPENV_PYPI_MIRROR
         if value is not None:
             state.pypi_mirror = validate_pypi_mirror(ctx, param, value)
         return value
-    return option("--pypi-mirror", default=environments.PIPENV_PYPI_MIRROR, nargs=1,
-                  callback=callback, help="Specify a PyPI mirror.", expose_value=False)(f)
+    return option("--pypi-mirror", nargs=1, callback=callback,
+                  help="Specify a PyPI mirror.", expose_value=False)(f)
 
 
 def verbose_option(f):
@@ -387,7 +386,7 @@ def setup_verbosity(ctx, param, value):
     elif value == -1:
         for logger in loggers:
             logging.getLogger(logger).setLevel(logging.CRITICAL)
-    environments.PIPENV_VERBOSITY = value
+    ctx.ensure_object(State).project.s.PIPENV_VERBOSITY = value
 
 
 def validate_python_path(ctx, param, value):

--- a/pipenv/cli/options.py
+++ b/pipenv/cli/options.py
@@ -1,15 +1,13 @@
 import os
 
-import click.types
-
-from click import (
+from pipenv.project import Project
+from pipenv.utils import is_valid_url
+from pipenv.vendor.click import (
     BadArgumentUsage, BadParameter, Group, Option, argument, echo,
     make_pass_decorator, option
 )
-from click_didyoumean import DYMMixin
-
-from pipenv.project import Project
-from pipenv.utils import is_valid_url
+from pipenv.vendor.click import types as click_types
+from pipenv.vendor.click_didyoumean import DYMMixin
 
 
 CONTEXT_SETTINGS = {
@@ -119,7 +117,7 @@ def editable_option(f):
         state.installstate.editables.extend(value)
         return value
     return option('-e', '--editable', expose_value=False, multiple=True,
-                  callback=callback, type=click.types.STRING, help=(
+                  callback=callback, type=click_types.STRING, help=(
                       "An editable Python package URL or path, often to a VCS "
                       "repository."
                   ))(f)
@@ -132,7 +130,7 @@ def sequential_option(f):
         return value
     return option("--sequential", is_flag=True, default=False, expose_value=False,
                   help="Install dependencies one-at-a-time, instead of concurrently.",
-                  callback=callback, type=click.types.BOOL, show_envvar=True)(f)
+                  callback=callback, type=click_types.BOOL, show_envvar=True)(f)
 
 
 def skip_lock_option(f):
@@ -142,7 +140,7 @@ def skip_lock_option(f):
         return value
     return option("--skip-lock", is_flag=True, default=False, expose_value=False,
                   help="Skip locking mechanisms and use the Pipfile instead during operation.",
-                  envvar="PIPENV_SKIP_LOCK", callback=callback, type=click.types.BOOL,
+                  envvar="PIPENV_SKIP_LOCK", callback=callback, type=click_types.BOOL,
                   show_envvar=True)(f)
 
 
@@ -153,7 +151,7 @@ def keep_outdated_option(f):
         return value
     return option("--keep-outdated", is_flag=True, default=False, expose_value=False,
                   help="Keep out-dated dependencies from being updated in Pipfile.lock.",
-                  callback=callback, type=click.types.BOOL, show_envvar=True)(f)
+                  callback=callback, type=click_types.BOOL, show_envvar=True)(f)
 
 
 def selective_upgrade_option(f):
@@ -161,7 +159,7 @@ def selective_upgrade_option(f):
         state = ctx.ensure_object(State)
         state.installstate.selective_upgrade = value
         return value
-    return option("--selective-upgrade", is_flag=True, default=False, type=click.types.BOOL,
+    return option("--selective-upgrade", is_flag=True, default=False, type=click_types.BOOL,
                   help="Update specified packages.", callback=callback,
                   expose_value=False)(f)
 
@@ -173,7 +171,7 @@ def ignore_pipfile_option(f):
         return value
     return option("--ignore-pipfile", is_flag=True, default=False, expose_value=False,
                   help="Ignore Pipfile when installing, using the Pipfile.lock.",
-                  callback=callback, type=click.types.BOOL, show_envvar=True)(f)
+                  callback=callback, type=click_types.BOOL, show_envvar=True)(f)
 
 
 def _dev_option(f, help_text):
@@ -181,7 +179,7 @@ def _dev_option(f, help_text):
         state = ctx.ensure_object(State)
         state.installstate.dev = value
         return value
-    return option("--dev", "-d", is_flag=True, default=False, type=click.types.BOOL,
+    return option("--dev", "-d", is_flag=True, default=False, type=click_types.BOOL,
                   help=help_text, callback=callback,
                   expose_value=False, show_envvar=True)(f)
 
@@ -204,7 +202,7 @@ def pre_option(f):
         state.installstate.pre = value
         return value
     return option("--pre", is_flag=True, default=False, help="Allow pre-releases.",
-                  callback=callback, type=click.types.BOOL, expose_value=False)(f)
+                  callback=callback, type=click_types.BOOL, expose_value=False)(f)
 
 
 def package_arg(f):
@@ -213,7 +211,7 @@ def package_arg(f):
         state.installstate.packages.extend(value)
         return value
     return argument('packages', nargs=-1, callback=callback, expose_value=False,
-                    type=click.types.STRING)(f)
+                    type=click_types.STRING)(f)
 
 
 def three_option(f):
@@ -237,7 +235,7 @@ def python_option(f):
     return option("--python", default="", nargs=1, callback=callback,
                   help="Specify which version of Python virtualenv should use.",
                   expose_value=False, allow_from_autoenv=False,
-                  type=click.types.STRING)(f)
+                  type=click_types.STRING)(f)
 
 
 def pypi_mirror_option(f):
@@ -263,7 +261,7 @@ def verbose_option(f):
             state.verbose = True
             setup_verbosity(ctx, param, 1)
     return option("--verbose", "-v", is_flag=True, expose_value=False,
-                  callback=callback, help="Verbose mode.", type=click.types.BOOL)(f)
+                  callback=callback, help="Verbose mode.", type=click_types.BOOL)(f)
 
 
 def quiet_option(f):
@@ -278,7 +276,7 @@ def quiet_option(f):
             state.quiet = True
             setup_verbosity(ctx, param, -1)
     return option("--quiet", "-q", is_flag=True, expose_value=False,
-                  callback=callback, help="Quiet mode.", type=click.types.BOOL)(f)
+                  callback=callback, help="Quiet mode.", type=click_types.BOOL)(f)
 
 
 def site_packages_option(f):
@@ -297,7 +295,7 @@ def clear_option(f):
         state = ctx.ensure_object(State)
         state.clear = value
         return value
-    return option("--clear", is_flag=True, callback=callback, type=click.types.BOOL,
+    return option("--clear", is_flag=True, callback=callback, type=click_types.BOOL,
                   help="Clears caches (pipenv, pip, and pip-tools).",
                   expose_value=False, show_envvar=True)(f)
 
@@ -309,7 +307,7 @@ def system_option(f):
             state.system = value
         return value
     return option("--system", is_flag=True, default=False, help="System pip management.",
-                  callback=callback, type=click.types.BOOL, expose_value=False,
+                  callback=callback, type=click_types.BOOL, expose_value=False,
                   show_envvar=True)(f)
 
 
@@ -321,7 +319,7 @@ def requirementstxt_option(f):
         return value
     return option("--requirements", "-r", nargs=1, default="", expose_value=False,
                   help="Import a requirements.txt file.", callback=callback,
-                  type=click.types.STRING)(f)
+                  type=click_types.STRING)(f)
 
 
 def emit_requirements_flag(f):
@@ -362,7 +360,7 @@ def code_option(f):
         return value
     return option("--code", "-c", nargs=1, default="", help="Install packages "
                   "automatically discovered from import statements.", callback=callback,
-                  expose_value=False, type=click.types.STRING)(f)
+                  expose_value=False, type=click_types.STRING)(f)
 
 
 def deploy_option(f):
@@ -370,7 +368,7 @@ def deploy_option(f):
         state = ctx.ensure_object(State)
         state.installstate.deploy = value
         return value
-    return option("--deploy", is_flag=True, default=False, type=click.types.BOOL,
+    return option("--deploy", is_flag=True, default=False, type=click_types.BOOL,
                   help="Abort if the Pipfile.lock is out-of-date, or Python version is"
                   " wrong.", callback=callback, expose_value=False)(f)
 
@@ -403,7 +401,7 @@ def validate_python_path(ctx, param, value):
 
 def validate_bool_or_none(ctx, param, value):
     if value is not None:
-        return click.types.BOOL(value)
+        return click_types.BOOL(value)
     return False
 
 

--- a/pipenv/cli/options.py
+++ b/pipenv/cli/options.py
@@ -64,6 +64,7 @@ class State:
         self.site_packages = None
         self.clear = False
         self.system = False
+        self.project = Project()
         self.installstate = InstallState()
         self.lockoptions = LockOptions()
 
@@ -92,7 +93,6 @@ class LockOptions:
 
 
 pass_state = make_pass_decorator(State, ensure=True)
-pass_project = make_pass_decorator(Project, ensure=True)
 
 
 def index_option(f):

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -1,6 +1,7 @@
 import json as simplejson
 import logging
 import os
+from posixpath import expandvars
 import sys
 import time
 import warnings
@@ -83,7 +84,7 @@ def do_clear(project):
         # Other processes may be writing into this directory simultaneously.
         vistir.path.rmtree(
             locations.USER_CACHE_DIR,
-            ignore_errors=project.s.PIPENV_IS_CI,
+            ignore_errors=environments.PIPENV_IS_CI,
             onerror=vistir.path.handle_remove_readonly
         )
     except OSError as e:
@@ -2387,6 +2388,7 @@ def _launch_windows_subprocess(script, path):
     command = system_which(script.command, path=path)
 
     options = {"universal_newlines": True}
+    script.cmd_args[1:] = [expandvars(arg) for arg in script.args]
 
     # Command not found, maybe this is a shell built-in?
     if not command:

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -465,7 +465,7 @@ def ensure_virtualenv(project, three=None, python=None, site_packages=None, pypi
                 )
                 sys.exit(1)
             do_create_virtualenv(
-                python=python, site_packages=site_packages, pypi_mirror=pypi_mirror
+                project, python=python, site_packages=site_packages, pypi_mirror=pypi_mirror
             )
         except KeyboardInterrupt:
             # If interrupted, cleanup the virtualenv.

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -803,7 +803,7 @@ def do_install_dependencies(
     deps_list = list(lockfile.get_requirements(dev=dev, only=dev_only))
     if emit_requirements:
         index_args = prepare_pip_source_args(
-            get_source_list(project, pypi_mirror=pypi_mirror, project=project)
+            get_source_list(project, pypi_mirror=pypi_mirror)
         )
         index_args = " ".join(index_args).replace(" -", "\n-")
         deps = [

--- a/pipenv/environment.py
+++ b/pipenv/environment.py
@@ -1,5 +1,6 @@
 import contextlib
 import importlib
+import itertools
 import json
 import operator
 import os
@@ -8,24 +9,27 @@ import sys
 
 from sysconfig import get_paths, get_python_version
 
-import itertools
 import pkg_resources
 
 import pipenv
 
+from pipenv.environments import is_type_checking
+from pipenv.utils import make_posix, normalize_path, subprocess_run
+from pipenv.vendor import vistir
 from pipenv.vendor.cached_property import cached_property
 from pipenv.vendor.packaging.utils import canonicalize_name
-from pipenv.vendor import vistir
-
-from pipenv.utils import normalize_path, make_posix, subprocess_run
 
 
-if False:
+if is_type_checking():
+    from types import ModuleType
+    from typing import (
+        ContextManager, Dict, Generator, List, Optional, Set, Union
+    )
+
     import pip_shims.shims
     import tomlkit
-    from typing import ContextManager, Dict, Generator, List, Optional, Set, Union
-    from types import ModuleType
-    from pipenv.project import TSource, TPipfile, Project
+
+    from pipenv.project import Project, TPipfile, TSource
     from pipenv.vendor.packaging.version import Version
 
 BASE_WORKING_SET = pkg_resources.WorkingSet(sys.path)
@@ -82,14 +86,6 @@ class Environment:
             if dist:
                 dist.activate()
             module = importlib.import_module(name)
-        if name in sys.modules:
-            try:
-                importlib.reload(module)
-                importlib.reload(sys.modules[name])
-            except TypeError:
-                del sys.modules[name]
-                sys.modules[name] = self._modules[name]
-                return self._modules[name]
         return module
 
     @classmethod
@@ -544,7 +540,6 @@ class Environment:
         :rtype: iterator
         """
 
-        pkg_resources = self.safe_import("pkg_resources")
         libdirs = self.base_paths["libdirs"].split(os.pathsep)
         dists = (pkg_resources.find_distributions(libdir) for libdir in libdirs)
         yield from itertools.chain.from_iterable(dists)
@@ -576,7 +571,7 @@ class Environment:
     def dist_is_in_project(self, dist):
         # type: (pkg_resources.Distribution) -> bool
         """Determine whether the supplied distribution is in the environment."""
-        from .project import _normalized
+        from .environments import normalize_pipfile_path as _normalized
         prefixes = [
             _normalized(prefix) for prefix in self.base_paths["libdirs"].split(os.pathsep)
             if _normalized(prefix).startswith(_normalized(self.prefix.as_posix()))
@@ -600,15 +595,12 @@ class Environment:
     @contextlib.contextmanager
     def get_finder(self, pre=False):
         # type: (bool) -> ContextManager[pip_shims.shims.PackageFinder]
-        from .vendor.pip_shims.shims import (
-            InstallCommand, get_package_finder
-        )
-        from .environments import PIPENV_CACHE_DIR
+        from .vendor.pip_shims.shims import InstallCommand, get_package_finder
 
         pip_command = InstallCommand()
         pip_args = self._modules["pipenv"].utils.prepare_pip_source_args(self.sources)
         pip_options, _ = pip_command.parser.parse_args(pip_args)
-        pip_options.cache_dir = PIPENV_CACHE_DIR
+        pip_options.cache_dir = self.project.s.PIPENV_CACHE_DIR
         pip_options.pre = self.pipfile.get("pre", pre)
         with pip_command._build_session(pip_options) as session:
             finder = get_package_finder(install_cmd=pip_command, options=pip_options, session=session)
@@ -616,7 +608,7 @@ class Environment:
 
     def get_package_info(self, pre=False):
         # type: (bool) -> Generator[pkg_resources.Distribution, None, None]
-        from .vendor.pip_shims.shims import pip_version, parse_version
+        from .vendor.pip_shims.shims import parse_version, pip_version
         dependency_links = []
         packages = self.get_installed_packages()
         # This code is borrowed from pip's current implementation
@@ -685,7 +677,7 @@ class Environment:
         return d
 
     def get_package_requirements(self, pkg=None):
-        from .vendor.pipdeptree import flatten, PackageDAG
+        from .vendor.pipdeptree import PackageDAG, flatten
 
         packages = self.get_installed_packages()
         if pkg:
@@ -716,7 +708,7 @@ class Environment:
         yield new_node
 
     def reverse_dependencies(self):
-        from vistir.misc import unnest, chunked
+        from vistir.misc import chunked, unnest
         rdeps = {}
         for req in self.get_package_requirements():
             for d in self.reverse_dependency(req):
@@ -877,12 +869,11 @@ class Environment:
             ])
             os.environ["PYTHONIOENCODING"] = vistir.compat.fs_str("utf-8")
             os.environ["PYTHONDONTWRITEBYTECODE"] = vistir.compat.fs_str("1")
-            from .environments import PIPENV_USE_SYSTEM
             if self.is_venv:
                 os.environ["PYTHONPATH"] = self.base_paths["PYTHONPATH"]
                 os.environ["VIRTUAL_ENV"] = vistir.compat.fs_str(prefix)
             else:
-                if not PIPENV_USE_SYSTEM and not os.environ.get("VIRTUAL_ENV"):
+                if not self.project.s.PIPENV_USE_SYSTEM and not os.environ.get("VIRTUAL_ENV"):
                     os.environ["PYTHONPATH"] = self.base_paths["PYTHONPATH"]
                     os.environ.pop("PYTHONHOME", None)
             sys.path = self.sys_path

--- a/pipenv/environment.py
+++ b/pipenv/environment.py
@@ -898,7 +898,6 @@ class Environment:
             finally:
                 sys.path = original_path
                 sys.prefix = original_prefix
-                importlib.reload(pkg_resources)
 
     @cached_property
     def finders(self):

--- a/pipenv/environments.py
+++ b/pipenv/environments.py
@@ -1,7 +1,11 @@
+import glob
 import os
+import pathlib
+import re
 import sys
 
 from appdirs import user_cache_dir
+from vistir.path import normalize_drive
 
 from pipenv._compat import fix_utf8
 from pipenv.vendor.vistir.misc import _isatty, fs_str
@@ -73,67 +77,36 @@ def get_from_env(arg, prefix="PIPENV", check_for_negation=True):
     return None
 
 
-PIPENV_IS_CI = bool("CI" in os.environ or "TF_BUILD" in os.environ)
+def normalize_pipfile_path(p):
+    if p is None:
+        return None
+    loc = pathlib.Path(p)
+    try:
+        loc = loc.resolve()
+    except OSError:
+        loc = loc.absolute()
+    # Recase the path properly on Windows. From https://stackoverflow.com/a/35229734/5043728
+    if os.name == 'nt':
+        matches = glob.glob(re.sub(r'([^:/\\])(?=[/\\]|$)', r'[\1]', str(loc)))
+        path_str = matches and matches[0] or str(loc)
+    else:
+        path_str = str(loc)
+    return normalize_drive(os.path.abspath(path_str))
+
 
 # HACK: Prevent invalid shebangs with Homebrew-installed Python:
 # https://bugs.python.org/issue22490
 os.environ.pop("__PYVENV_LAUNCHER__", None)
-
 # Load patched pip instead of system pip
 os.environ["PIP_SHIMS_BASE_MODULE"] = fs_str("pipenv.patched.notpip")
-
-PIPENV_CACHE_DIR = os.environ.get("PIPENV_CACHE_DIR", user_cache_dir("pipenv"))
-"""Location for Pipenv to store it's package cache.
-
-Default is to use appdir's user cache directory.
-"""
-
+# Internal, to tell whether the command line session is interactive.
+SESSION_IS_INTERACTIVE = _isatty(sys.stdout)
+PIPENV_IS_CI = bool("CI" in os.environ or "TF_BUILD" in os.environ)
 PIPENV_COLORBLIND = bool(os.environ.get("PIPENV_COLORBLIND"))
 """If set, disable terminal colors.
 
 Some people don't like colors in their terminals, for some reason. Default is
 to show colors.
-"""
-
-# Tells Pipenv which Python to default to, when none is provided.
-PIPENV_DEFAULT_PYTHON_VERSION = os.environ.get("PIPENV_DEFAULT_PYTHON_VERSION")
-"""Use this Python version when creating new virtual environments by default.
-
-This can be set to a version string, e.g. ``3.6``, or a path. Default is to use
-whatever Python Pipenv is installed under (i.e. ``sys.executable``). Command
-line flags (e.g. ``--python``, ``--three``, and ``--two``) are prioritized over
-this configuration.
-"""
-
-PIPENV_DONT_LOAD_ENV = bool(os.environ.get("PIPENV_DONT_LOAD_ENV"))
-"""If set, Pipenv does not load the ``.env`` file.
-
-Default is to load ``.env`` for ``run`` and ``shell`` commands.
-"""
-
-PIPENV_DONT_USE_PYENV = bool(os.environ.get("PIPENV_DONT_USE_PYENV"))
-"""If set, Pipenv does not attempt to install Python with pyenv.
-
-Default is to install Python automatically via pyenv when needed, if possible.
-"""
-
-PIPENV_DONT_USE_ASDF = bool(os.environ.get("PIPENV_DONT_USE_ASDF"))
-"""If set, Pipenv does not attempt to install Python with asdf.
-
-Default is to install Python automatically via asdf when needed, if possible.
-"""
-
-PIPENV_DOTENV_LOCATION = os.environ.get("PIPENV_DOTENV_LOCATION")
-"""If set, Pipenv loads the ``.env`` file at the specified location.
-
-Default is to load ``.env`` from the project root, if found.
-"""
-
-PIPENV_EMULATOR = os.environ.get("PIPENV_EMULATOR", "")
-"""If set, the terminal emulator's name for ``pipenv shell`` to use.
-
-Default is to detect emulators automatically. This should be set if your
-emulator, e.g. Cmder, cannot be detected correctly.
 """
 
 PIPENV_HIDE_EMOJIS = (
@@ -146,221 +119,279 @@ PIPENV_HIDE_EMOJIS = (
 Default is to show emojis. This is automatically set on Windows.
 """
 
-PIPENV_IGNORE_VIRTUALENVS = bool(os.environ.get("PIPENV_IGNORE_VIRTUALENVS"))
-"""If set, Pipenv will always assign a virtual environment for this project.
 
-By default, Pipenv tries to detect whether it is run inside a virtual
-environment, and reuses it if possible. This is usually the desired behavior,
-and enables the user to use any user-built environments with Pipenv.
-"""
+class Setting:
+    def __init__(self) -> None:
+        self.USING_DEFAULT_PYTHON = True
+        self.initialize()
 
-PIPENV_INSTALL_TIMEOUT = int(os.environ.get("PIPENV_INSTALL_TIMEOUT", 60 * 15))
-"""Max number of seconds to wait for package installation.
+    def initialize(self):
 
-Defaults to 900 (15 minutes), a very long arbitrary time.
-"""
+        self.PIPENV_CACHE_DIR = os.environ.get("PIPENV_CACHE_DIR", user_cache_dir("pipenv"))
+        """Location for Pipenv to store it's package cache.
 
-# NOTE: +1 because of a temporary bug in Pipenv.
-PIPENV_MAX_DEPTH = int(os.environ.get("PIPENV_MAX_DEPTH", "3")) + 1
-"""Maximum number of directories to recursively search for a Pipfile.
+        Default is to use appdir's user cache directory.
+        """
 
-Default is 3. See also ``PIPENV_NO_INHERIT``.
-"""
+        # Tells Pipenv which Python to default to, when none is provided.
+        self.PIPENV_DEFAULT_PYTHON_VERSION = os.environ.get("PIPENV_DEFAULT_PYTHON_VERSION")
+        """Use this Python version when creating new virtual environments by default.
 
-PIPENV_MAX_RETRIES = int(
-    os.environ.get("PIPENV_MAX_RETRIES", "1" if PIPENV_IS_CI else "0")
-)
-"""Specify how many retries Pipenv should attempt for network requests.
+        This can be set to a version string, e.g. ``3.6``, or a path. Default is to use
+        whatever Python Pipenv is installed under (i.e. ``sys.executable``). Command
+        line flags (e.g. ``--python``, ``--three``, and ``--two``) are prioritized over
+        this configuration.
+        """
 
-Default is 0. Automatically set to 1 on CI environments for robust testing.
-"""
+        self.PIPENV_DONT_LOAD_ENV = bool(os.environ.get("PIPENV_DONT_LOAD_ENV"))
+        """If set, Pipenv does not load the ``.env`` file.
 
-PIPENV_MAX_ROUNDS = int(os.environ.get("PIPENV_MAX_ROUNDS", "16"))
-"""Tells Pipenv how many rounds of resolving to do for Pip-Tools.
+        Default is to load ``.env`` for ``run`` and ``shell`` commands.
+        """
 
-Default is 16, an arbitrary number that works most of the time.
-"""
+        self.PIPENV_DONT_USE_PYENV = bool(os.environ.get("PIPENV_DONT_USE_PYENV"))
+        """If set, Pipenv does not attempt to install Python with pyenv.
 
-PIPENV_MAX_SUBPROCESS = int(os.environ.get("PIPENV_MAX_SUBPROCESS", "8"))
-"""How many subprocesses should Pipenv use when installing.
+        Default is to install Python automatically via pyenv when needed, if possible.
+        """
 
-Default is 16, an arbitrary number that seems to work.
-"""
+        self.PIPENV_DONT_USE_ASDF = bool(os.environ.get("PIPENV_DONT_USE_ASDF"))
+        """If set, Pipenv does not attempt to install Python with asdf.
 
-PIPENV_NO_INHERIT = "PIPENV_NO_INHERIT" in os.environ
-"""Tell Pipenv not to inherit parent directories.
+        Default is to install Python automatically via asdf when needed, if possible.
+        """
 
-This is useful for deployment to avoid using the wrong current directory.
-Overwrites ``PIPENV_MAX_DEPTH``.
-"""
-if PIPENV_NO_INHERIT:
-    PIPENV_MAX_DEPTH = 2
+        self.PIPENV_DOTENV_LOCATION = os.environ.get("PIPENV_DOTENV_LOCATION")
+        """If set, Pipenv loads the ``.env`` file at the specified location.
 
-PIPENV_NOSPIN = bool(os.environ.get("PIPENV_NOSPIN"))
-"""If set, disable terminal spinner.
+        Default is to load ``.env`` from the project root, if found.
+        """
 
-This can make the logs cleaner. Automatically set on Windows, and in CI
-environments.
-"""
-if PIPENV_IS_CI:
-    PIPENV_NOSPIN = True
+        self.PIPENV_EMULATOR = os.environ.get("PIPENV_EMULATOR", "")
+        """If set, the terminal emulator's name for ``pipenv shell`` to use.
 
-PIPENV_SPINNER = "dots" if not os.name == "nt" else "bouncingBar"
-PIPENV_SPINNER = os.environ.get("PIPENV_SPINNER", PIPENV_SPINNER)
-"""Sets the default spinner type.
+        Default is to detect emulators automatically. This should be set if your
+        emulator, e.g. Cmder, cannot be detected correctly.
+        """
 
-Spinners are identical to the ``node.js`` spinners and can be found at
-https://github.com/sindresorhus/cli-spinners
-"""
+        self.PIPENV_IGNORE_VIRTUALENVS = bool(os.environ.get("PIPENV_IGNORE_VIRTUALENVS"))
+        """If set, Pipenv will always assign a virtual environment for this project.
 
-PIPENV_PIPFILE = os.environ.get("PIPENV_PIPFILE")
-"""If set, this specifies a custom Pipfile location.
+        By default, Pipenv tries to detect whether it is run inside a virtual
+        environment, and reuses it if possible. This is usually the desired behavior,
+        and enables the user to use any user-built environments with Pipenv.
+        """
 
-When running pipenv from a location other than the same directory where the
-Pipfile is located, instruct pipenv to find the Pipfile in the location
-specified by this environment variable.
+        self.PIPENV_INSTALL_TIMEOUT = int(os.environ.get("PIPENV_INSTALL_TIMEOUT", 60 * 15))
+        """Max number of seconds to wait for package installation.
 
-Default is to find Pipfile automatically in the current and parent directories.
-See also ``PIPENV_MAX_DEPTH``.
-"""
+        Defaults to 900 (15 minutes), a very long arbitrary time.
+        """
 
-PIPENV_PYPI_MIRROR = os.environ.get("PIPENV_PYPI_MIRROR")
-"""If set, tells pipenv to override PyPI index urls with a mirror.
+        # NOTE: +1 because of a temporary bug in Pipenv.
+        self.PIPENV_MAX_DEPTH = int(os.environ.get("PIPENV_MAX_DEPTH", "3")) + 1
+        """Maximum number of directories to recursively search for a Pipfile.
 
-Default is to not mirror PyPI, i.e. use the real one, pypi.org. The
-``--pypi-mirror`` command line flag overwrites this.
-"""
+        Default is 3. See also ``PIPENV_NO_INHERIT``.
+        """
 
-PIPENV_QUIET = bool(os.environ.get("PIPENV_QUIET"))
-"""If set, makes Pipenv quieter.
+        self.PIPENV_MAX_RETRIES = int(
+            os.environ.get("PIPENV_MAX_RETRIES", "1" if PIPENV_IS_CI else "0")
+        )
+        """Specify how many retries Pipenv should attempt for network requests.
 
-Default is unset, for normal verbosity. ``PIPENV_VERBOSE`` overrides this.
-"""
+        Default is 0. Automatically set to 1 on CI environments for robust testing.
+        """
 
-PIPENV_SHELL = os.environ.get("PIPENV_SHELL")
-"""An absolute path to the preferred shell for ``pipenv shell``.
+        self.PIPENV_MAX_ROUNDS = int(os.environ.get("PIPENV_MAX_ROUNDS", "16"))
+        """Tells Pipenv how many rounds of resolving to do for Pip-Tools.
 
-Default is to detect automatically what shell is currently in use.
-"""
-# Hack because PIPENV_SHELL is actually something else. Internally this
-# variable is called PIPENV_SHELL_EXPLICIT instead.
-PIPENV_SHELL_EXPLICIT = PIPENV_SHELL
-del PIPENV_SHELL
+        Default is 16, an arbitrary number that works most of the time.
+        """
 
-PIPENV_SHELL_FANCY = bool(os.environ.get("PIPENV_SHELL_FANCY"))
-"""If set, always use fancy mode when invoking ``pipenv shell``.
+        self.PIPENV_MAX_SUBPROCESS = int(os.environ.get("PIPENV_MAX_SUBPROCESS", "8"))
+        """How many subprocesses should Pipenv use when installing.
 
-Default is to use the compatibility shell if possible.
-"""
+        Default is 16, an arbitrary number that seems to work.
+        """
 
-PIPENV_TIMEOUT = int(os.environ.get("PIPENV_TIMEOUT", 120))
-"""Max number of seconds Pipenv will wait for virtualenv creation to complete.
+        self.PIPENV_NO_INHERIT = "PIPENV_NO_INHERIT" in os.environ
+        """Tell Pipenv not to inherit parent directories.
 
-Default is 120 seconds, an arbitrary number that seems to work.
-"""
+        This is useful for deployment to avoid using the wrong current directory.
+        Overwrites ``PIPENV_MAX_DEPTH``.
+        """
+        if self.PIPENV_NO_INHERIT:
+            self.PIPENV_MAX_DEPTH = 2
 
-PIPENV_VENV_IN_PROJECT = bool(os.environ.get("PIPENV_VENV_IN_PROJECT"))
-"""If set, creates ``.venv`` in your project directory.
+        self.PIPENV_NOSPIN = bool(os.environ.get("PIPENV_NOSPIN"))
+        """If set, disable terminal spinner.
 
-Default is to create new virtual environments in a global location.
-"""
+        This can make the logs cleaner. Automatically set on Windows, and in CI
+        environments.
+        """
+        if PIPENV_IS_CI:
+            self.PIPENV_NOSPIN = True
 
-PIPENV_VERBOSE = bool(os.environ.get("PIPENV_VERBOSE"))
-"""If set, makes Pipenv more wordy.
+        pipenv_spinner = "dots" if not os.name == "nt" else "bouncingBar"
+        self.PIPENV_SPINNER = os.environ.get("PIPENV_SPINNER", pipenv_spinner)
+        """Sets the default spinner type.
 
-Default is unset, for normal verbosity. This takes precedence over
-``PIPENV_QUIET``.
-"""
+        Spinners are identical to the ``node.js`` spinners and can be found at
+        https://github.com/sindresorhus/cli-spinners
+        """
 
-PIPENV_YES = bool(os.environ.get("PIPENV_YES"))
-"""If set, Pipenv automatically assumes "yes" at all prompts.
+        pipenv_pipfile = os.environ.get("PIPENV_PIPFILE")
+        if pipenv_pipfile:
+            if not os.path.isfile(pipenv_pipfile):
+                raise RuntimeError("Given PIPENV_PIPFILE is not found!")
 
-Default is to prompt the user for an answer if the current command line session
-if interactive.
-"""
+            else:
+                pipenv_pipfile = normalize_pipfile_path(pipenv_pipfile)
+                # Overwrite environment variable so that subprocesses can get the correct path.
+                # See https://github.com/pypa/pipenv/issues/3584
+                os.environ['PIPENV_PIPFILE'] = pipenv_pipfile
+        self.PIPENV_PIPFILE = pipenv_pipfile
+        """If set, this specifies a custom Pipfile location.
 
-PIPENV_SKIP_LOCK = False
-"""If set, Pipenv won't lock dependencies automatically.
+        When running pipenv from a location other than the same directory where the
+        Pipfile is located, instruct pipenv to find the Pipfile in the location
+        specified by this environment variable.
 
-This might be desirable if a project has large number of dependencies,
-because locking is an inherently slow operation.
+        Default is to find Pipfile automatically in the current and parent directories.
+        See also ``PIPENV_MAX_DEPTH``.
+        """
 
-Default is to lock dependencies and update ``Pipfile.lock`` on each run.
+        self.PIPENV_PYPI_MIRROR = os.environ.get("PIPENV_PYPI_MIRROR")
+        """If set, tells pipenv to override PyPI index urls with a mirror.
 
-NOTE: This only affects the ``install`` and ``uninstall`` commands.
-"""
+        Default is to not mirror PyPI, i.e. use the real one, pypi.org. The
+        ``--pypi-mirror`` command line flag overwrites this.
+        """
 
-PIP_EXISTS_ACTION = os.environ.get("PIP_EXISTS_ACTION", "w")
-"""Specifies the value for pip's --exists-action option
+        self.PIPENV_QUIET = bool(os.environ.get("PIPENV_QUIET"))
+        """If set, makes Pipenv quieter.
 
-Defaults to ``(w)ipe``
-"""
+        Default is unset, for normal verbosity. ``PIPENV_VERBOSE`` overrides this.
+        """
 
-PIPENV_RESOLVE_VCS = (
-    os.environ.get("PIPENV_RESOLVE_VCS") is None
-    or _is_env_truthy("PIPENV_RESOLVE_VCS")
-)
+        self.PIPENV_SHELL_EXPLICIT = os.environ.get("PIPENV_SHELL")
+        """An absolute path to the preferred shell for ``pipenv shell``.
 
-"""Tells Pipenv whether to resolve all VCS dependencies in full.
+        Default is to detect automatically what shell is currently in use.
+        """
+        # Hack because PIPENV_SHELL is actually something else. Internally this
+        # variable is called PIPENV_SHELL_EXPLICIT instead.
 
-As of Pipenv 2018.11.26, only editable VCS dependencies were resolved in full.
-To retain this behavior and avoid handling any conflicts that arise from the new
-approach, you may set this to '0', 'off', or 'false'.
-"""
+        self.PIPENV_SHELL_FANCY = bool(os.environ.get("PIPENV_SHELL_FANCY"))
+        """If set, always use fancy mode when invoking ``pipenv shell``.
 
-PIPENV_PYUP_API_KEY = os.environ.get(
-    "PIPENV_PYUP_API_KEY", None
-)
+        Default is to use the compatibility shell if possible.
+        """
 
-# Internal, support running in a different Python from sys.executable.
-PIPENV_PYTHON = os.environ.get("PIPENV_PYTHON")
+        self.PIPENV_TIMEOUT = int(os.environ.get("PIPENV_TIMEOUT", 120))
+        """Max number of seconds Pipenv will wait for virtualenv creation to complete.
 
-# Internal, overwrite all index funcitonality.
-PIPENV_TEST_INDEX = os.environ.get("PIPENV_TEST_INDEX")
+        Default is 120 seconds, an arbitrary number that seems to work.
+        """
 
-# Internal, tells Pipenv about the surrounding environment.
-PIPENV_USE_SYSTEM = False
-PIPENV_VIRTUALENV = None
-if "PIPENV_ACTIVE" not in os.environ and not PIPENV_IGNORE_VIRTUALENVS:
-    PIPENV_VIRTUALENV = os.environ.get("VIRTUAL_ENV")
-    PIPENV_USE_SYSTEM = bool(PIPENV_VIRTUALENV)
+        self.PIPENV_VENV_IN_PROJECT = bool(os.environ.get("PIPENV_VENV_IN_PROJECT"))
+        """If set, creates ``.venv`` in your project directory.
 
-# Internal, tells Pipenv to skip case-checking (slow internet connections).
-# This is currently always set to True for performance reasons.
-PIPENV_SKIP_VALIDATION = True
+        Default is to create new virtual environments in a global location.
+        """
 
-# Internal, the default shell to use if shell detection fails.
-PIPENV_SHELL = (
-    os.environ.get("SHELL")
-    or os.environ.get("PYENV_SHELL")
-    or os.environ.get("COMSPEC")
-)
+        self.PIPENV_VERBOSE = bool(os.environ.get("PIPENV_VERBOSE"))
+        """If set, makes Pipenv more wordy.
 
-# Internal, to tell whether the command line session is interactive.
-SESSION_IS_INTERACTIVE = _isatty(sys.stdout)
+        Default is unset, for normal verbosity. This takes precedence over
+        ``PIPENV_QUIET``.
+        """
 
-# Internal, consolidated verbosity representation as an integer. The default
-# level is 0, increased for wordiness and decreased for terseness.
-PIPENV_VERBOSITY = os.environ.get("PIPENV_VERBOSITY", "")
-try:
-    PIPENV_VERBOSITY = int(PIPENV_VERBOSITY)
-except (ValueError, TypeError):
-    if PIPENV_VERBOSE:
-        PIPENV_VERBOSITY = 1
-    elif PIPENV_QUIET:
-        PIPENV_VERBOSITY = -1
-    else:
-        PIPENV_VERBOSITY = 0
-del PIPENV_QUIET
-del PIPENV_VERBOSE
+        self.PIPENV_YES = bool(os.environ.get("PIPENV_YES"))
+        """If set, Pipenv automatically assumes "yes" at all prompts.
 
+        Default is to prompt the user for an answer if the current command line session
+        if interactive.
+        """
 
-def is_verbose(threshold=1):
-    return PIPENV_VERBOSITY >= threshold
+        self.PIPENV_SKIP_LOCK = False
+        """If set, Pipenv won't lock dependencies automatically.
 
+        This might be desirable if a project has large number of dependencies,
+        because locking is an inherently slow operation.
 
-def is_quiet(threshold=-1):
-    return PIPENV_VERBOSITY <= threshold
+        Default is to lock dependencies and update ``Pipfile.lock`` on each run.
+
+        NOTE: This only affects the ``install`` and ``uninstall`` commands.
+        """
+
+        self.PIP_EXISTS_ACTION = os.environ.get("PIP_EXISTS_ACTION", "w")
+        """Specifies the value for pip's --exists-action option
+
+        Defaults to ``(w)ipe``
+        """
+
+        self.PIPENV_RESOLVE_VCS = (
+            os.environ.get("PIPENV_RESOLVE_VCS") is None
+            or _is_env_truthy("PIPENV_RESOLVE_VCS")
+        )
+
+        """Tells Pipenv whether to resolve all VCS dependencies in full.
+
+        As of Pipenv 2018.11.26, only editable VCS dependencies were resolved in full.
+        To retain this behavior and avoid handling any conflicts that arise from the new
+        approach, you may set this to '0', 'off', or 'false'.
+        """
+
+        self.PIPENV_PYUP_API_KEY = os.environ.get(
+            "PIPENV_PYUP_API_KEY", None
+        )
+
+        # Internal, support running in a different Python from sys.executable.
+        self.PIPENV_PYTHON = os.environ.get("PIPENV_PYTHON")
+
+        # Internal, overwrite all index funcitonality.
+        self.PIPENV_TEST_INDEX = os.environ.get("PIPENV_TEST_INDEX")
+
+        # Internal, tells Pipenv about the surrounding environment.
+        self.PIPENV_USE_SYSTEM = False
+        self.PIPENV_VIRTUALENV = None
+        if "PIPENV_ACTIVE" not in os.environ and not self.PIPENV_IGNORE_VIRTUALENVS:
+            self.PIPENV_VIRTUALENV = os.environ.get("VIRTUAL_ENV")
+            self.PIPENV_USE_SYSTEM = bool(self.PIPENV_VIRTUALENV)
+
+        # Internal, tells Pipenv to skip case-checking (slow internet connections).
+        # This is currently always set to True for performance reasons.
+        self.PIPENV_SKIP_VALIDATION = True
+
+        # Internal, the default shell to use if shell detection fails.
+        self.PIPENV_SHELL = (
+            os.environ.get("SHELL")
+            or os.environ.get("PYENV_SHELL")
+            or os.environ.get("COMSPEC")
+        )
+
+        # Internal, consolidated verbosity representation as an integer. The default
+        # level is 0, increased for wordiness and decreased for terseness.
+        verbosity = os.environ.get("PIPENV_VERBOSITY", "")
+        try:
+            self.PIPENV_VERBOSITY = int(verbosity)
+        except (ValueError, TypeError):
+            if self.PIPENV_VERBOSE:
+                self.PIPENV_VERBOSITY = 1
+            elif self.PIPENV_QUIET:
+                self.PIPENV_VERBOSITY = -1
+            else:
+                self.PIPENV_VERBOSITY = 0
+        del self.PIPENV_QUIET
+        del self.PIPENV_VERBOSE
+
+    def is_verbose(self, threshold=1):
+        return self.PIPENV_VERBOSITY >= threshold
+
+    def is_quiet(self, threshold=-1):
+        return self.PIPENV_VERBOSITY <= threshold
 
 
 def is_using_venv():
@@ -389,11 +420,6 @@ def is_in_virtualenv():
     return virtual_env and not (pipenv_active or ignore_virtualenvs)
 
 
-PIPENV_SPINNER_FAIL_TEXT = fix_utf8("✘ {0}") if not PIPENV_HIDE_EMOJIS else ("{0}")
-
-PIPENV_SPINNER_OK_TEXT = fix_utf8("✔ {0}") if not PIPENV_HIDE_EMOJIS else ("{0}")
-
-
 def is_type_checking():
     try:
         from typing import TYPE_CHECKING
@@ -403,3 +429,5 @@ def is_type_checking():
 
 
 MYPY_RUNNING = is_type_checking()
+PIPENV_SPINNER_FAIL_TEXT = fix_utf8("✘ {0}") if not PIPENV_HIDE_EMOJIS else "{0}"
+PIPENV_SPINNER_OK_TEXT = fix_utf8("✔ {0}") if not PIPENV_HIDE_EMOJIS else "{0}"

--- a/pipenv/exceptions.py
+++ b/pipenv/exceptions.py
@@ -39,7 +39,7 @@ KNOWN_EXCEPTIONS = [
 
 
 def handle_exception(exc_type, exception, traceback, hook=sys.excepthook):
-    if environments.is_verbose() or not issubclass(exc_type, ClickException):
+    if environments.Setting().is_verbose() or not issubclass(exc_type, ClickException):
         hook(exc_type, exception, traceback)
     else:
         tb = format_tb(traceback, limit=-6)

--- a/pipenv/exceptions.py
+++ b/pipenv/exceptions.py
@@ -258,17 +258,6 @@ class SystemUsageError(PipenvOptionsError):
         super().__init__(option_name, message=message, ctx=ctx, extra=extra, **kwargs)
 
 
-class PipfileException(PipenvFileError):
-    def __init__(self, hint=None, **kwargs):
-        from .core import project
-
-        if not hint:
-            hint = "{} {}".format(crayons.red("ERROR (PACKAGE NOT INSTALLED):"), hint)
-        filename = project.pipfile_location
-        extra = kwargs.pop("extra", [])
-        PipenvFileError.__init__(self, filename, hint, extra=extra, **kwargs)
-
-
 class SetupException(PipenvException):
     def __init__(self, message=None, **kwargs):
         PipenvException.__init__(self, message, **kwargs)

--- a/pipenv/help.py
+++ b/pipenv/help.py
@@ -4,7 +4,6 @@ import sys
 
 import pipenv
 
-from pipenv.core import project
 from pipenv.pep508checker import lookup
 from pipenv.vendor import pythonfinder
 
@@ -16,7 +15,7 @@ def print_utf(line):
         print(line.encode("utf-8"))
 
 
-def get_pipenv_diagnostics():
+def get_pipenv_diagnostics(project):
     print("<details><summary>$ pipenv --support</summary>")
     print("")
     print(f"Pipenv version: `{pipenv.__version__!r}`")
@@ -82,4 +81,5 @@ def get_pipenv_diagnostics():
 
 
 if __name__ == "__main__":
-    get_pipenv_diagnostics()
+    from pipenv.project import Project
+    get_pipenv_diagnostics(Project())

--- a/pipenv/installers.py
+++ b/pipenv/installers.py
@@ -3,8 +3,6 @@ import operator
 import re
 from abc import ABCMeta, abstractmethod
 
-
-from pipenv.environments import PIPENV_INSTALL_TIMEOUT
 from pipenv.vendor import attr
 from pipenv.utils import find_windows_executable, subprocess_run
 
@@ -65,9 +63,9 @@ class InstallerError(RuntimeError):
 
 class Installer(metaclass=ABCMeta):
 
-    def __init__(self):
+    def __init__(self, project):
         self.cmd = self._find_installer()
-        super().__init__()
+        self.project = project
 
     def __str__(self):
         return self.__class__.__name__
@@ -187,7 +185,7 @@ class Pyenv(Installer):
         """
         c = self._run(
             'install', '-s', str(version),
-            timeout=PIPENV_INSTALL_TIMEOUT,
+            timeout=self.project.s.PIPENV_INSTALL_TIMEOUT,
         )
         return c
 
@@ -216,6 +214,6 @@ class Asdf(Installer):
         """
         c = self._run(
             'install', 'python', str(version),
-            timeout=PIPENV_INSTALL_TIMEOUT,
+            timeout=self.project.s.PIPENV_INSTALL_TIMEOUT,
         )
         return c

--- a/pipenv/project.py
+++ b/pipenv/project.py
@@ -319,7 +319,7 @@ class Project:
     def get_environment(self, allow_global=False):
         # type: (bool) -> Environment
         is_venv = is_in_virtualenv()
-        if allow_global or is_venv:
+        if allow_global and not is_venv:
             prefix = sys.prefix
             python = sys.executable
         else:

--- a/pipenv/resolver.py
+++ b/pipenv/resolver.py
@@ -510,7 +510,6 @@ class Entry:
         :raises: :exc:`pipenv.exceptions.DependencyConflict` if the constraints dont exist
         """
         from pipenv.exceptions import DependencyConflict
-        from pipenv.environments import is_verbose
 
         constraints = self.get_constraints()
         pinned_version = self.updated_version
@@ -520,7 +519,7 @@ class Entry:
             if pinned_version and not constraint.req.specifier.contains(
                 str(pinned_version), prereleases=True
             ):
-                if is_verbose():
+                if self.project.s.is_verbose():
                     print(f"Tried constraint: {constraint!r}", file=sys.stderr)
                 msg = (
                     "Cannot resolve conflicting version {}{} while {}{} is "

--- a/pipenv/resolver.py
+++ b/pipenv/resolver.py
@@ -688,7 +688,8 @@ def resolve_packages(pre, clear, verbose, system, write, requirements_dir, packa
             req_dir=requirements_dir
         )
 
-    from pipenv.core import project
+    from pipenv.project import Project
+    project = Project()
     sources = (
         replace_pypi_sources(project.pipfile_sources, pypi_mirror_source)
         if pypi_mirror_source

--- a/pipenv/shells.py
+++ b/pipenv/shells.py
@@ -6,7 +6,6 @@ import signal
 import subprocess
 import sys
 
-from pipenv.environments import PIPENV_EMULATOR, PIPENV_SHELL, PIPENV_SHELL_EXPLICIT
 from pipenv.vendor import shellingham
 from pipenv.vendor.vistir.compat import Path, get_terminal_size
 from pipenv.vendor.vistir.contextmanagers import temp_environ
@@ -19,14 +18,14 @@ def _build_info(value):
     return (os.path.splitext(os.path.basename(value))[0], value)
 
 
-def detect_info():
-    if PIPENV_SHELL_EXPLICIT:
-        return _build_info(PIPENV_SHELL_EXPLICIT)
+def detect_info(project):
+    if project.s.PIPENV_SHELL_EXPLICIT:
+        return _build_info(project.s.PIPENV_SHELL_EXPLICIT)
     try:
         return shellingham.detect_shell()
     except (shellingham.ShellDetectionFailure, TypeError):
-        if PIPENV_SHELL:
-            return _build_info(PIPENV_SHELL)
+        if project.s.PIPENV_SHELL:
+            return _build_info(project.s.PIPENV_SHELL)
     raise ShellDetectionFailure
 
 
@@ -232,9 +231,9 @@ def _detect_emulator():
     return ",".join(keys)
 
 
-def choose_shell():
-    emulator = PIPENV_EMULATOR.lower() or _detect_emulator()
-    type_, command = detect_info()
+def choose_shell(project):
+    emulator = project.PIPENV_EMULATOR.lower() or _detect_emulator()
+    type_, command = project.detect_info()
     shell_types = SHELL_LOOKUP[type_]
     for key in emulator.split(","):
         key = key.strip().lower()

--- a/pipenv/utils.py
+++ b/pipenv/utils.py
@@ -322,7 +322,7 @@ def get_source_list(
     return sources
 
 
-def get_indexes_from_requirement(req, project, ndex=None, extra_indexes=None, trusted_hosts=None, pypi_mirror=None):
+def get_indexes_from_requirement(req, project, index=None, extra_indexes=None, trusted_hosts=None, pypi_mirror=None):
     # type: (Requirement, Project, Optional[Text], Optional[List[Text]], Optional[List[Text]], Optional[Text]) -> Tuple[TSource, List[TSource], List[Text]]
     index_sources = []  # type: List[TSource]
     if not trusted_hosts:
@@ -341,7 +341,7 @@ def get_indexes_from_requirement(req, project, ndex=None, extra_indexes=None, tr
     indexes.extend(project_indexes)
     if len(indexes) > 1:
         index, extra_indexes = indexes[0], indexes[1:]
-    index_sources = get_source_list(index=index, extra_indexes=extra_indexes, trusted_hosts=trusted_hosts, pypi_mirror=pypi_mirror, project=project)
+    index_sources = get_source_list(project, index=index, extra_indexes=extra_indexes, trusted_hosts=trusted_hosts, pypi_mirror=pypi_mirror)
     if len(index_sources) > 1:
         index_source, extra_index_sources = index_sources[0], index_sources[1:]
     else:

--- a/pipenv/utils.py
+++ b/pipenv/utils.py
@@ -1,4 +1,3 @@
-import subprocess
 import contextlib
 import errno
 import logging
@@ -8,33 +7,43 @@ import re
 import shutil
 import signal
 import stat
+import subprocess
 import sys
 import warnings
+
 from contextlib import contextmanager
 from distutils.spawn import find_executable
 from urllib.parse import urlparse
 
-import toml
-from click import echo as click_echo
-
 import crayons
 import parse
+import toml
 import tomlkit
+
+from click import echo as click_echo
 
 from pipenv import environments
 from pipenv._compat import DEFAULT_ENCODING
-from pipenv.exceptions import PipenvCmdError, PipenvUsageError, RequirementError, ResolutionFailure
+from pipenv.exceptions import (
+    PipenvCmdError, PipenvUsageError, RequirementError, ResolutionFailure
+)
 from pipenv.pep508checker import lookup
 from pipenv.vendor.packaging.markers import Marker
 from pipenv.vendor.urllib3 import util as urllib3_util
-from pipenv.vendor.vistir.compat import Mapping, ResourceWarning, Sequence, Set, lru_cache
+from pipenv.vendor.vistir.compat import (
+    Mapping, ResourceWarning, Sequence, Set, lru_cache
+)
 from pipenv.vendor.vistir.misc import fs_str, run
 
+
 if environments.MYPY_RUNNING:
-    from typing import Tuple, Dict, Any, List, Union, Optional, Text
-    from pipenv.vendor.requirementslib.models.requirements import Requirement, Line
-    from pipenv.vendor.requirementslib.models.pipfile import Pipfile
+    from typing import Any, Dict, List, Optional, Text, Tuple, Union
+
     from pipenv.project import Project, TSource
+    from pipenv.vendor.requirementslib.models.pipfile import Pipfile
+    from pipenv.vendor.requirementslib.models.requirements import (
+        Line, Requirement
+    )
 
 
 logging.basicConfig(level=logging.ERROR)
@@ -46,7 +55,7 @@ SCHEME_LIST = ("http://", "https://", "ftp://", "ftps://", "file://")
 requests_session = None  # type: ignore
 
 
-def _get_requests_session():
+def _get_requests_session(max_retries=1):
     """Load requests lazily."""
     global requests_session
     if requests_session is not None:
@@ -54,9 +63,7 @@ def _get_requests_session():
     import requests
 
     requests_session = requests.Session()
-    adapter = requests.adapters.HTTPAdapter(
-        max_retries=environments.PIPENV_MAX_RETRIES
-    )
+    adapter = requests.adapters.HTTPAdapter(max_retries=max_retries)
     requests_session.mount("https://pypi.org/pypi", adapter)
     return requests_session
 
@@ -119,7 +126,7 @@ def convert_toml_outline_tables(parsed):
     return parsed
 
 
-def run_command(cmd, *args, **kwargs):
+def run_command(cmd, *args, is_verbose=False, **kwargs):
     """
     Take an input command and run it, handling exceptions and error codes and returning
     its stdout and stderr.
@@ -142,10 +149,10 @@ def run_command(cmd, *args, **kwargs):
         kwargs["env"] = os.environ.copy()
     kwargs["env"]["PYTHONIOENCODING"] = "UTF-8"
     command = [cmd.command, *cmd.args]
-    if environments.is_verbose():
+    if is_verbose:
         click_echo(f"Running command: $ {cmd.cmdify()}")
     c = subprocess_run(command, *args, **kwargs)
-    if environments.is_verbose():
+    if is_verbose:
         click_echo("Command output: {}".format(
             crayons.cyan(decode_for_output(c.stdout))
         ), err=True)
@@ -367,9 +374,9 @@ class Resolver:
         markers_lookup=None, skipped=None, clear=False, pre=False
     ):
         from pipenv.patched.piptools import logging as piptools_logging
-        if environments.is_verbose():
+        if project.s.is_verbose():
             logging.log.verbose = True
-            piptools_logging.log.verbosity = environments.PIPENV_VERBOSITY
+            piptools_logging.log.verbosity = project.s.PIPENV_VERBOSITY
         self.initial_constraints = constraints
         self.req_dir = req_dir
         self.project = project
@@ -446,7 +453,7 @@ class Resolver:
             # rest of the dependencies, while adding the files/vcs deps/paths themselves
             # to the lockfile directly
             constraint_update, lockfile_update = cls.get_deps_from_req(
-                req, resolver=transient_resolver
+                req, resolver=transient_resolver, resolve_vcs=project.s.PIPENV_RESOLVE_VCS
             )
             constraints |= constraint_update
             skipped.update(lockfile_update)
@@ -512,12 +519,15 @@ class Resolver:
         return cls.get_deps_from_req(req)
 
     @classmethod
-    def get_deps_from_req(cls, req, resolver=None):
-        # type: (Requirement, Optional["Resolver"]) -> Tuple[Set[str], Dict[str, Dict[str, Union[str, bool, List[str]]]]]
+    def get_deps_from_req(cls, req, resolver=None, resolve_vcs=True):
+        # type: (Requirement, Optional["Resolver"], bool) -> Tuple[Set[str], Dict[str, Dict[str, Union[str, bool, List[str]]]]]
         from .patched.piptools.exceptions import NoCandidateFound
-        from .vendor.requirementslib.models.utils import _requirement_to_str_lowercase_name
         from .vendor.requirementslib.models.requirements import Requirement
+        from .vendor.requirementslib.models.utils import (
+            _requirement_to_str_lowercase_name
+        )
         from .vendor.requirementslib.utils import is_installable_dir
+
         # TODO: this is way too complex, refactor this
         constraints = set()  # type: Set[str]
         locked_deps = dict()  # type: Dict[str, Dict[str, Union[str, bool, List[str]]]]
@@ -541,7 +551,7 @@ class Resolver:
             requirements = []
             # Allow users to toggle resolution off for non-editable VCS packages
             # but leave it on for local, installable folders on the filesystem
-            if environments.PIPENV_RESOLVE_VCS or (
+            if resolve_vcs or (
                 req.editable or parsed_line.is_wheel or (
                     req.is_file_or_url and parsed_line.is_local
                     and is_installable_dir(parsed_line.path)
@@ -688,7 +698,7 @@ class Resolver:
             pip_args.append("--no-build-isolation")
         if self.pre:
             pip_args.append("--pre")
-        pip_args.extend(["--cache-dir", environments.PIPENV_CACHE_DIR])
+        pip_args.extend(["--cache-dir", self.project.s.PIPENV_CACHE_DIR])
         return pip_args
 
     @property
@@ -734,7 +744,7 @@ class Resolver:
     def pip_options(self):
         if self._pip_options is None:
             pip_options, _ = self.pip_command.parser.parse_args(self.pip_args)
-            pip_options.cache_dir = environments.PIPENV_CACHE_DIR
+            pip_options.cache_dir = self.project.s.PIPENV_CACHE_DIR
             pip_options.no_python_version_warning = True
             pip_options.no_input = True
             pip_options.progress_bar = "off"
@@ -746,10 +756,6 @@ class Resolver:
     def session(self):
         if self._session is None:
             self._session = self.pip_command._build_session(self.pip_options)
-            # if environments.is_verbose():
-            #     click_echo(
-            #         crayons.cyan("Using pip: {0}".format(" ".join(self.pip_args))), err=True
-            #     )
         return self._session
 
     @property
@@ -779,11 +785,12 @@ class Resolver:
         return self._parsed_constraints
 
     def get_resolver(self, clear=False, pre=False):
-        from pipenv.patched.piptools.resolver import Resolver as PiptoolsResolver
         from pipenv.patched.piptools.cache import DependencyCache
+        from pipenv.patched.piptools.resolver import \
+            Resolver as PiptoolsResolver
         self._resolver = PiptoolsResolver(
             constraints=self.parsed_constraints, repository=self.repository,
-            cache=DependencyCache(environments.PIPENV_CACHE_DIR), clear_caches=clear,
+            cache=DependencyCache(self.project.s.PIPENV_CACHE_DIR), clear_caches=clear,
             # TODO: allow users to toggle the 'allow unsafe' flag to resolve setuptools?
             prereleases=pre, allow_unsafe=False
         )
@@ -795,15 +802,16 @@ class Resolver:
         return self._resolver
 
     def resolve(self):
+        from pipenv.patched.piptools.cache import CorruptCacheError
+        from pipenv.patched.piptools.exceptions import NoCandidateFound
         from pipenv.vendor.pip_shims.shims import DistributionNotFound
         from pipenv.vendor.requests.exceptions import HTTPError
-        from pipenv.patched.piptools.exceptions import NoCandidateFound
-        from pipenv.patched.piptools.cache import CorruptCacheError
+
         from .exceptions import CacheError, ResolutionFailure
         with temp_environ():
             os.environ["PIP_NO_USE_PEP517"] = ""
             try:
-                results = self.resolver.resolve(max_rounds=environments.PIPENV_MAX_ROUNDS)
+                results = self.resolver.resolve(max_rounds=self.project.s.PIPENV_MAX_ROUNDS)
             except CorruptCacheError as e:
                 if environments.PIPENV_IS_CI or self.clear:
                     if self._retry_attempts < 3:
@@ -877,7 +885,7 @@ class Resolver:
             for source in self.sources
         ):
             pkg_url = f"https://pypi.org/pypi/{ireq.name}/json"
-            session = _get_requests_session()
+            session = _get_requests_session(self.project.s.PIPENV_MAX_RETRIES)
             try:
                 # Grab the hashes from the new warehouse API.
                 r = session.get(pkg_url, timeout=10)
@@ -895,7 +903,7 @@ class Resolver:
                     collected_hashes.append(release["digests"]["sha256"])
                 collected_hashes = self.prepend_hash_types(collected_hashes)
             except (ValueError, KeyError, ConnectionError):
-                if environments.is_verbose():
+                if self.project.s.is_verbose():
                     click_echo(
                         "{}: Error generating hash for {}".format(
                             crayons.red("Warning", bold=True), ireq.name
@@ -989,7 +997,9 @@ class Resolver:
         return req.name, entry
 
     def clean_results(self):
-        from pipenv.vendor.requirementslib.models.requirements import Requirement
+        from pipenv.vendor.requirementslib.models.requirements import (
+            Requirement
+        )
         reqs = [(Requirement.from_ireq(ireq), ireq) for ireq in self.resolved_tree]
         results = {}
         for req, ireq in reqs:
@@ -1099,13 +1109,13 @@ def actually_resolve_deps(
 
 
 @contextlib.contextmanager
-def create_spinner(text, nospin=None, spinner_name=None):
+def create_spinner(text, setting, nospin=None, spinner_name=None):
     from .vendor.vistir import spin
     from .vendor.vistir.misc import fs_str
     if not spinner_name:
-        spinner_name = environments.PIPENV_SPINNER
+        spinner_name = setting.PIPENV_SPINNER
     if nospin is None:
-        nospin = environments.PIPENV_NOSPIN
+        nospin = setting.PIPENV_NOSPIN
     with spin.create_spinner(
         spinner_name=spinner_name,
         start_text=fs_str(text),
@@ -1114,16 +1124,17 @@ def create_spinner(text, nospin=None, spinner_name=None):
         yield sp
 
 
-def resolve(cmd, sp):
+def resolve(cmd, sp, project):
+    from ._compat import decode_output
     from .cmdparse import Script
     from .vendor.vistir.misc import echo
-    from ._compat import decode_output
     c = subprocess_run(Script.parse(cmd).cmd_args, block=False, env=os.environ.copy())
+    is_verbose = project.s.is_verbose()
     err = ""
     for line in iter(c.stderr.readline, ""):
         line = decode_output(line)
         err += line
-        if environments.is_verbose() and line.rstrip():
+        if is_verbose and line.rstrip():
             sp.hide_and_write(line.rstrip())
 
     c.wait()
@@ -1134,10 +1145,10 @@ def resolve(cmd, sp):
             "Locking Failed!"
         ))
         echo(out.strip(), err=True)
-        if not environments.is_verbose():
+        if not is_verbose:
             echo(err, err=True)
         sys.exit(returncode)
-    if environments.is_verbose():
+    if is_verbose:
         echo(out.strip(), err=True)
     return subprocess.CompletedProcess(c.args, returncode, out, err)
 
@@ -1235,12 +1246,13 @@ def venv_resolve_deps(
     :rtype: None
     """
 
-    from .vendor.vistir.misc import fs_str
-    from .vendor.vistir.compat import Path, JSONDecodeError, NamedTemporaryFile
-    from .vendor.vistir.path import create_tracked_tempdir
+    import json
+
     from . import resolver
     from ._compat import decode_for_output
-    import json
+    from .vendor.vistir.compat import JSONDecodeError, NamedTemporaryFile, Path
+    from .vendor.vistir.misc import fs_str
+    from .vendor.vistir.path import create_tracked_tempdir
 
     results = []
     pipfile_section = "dev-packages" if dev else "packages"
@@ -1276,7 +1288,7 @@ def venv_resolve_deps(
         os.environ.update({fs_str(k): fs_str(val) for k, val in os.environ.items()})
         if pypi_mirror:
             os.environ["PIPENV_PYPI_MIRROR"] = str(pypi_mirror)
-        os.environ["PIPENV_VERBOSITY"] = str(environments.PIPENV_VERBOSITY)
+        os.environ["PIPENV_VERBOSITY"] = str(project.s.PIPENV_VERBOSITY)
         os.environ["PIPENV_REQ_DIR"] = fs_str(req_dir)
         os.environ["PIP_NO_INPUT"] = fs_str("1")
         pipenv_site_dir = get_pipenv_sitedir()
@@ -1286,7 +1298,7 @@ def venv_resolve_deps(
             os.environ.pop("PIPENV_SITE_DIR", None)
         if keep_outdated:
             os.environ["PIPENV_KEEP_OUTDATED"] = fs_str("1")
-        with create_spinner(text=decode_for_output("Locking...")) as sp:
+        with create_spinner(text=decode_for_output("Locking..."), setting=project.s) as sp:
             # This conversion is somewhat slow on local and file-type requirements since
             # we now download those requirements / make temporary folders to perform
             # dependency resolution on them, so we are including this step inside the
@@ -1298,11 +1310,11 @@ def venv_resolve_deps(
             constraints = set(deps)
             os.environ["PIPENV_PACKAGES"] = str("\n".join(constraints))
             sp.write(decode_for_output("Resolving dependencies..."))
-            c = resolve(cmd, sp)
+            c = resolve(cmd, sp, project=project)
             results = c.stdout.strip()
             if c.returncode == 0:
                 sp.green.ok(environments.PIPENV_SPINNER_OK_TEXT.format("Success!"))
-                if not environments.is_verbose() and c.stderr.strip():
+                if not project.s.is_verbose() and c.stderr.strip():
                     click_echo(crayons.yellow(f"Warning: {c.stderr.strip()}"), err=True)
             else:
                 sp.red.fail(environments.PIPENV_SPINNER_FAIL_TEXT.format("Locking Failed!"))
@@ -1483,9 +1495,9 @@ def is_editable(pipfile_entry):
 
 def is_installable_file(path):
     """Determine if a path can potentially be installed"""
-    from .vendor.pip_shims.shims import is_installable_dir, is_archive_file
-    from .patched.notpip._internal.utils.packaging import specifiers
     from ._compat import Path
+    from .patched.notpip._internal.utils.packaging import specifiers
+    from .vendor.pip_shims.shims import is_archive_file, is_installable_dir
 
     if hasattr(path, "keys") and any(
         key for key in path.keys() if key in ["file", "path"]
@@ -1688,8 +1700,9 @@ def temp_path():
 
 
 def load_path(python):
-    from pathlib import Path
     import json
+
+    from pathlib import Path
     python = Path(python).as_posix()
     json_dump_commmand = '"import json, sys; print(json.dumps(sys.path));"'
     c = subprocess_run([python, "-c", json_dump_commmand])
@@ -1723,9 +1736,9 @@ def create_mirror_source(url):
     }
 
 
-def download_file(url, filename):
+def download_file(url, filename, max_retries=1):
     """Downloads file from url to a path with filename"""
-    r = _get_requests_session().get(url, stream=True)
+    r = _get_requests_session(max_retries).get(url, stream=True)
     if not r.ok:
         raise OSError("Unable to download file")
 
@@ -1850,7 +1863,10 @@ def get_vcs_deps(
         if requirement.is_vcs:
             try:
                 with temp_path(), locked_repository(requirement) as repo:
-                    from pipenv.vendor.requirementslib.models.requirements import Requirement
+                    from pipenv.vendor.requirementslib.models.requirements import (
+                        Requirement
+                    )
+
                     # from distutils.sysconfig import get_python_lib
                     # sys.path = [repo.checkout_directory, "", ".", get_python_lib(plat_specific=0)]
                     commit_hash = repo.get_commit_hash()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import pytest
+
+
+@pytest.fixture()
+def project():
+    from pipenv.project import Project
+    return Project()

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,4 +1,5 @@
 import errno
+import functools
 import json
 import logging
 import os
@@ -449,7 +450,7 @@ def pip_src_dir(request, vistir_tmpdir):
 
 
 @pytest.fixture()
-def PipenvInstance(pip_src_dir, monkeypatch, pypi):
+def PipenvInstance(pip_src_dir, monkeypatch, pypi, tmp_path):
     with temp_environ(), monkeypatch.context() as m:
         m.setattr(shutil, "rmtree", _rmtree_func)
         original_umask = os.umask(0o007)
@@ -463,7 +464,7 @@ def PipenvInstance(pip_src_dir, monkeypatch, pypi):
         warnings.simplefilter("ignore", category=ResourceWarning)
         warnings.filterwarnings("ignore", category=ResourceWarning, message="unclosed.*<ssl.SSLSocket.*>")
         try:
-            yield _PipenvInstance
+            yield functools.partial(_PipenvInstance, path=tmp_path, pypi=pypi)
         finally:
             os.umask(original_umask)
 

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -8,7 +8,7 @@ import pytest
 
 from flaky import flaky
 
-from pipenv.utils import normalize_drive
+from pipenv.utils import normalize_drive, subprocess_run
 
 
 @pytest.mark.cli
@@ -217,8 +217,8 @@ def test_help(PipenvInstance):
 
 @pytest.mark.cli
 def test_man(PipenvInstance):
-    with PipenvInstance() as p:
-        c = p.pipenv('--man')
+    with PipenvInstance():
+        c = subprocess_run(["pipenv", "--man"])
         assert c.returncode == 0, c.stderr
 
 

--- a/tests/integration/test_install_markers.py
+++ b/tests/integration/test_install_markers.py
@@ -1,5 +1,4 @@
 import os
-import sys
 
 import pytest
 

--- a/tests/integration/test_lock.py
+++ b/tests/integration/test_lock.py
@@ -646,16 +646,11 @@ requests = "*"
 
 @pytest.mark.lock
 @pytest.mark.install
-def test_lock_no_warnings(PipenvInstance):
+def test_lock_no_warnings(PipenvInstance, recwarn):
     with PipenvInstance(chdir=True) as p:
-        os.environ["PYTHONWARNINGS"] = "once"
         c = p.pipenv("install six")
         assert c.returncode == 0
-        c = p.pipenv('run python -c "import warnings; warnings.warn(\\"This is a warning\\", DeprecationWarning); print(\\"hello\\")"')
-        assert c.returncode == 0
-        assert "Warning" in c.stderr
-        assert "Warning" not in c.stdout
-        assert "hello" in c.stdout
+        assert len(recwarn) == 0
 
 
 @pytest.mark.lock

--- a/tests/integration/test_uninstall.py
+++ b/tests/integration/test_uninstall.py
@@ -193,4 +193,4 @@ def test_uninstall_missing_parameters(PipenvInstance):
 
         c = p.pipenv("uninstall")
         assert c.returncode != 0
-        assert "No package provided!" in str(c.exception)
+        assert "No package provided!" in c.stderr

--- a/tests/integration/test_uninstall.py
+++ b/tests/integration/test_uninstall.py
@@ -193,4 +193,4 @@ def test_uninstall_missing_parameters(PipenvInstance):
 
         c = p.pipenv("uninstall")
         assert c.returncode != 0
-        assert "No package provided!" in c.stderr
+        assert "No package provided!" in str(c.exception)

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -1,6 +1,5 @@
 import os
 
-from unittest import mock
 import pytest
 
 from pipenv._compat import TemporaryDirectory
@@ -8,13 +7,13 @@ from pipenv.core import load_dot_env, warn_in_virtualenv
 from pipenv.utils import temp_environ
 
 
-@mock.patch('pipenv.environments.PIPENV_VIRTUALENV', 'totallyrealenv')
-@mock.patch('pipenv.environments.PIPENV_VERBOSITY', -1)
 @pytest.mark.core
-def test_suppress_nested_venv_warning(capsys):
+def test_suppress_nested_venv_warning(capsys, project):
     # Capture the stderr of warn_in_virtualenv to test for the presence of the
     # courtesy notice.
-    warn_in_virtualenv()
+    project.s.PIPENV_VIRTUALENV = 'totallyrealenv'
+    project.s.PIPENV_VERBOSITY = -1
+    warn_in_virtualenv(project)
     output, err = capsys.readouterr()
     assert 'Courtesy Notice' not in err
 
@@ -31,8 +30,7 @@ def test_load_dot_env_from_environment_variable_location(monkeypatch, capsys, pr
         with open(dotenv_path, 'w') as f:
             f.write(f'{key}={val}')
 
-        m.setenv("PIPENV_DOTENV_LOCATION", str(dotenv_path))
-        m.setattr("pipenv.environments.PIPENV_DOTENV_LOCATION", str(dotenv_path))
+        project.s.PIPENV_DOTENV_LOCATION = str(dotenv_path)
         load_dot_env(project)
         assert os.environ[key] == val
 
@@ -49,12 +47,11 @@ def test_doesnt_load_dot_env_if_disabled(monkeypatch, capsys, project):
         with open(dotenv_path, 'w') as f:
             f.write(f'{key}={val}')
 
-        m.setenv("PIPENV_DOTENV_LOCATION", str(dotenv_path))
-        m.setattr("pipenv.environments.PIPENV_DOTENV_LOCATION", str(dotenv_path))
-        m.setattr("pipenv.environments.PIPENV_DONT_LOAD_ENV", True)
+        project.s.PIPENV_DOTENV_LOCATION = str(dotenv_path)
+        project.s.PIPENV_DONT_LOAD_ENV = True
         load_dot_env(project)
         assert key not in os.environ
-        m.setattr("pipenv.environments.PIPENV_DONT_LOAD_ENV", False)
+        project.s.PIPENV_DONT_LOAD_ENV = False
         load_dot_env(project)
         assert key in os.environ
 
@@ -67,8 +64,7 @@ def test_load_dot_env_warns_if_file_doesnt_exist(monkeypatch, capsys, project):
             is_console = False
             m.setattr(click._winconsole, "_is_console", lambda x: is_console)
         dotenv_path = os.path.join(tempdir.name, 'does-not-exist.env')
-        m.setenv("PIPENV_DOTENV_LOCATION", str(dotenv_path))
-        m.setattr("pipenv.environments.PIPENV_DOTENV_LOCATION", str(dotenv_path))
+        project.s.PIPENV_DOTENV_LOCATION = str(dotenv_path)
         load_dot_env(project)
         output, err = capsys.readouterr()
         assert 'Warning' in err

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -20,7 +20,7 @@ def test_suppress_nested_venv_warning(capsys):
 
 
 @pytest.mark.core
-def test_load_dot_env_from_environment_variable_location(monkeypatch, capsys):
+def test_load_dot_env_from_environment_variable_location(monkeypatch, capsys, project):
     with temp_environ(), monkeypatch.context() as m, TemporaryDirectory(prefix='pipenv-', suffix='') as tempdir:
         if os.name == "nt":
             import click
@@ -33,12 +33,12 @@ def test_load_dot_env_from_environment_variable_location(monkeypatch, capsys):
 
         m.setenv("PIPENV_DOTENV_LOCATION", str(dotenv_path))
         m.setattr("pipenv.environments.PIPENV_DOTENV_LOCATION", str(dotenv_path))
-        load_dot_env()
+        load_dot_env(project)
         assert os.environ[key] == val
 
 
 @pytest.mark.core
-def test_doesnt_load_dot_env_if_disabled(monkeypatch, capsys):
+def test_doesnt_load_dot_env_if_disabled(monkeypatch, capsys, project):
     with temp_environ(), monkeypatch.context() as m, TemporaryDirectory(prefix='pipenv-', suffix='') as tempdir:
         if os.name == "nt":
             import click
@@ -52,15 +52,15 @@ def test_doesnt_load_dot_env_if_disabled(monkeypatch, capsys):
         m.setenv("PIPENV_DOTENV_LOCATION", str(dotenv_path))
         m.setattr("pipenv.environments.PIPENV_DOTENV_LOCATION", str(dotenv_path))
         m.setattr("pipenv.environments.PIPENV_DONT_LOAD_ENV", True)
-        load_dot_env()
+        load_dot_env(project)
         assert key not in os.environ
         m.setattr("pipenv.environments.PIPENV_DONT_LOAD_ENV", False)
-        load_dot_env()
+        load_dot_env(project)
         assert key in os.environ
 
 
 @pytest.mark.core
-def test_load_dot_env_warns_if_file_doesnt_exist(monkeypatch, capsys):
+def test_load_dot_env_warns_if_file_doesnt_exist(monkeypatch, capsys, project):
     with temp_environ(), monkeypatch.context() as m, TemporaryDirectory(prefix='pipenv-', suffix='') as tempdir:
         if os.name == "nt":
             import click
@@ -69,6 +69,6 @@ def test_load_dot_env_warns_if_file_doesnt_exist(monkeypatch, capsys):
         dotenv_path = os.path.join(tempdir.name, 'does-not-exist.env')
         m.setenv("PIPENV_DOTENV_LOCATION", str(dotenv_path))
         m.setattr("pipenv.environments.PIPENV_DOTENV_LOCATION", str(dotenv_path))
-        load_dot_env()
+        load_dot_env(project)
         output, err = capsys.readouterr()
         assert 'Warning' in err

--- a/tests/unit/test_help.py
+++ b/tests/unit/test_help.py
@@ -13,18 +13,3 @@ def test_help():
         stderr=subprocess.STDOUT, env=os.environ.copy(),
     )
     assert output
-
-
-@pytest.mark.cli
-@pytest.mark.help
-def test_count_of_description_pre_option():
-    test_command = 'pipenv install --help'
-    test_line = '--pre Allow pre-releases.'
-    out = subprocess.Popen(test_command.split(), stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-    stdout, _ = out.communicate()
-    lines = stdout.decode().split('\n')
-    count = 0
-    for line in lines:
-        if line.strip().split() == test_line.split():
-            count += 1
-    assert count == 1


### PR DESCRIPTION
This is an attempt to solve #4746 

- [x] Replace shared project with create-on-demand.
- [x] Bind `environments` module to the project.
- [ ] Switch the testing infrastructure to `click.testing.CliRunner`