### PR TITLE
remove prefixes on install commands for easy copy/pasting

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,23 +43,23 @@ Installation
 
 If you\'re using Debian Buster+:
 
-    $ sudo apt install pipenv
+    sudo apt install pipenv
 
 Or, if you\'re using Fedora:
 
-    $ sudo dnf install pipenv
+    sudo dnf install pipenv
 
 Or, if you\'re using FreeBSD:
 
-    # pkg install py36-pipenv
+    pkg install py36-pipenv
 
 Or, if you\'re using Windows:
 
-    # pip install --user pipenv
+    pip install --user pipenv
 
 When none of the above is an option, it is recommended to use [Pipx](https://pypi.org/p/pipx):
 
-    $ pipx install pipenv
+    pipx install pipenv
 
 Otherwise, refer to the [documentation](https://pipenv.pypa.io/en/latest/#install-pipenv-today) for instructions.
 

--- a/news/4792.doc.rst
+++ b/news/4792.doc.rst
@@ -1,0 +1,1 @@
+remove prefixes on install commands for easy copy/pasting


### PR DESCRIPTION
### The issue
the install commands in the readme are made more difficult to copy because of the `$` and `#` prefixes
![image](https://user-images.githubusercontent.com/57028336/133917798-c33ebc27-f5f9-47b1-813e-d9367b00a4dd.png)


### The fix
removed the prefixes so now you can easily copy and paste the command
### The checklist

* [ ] Associated issue
* [x] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

<!--
### If this is a patch to the `vendor` directory...

Please try to refrain from submitting patches directly to `vendor` or `patched`, but raise your issue to the upstream project instead, and inform Pipenv to upgrade when the upstream project accepts the fix.

A pull request to upgrade vendor packages is strongly discouraged, unless there is a very good reason (e.g. you need to test Pipenv’s integration to a new vendor feature). Pipenv audits and performs vendor upgrades regularly, generally before a new release is about to drop.

If your patch is not or cannot be accepted by upstream, but is essential to Pipenv (make sure to discuss this with maintainers!), please remember to attach a patch file in `tasks/vendoring/patched`, so this divergence from upstream can be recorded and replayed afterwards.
-->
