### PR TITLE
[Installer/Shells] Fixes for Windows/pyenv-win

### DIFF
--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -2305,7 +2305,7 @@ def do_shell(project, three=None, python=False, fancy=False, shell_args=None, py
 
     from .shells import choose_shell
 
-    shell = choose_shell()
+    shell = choose_shell(project)
     click.echo(fix_utf8("Launching subshell in virtual environment..."), err=True)
 
     fork_args = (

--- a/pipenv/installers.py
+++ b/pipenv/installers.py
@@ -169,7 +169,7 @@ class Pyenv(Installer):
     def iter_installable_versions(self):
         """Iterate through CPython versions available for Pipenv to install.
         """
-        for name in self._run('install', '--list').out.splitlines():
+        for name in self._run('install', '--list').stdout.splitlines():
             try:
                 version = Version.parse(name.strip())
             except ValueError:

--- a/pipenv/shells.py
+++ b/pipenv/shells.py
@@ -228,12 +228,19 @@ def _detect_emulator():
         keys.append("cmder")
     if os.environ.get("MSYSTEM"):
         keys.append("msys")
+    # VS Code internal terminal support
+    if os.environ.get("TERM_PROGRAM") == "vscode":
+        keys.append("vscode") 
     return ",".join(keys)
 
 
 def choose_shell(project):
-    emulator = project.PIPENV_EMULATOR.lower() or _detect_emulator()
-    type_, command = project.detect_info()
+    emulator = "none"
+    try:
+        emulator = _detect_emulator() or project.PIPENV_EMULATOR.lower()
+    except AttributeError as error:
+        print("Uh oh! Error: ", error)
+    type_, command = detect_info(project)
     shell_types = SHELL_LOOKUP[type_]
     for key in emulator.split(","):
         key = key.strip().lower()

--- a/pipenv/utils.py
+++ b/pipenv/utils.py
@@ -2282,10 +2282,16 @@ def subprocess_run(
         other_kwargs['stdout'] = subprocess.PIPE
         other_kwargs['stderr'] = subprocess.PIPE
     if block:
-        return subprocess.run(
-            args, universal_newlines=text,
-            encoding=encoding, **other_kwargs
-        )
+        if os.name == "nt":
+            return subprocess.run(
+                args, universal_newlines=text,
+                encoding=encoding, shell=True, **other_kwargs
+            )
+        else: 
+            return subprocess.run(
+                args, universal_newlines=text,
+                encoding=encoding, **other_kwargs
+            )
     else:
         return subprocess.Popen(
             args, universal_newlines=text,


### PR DESCRIPTION
Thank you for contributing to Pipenv!


### The issue

- `subprocess.run()` needs the argument `shell=True` on Windows when spawning new shell
- call to `choose_shell()` was missing non-options argument, `project`
- `detect_info(project)` no longer member of project

### The fix

- Added missing args to `choose_shell(project)` 
- changed `out()` to `stdout()` in `_iter_installable_versions()`
- change `project.detect_info()` to `detect_info(project)`