### PR TITLE
[docs] Add missing link of Pipx's home page

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -92,6 +92,8 @@ Once you have ``pipx`` ready on your system, continue to install Pipenv::
 
     $ pipx install pipenv
 
+.. _Pipx: https://pypa.github.io/pipx/
+
 
 ☤ Pragmatic Installation of Pipenv
 ----------------------------------


### PR DESCRIPTION
Thank you for contributing to Pipenv!


### The issue

> What is the thing you want to fix? Is it associated with an issue on GitHub? Please mention it.

In [Isolated Installation of Pipenv with Pipx](https://pipenv.pypa.io/en/latest/install/#isolated-installation-of-pipenv-with-pipx) section, link to Pipx's home page is missing. Since this is a minor changes in documentation, so there is no need for an issue on the Issue Tracker.


### The fix

> How does this pull request fix your problem? Did you consider any alternatives? Why is this the *best* solution, in your opinion?

This merge request fix the problem, by adding the missing link.


### The checklist

* [ ] Associated issue
* [ ] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.
