### PR TITLE
Bug solved: creating virtual environment when not present

### DIFF
--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -516,7 +516,7 @@ def ensure_project(
     # Automatically use an activated virtualenv.
     # checks if virtual Enviroment exists if it exists then it makes the system variable true
     if project.virtualenv_exists:
-       system = False
+       system = True
     if not project.pipfile_exists and deploy:
         raise exceptions.PipfileNotFound
     # Skip virtualenv creation when --system was used.

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -434,6 +434,7 @@ def ensure_virtualenv(project, three=None, python=None, site_packages=None, pypi
         sys.exit(1)
 
     if not project.virtualenv_exists:
+        print("hello1")
         try:
             # Ensure environment variables are set properly.
             ensure_environment()
@@ -470,7 +471,7 @@ def ensure_virtualenv(project, three=None, python=None, site_packages=None, pypi
         # If VIRTUAL_ENV is set, there is a possibility that we are
         # going to remove the active virtualenv that the user cares
         # about, so confirm first.
-        if project.virtualenv_exists:
+        if "VIRTUAL_ENV" in os.environ:
             if not (
                 project.s.PIPENV_YES or click.confirm("Using existing virtualenv?", default=True)
             ):
@@ -516,8 +517,8 @@ def ensure_project(
     # Automatically use an activated virtualenv.
     # checks if virtual Enviroment exists if it exists then it makes the system variable true
     if project.virtualenv_exists:
-        click.echo(crayons.red("Virtualenv already exists! Using existing virtualenv..."), err=True)
-        system = True
+       click.echo(crayons.red("Virtualenv already exists! Using existing virtualenv..."), err=True)
+       system = True
     if not project.pipfile_exists and deploy:
         raise exceptions.PipfileNotFound
     # Skip virtualenv creation when --system was used.

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -470,24 +470,26 @@ def ensure_virtualenv(project, three=None, python=None, site_packages=None, pypi
         # If VIRTUAL_ENV is set, there is a possibility that we are
         # going to remove the active virtualenv that the user cares
         # about, so confirm first.
-        if "VIRTUAL_ENV" in os.environ:
+        if project.virtualenv_exists:
             if not (
-                project.s.PIPENV_YES or click.confirm("Remove existing virtualenv?", default=True)
+                project.s.PIPENV_YES or click.confirm("Using existing virtualenv?", default=True)
             ):
+                click.echo(
+                crayons.normal(fix_utf8("Using existing virtualenv..."), bold=True), err=True
+                )
                 abort()
-        click.echo(
-            crayons.normal(fix_utf8("Removing existing virtualenv..."), bold=True), err=True
-        )
+
+        # Commented this part of the code because it was cleaning up the existing virtual enviroment and recursively calling the same funtion and creating a new virtual if vitual enviroment exists
         # Remove the virtualenv.
-        cleanup_virtualenv(project, bare=True)
+        # cleanup_virtualenv(project, bare=True)
         # Call this function again.
-        ensure_virtualenv(
-            project,
-            three=three,
-            python=python,
-            site_packages=site_packages,
-            pypi_mirror=pypi_mirror,
-        )
+        #ensure_virtualenv(
+        #   project,
+        #   three=three,
+        #   python=python,
+        #   site_packages=site_packages,
+        #   pypi_mirror=pypi_mirror,
+        #)
 
 
 def ensure_project(
@@ -507,12 +509,14 @@ def ensure_project(
 
     # Clear the caches, if appropriate.
     if clear:
+        print("here")
         print("clearing")
         sys.exit(1)
 
     # Automatically use an activated virtualenv.
-    if project.s.PIPENV_USE_SYSTEM:
-        system = True
+    # checks if virtual Enviroment exists if it exists then it makes the system variable true
+    if project.virtualenv_exists:
+       system = False
     if not project.pipfile_exists and deploy:
         raise exceptions.PipfileNotFound
     # Skip virtualenv creation when --system was used.

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -516,7 +516,8 @@ def ensure_project(
     # Automatically use an activated virtualenv.
     # checks if virtual Enviroment exists if it exists then it makes the system variable true
     if project.virtualenv_exists:
-       system = True
+        click.echo(crayons.red("Virtualenv already exists! Using existing virtualenv..."), err=True)
+        system = True
     if not project.pipfile_exists and deploy:
         raise exceptions.PipfileNotFound
     # Skip virtualenv creation when --system was used.

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -434,7 +434,6 @@ def ensure_virtualenv(project, three=None, python=None, site_packages=None, pypi
         sys.exit(1)
 
     if not project.virtualenv_exists:
-        print("hello1")
         try:
             # Ensure environment variables are set properly.
             ensure_environment()
@@ -479,18 +478,6 @@ def ensure_virtualenv(project, three=None, python=None, site_packages=None, pypi
                 crayons.normal(fix_utf8("Using existing virtualenv..."), bold=True), err=True
                 )
                 abort()
-
-        # Commented this part of the code because it was cleaning up the existing virtual enviroment and recursively calling the same funtion and creating a new virtual if vitual enviroment exists
-        # Remove the virtualenv.
-        # cleanup_virtualenv(project, bare=True)
-        # Call this function again.
-        #ensure_virtualenv(
-        #   project,
-        #   three=three,
-        #   python=python,
-        #   site_packages=site_packages,
-        #   pypi_mirror=pypi_mirror,
-        #)
 
 
 def ensure_project(


### PR DESCRIPTION
Thank you for contributing to Pipenv!


### The issue

What is the thing you want to fix? Is it associated with an issue on GitHub? Please mention it.

Yes it is associated with and issue #4537 

### The fix

Initially when virtual environment is not present it creates a virtual environment and if it is present then it removes the existing virtual environment and creates a new one if PIPENV_SITE_PACKAGES=1 is set.

I have removed this issue and added a feature which uses the existing virtual environment when present and does not remove the the existing virtual environment when PIPENV_SITE_PACKAGES=1 is set.

### The checklist

* [x]  Associated issue
* [x] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

<!--
### If this is a patch to the `vendor` directory...

Please try to refrain from submitting patches directly to `vendor` or `patched`, but raise your issue to the upstream project instead, and inform Pipenv to upgrade when the upstream project accepts the fix.

A pull request to upgrade vendor packages is strongly discouraged, unless there is a very good reason (e.g. you need to test Pipenv’s integration to a new vendor feature). Pipenv audits and performs vendor upgrades regularly, generally before a new release is about to drop.

If your patch is not or cannot be accepted by upstream, but is essential to Pipenv (make sure to discuss this with maintainers!), please remember to attach a patch file in `tasks/vendoring/patched`, so this divergence from upstream can be recorded and replayed afterwards.
-->
