### PR TITLE
Use PIPENV_SKIP_LOCK environment variable

### DIFF
--- a/news/4797.feature.rst
+++ b/news/4797.feature.rst
@@ -1,0 +1,1 @@
+Use environment variable `PIPENV_SKIP_LOCK` to control the behaviour of lock skipping.

--- a/pipenv/environments.py
+++ b/pipenv/environments.py
@@ -315,13 +315,15 @@ class Setting:
         if interactive.
         """
 
-        self.PIPENV_SKIP_LOCK = False
+        self.PIPENV_SKIP_LOCK = bool(os.environ.get("PIPENV_SKIP_LOCK", False))
         """If set, Pipenv won't lock dependencies automatically.
 
         This might be desirable if a project has large number of dependencies,
         because locking is an inherently slow operation.
 
         Default is to lock dependencies and update ``Pipfile.lock`` on each run.
+        
+        Usage: export PIPENV_SKIP_LOCK=true OR export PIPENV_SKIP_LOCK=1 to skip automatic locking
 
         NOTE: This only affects the ``install`` and ``uninstall`` commands.
         """

--- a/pipenv/environments.py
+++ b/pipenv/environments.py
@@ -323,7 +323,7 @@ class Setting:
 
         Default is to lock dependencies and update ``Pipfile.lock`` on each run.
         
-        Usage: export PIPENV_SKIP_LOCK=true OR export PIPENV_SKIP_LOCK=1 to skip automatic locking
+        Usage: `export PIPENV_SKIP_LOCK=true` OR `export PIPENV_SKIP_LOCK=1` to skip automatic locking
 
         NOTE: This only affects the ``install`` and ``uninstall`` commands.
         """


### PR DESCRIPTION
### The issue

The value of `PIPENV_SKIP_LOCK` is always False. This has been discussed in previous issues (#2200 and #3332) with no resolution. 

### The fix

`PIPENV_SKIP_LOCK` to consider the value of the environment variable `PIPENV_SKIP_LOCK`. 

This is useful to large project as it enables the environment variable `PIPENV_SKIP_LOCK` to control the locking behavior. 

Default behavior is not changed, still False.

### The checklist

* [x] Associated issue
* [x] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

