### PR TITLE
fix: do_sync should pass system/clear

### DIFF
--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -2825,8 +2825,10 @@ def do_sync(
         three=three,
         python=python,
         validate=False,
+        system=system,
         deploy=deploy,
         pypi_mirror=pypi_mirror,
+        clear=clear,
     )
 
     # Install everything.


### PR DESCRIPTION
### The issue

Currently, `pipenv sync --system` would create a virtualenv, which should not be created by design.


### The fix

Pass `system` to sub function.