### PR TITLE
Fixes #4790: behaving as no .venv if .venv is in project root and empty

### DIFF
--- a/news/4790.bugfix.rst
+++ b/news/4790.bugfix.rst
@@ -1,0 +1,1 @@
+Ignore empty .venv in rood dir and create project name base virtual environment

--- a/pipenv/project.py
+++ b/pipenv/project.py
@@ -270,6 +270,10 @@ class Project:
         with io.open(dot_venv) as f:
             name = f.read().strip()
 
+        # If .venv file is empty, set location based on config.
+        if not name:
+            return str(get_workon_home().joinpath(self.virtualenv_name))
+
         # If content looks like a path, use it as a relative path.
         # Otherwise use directory named after content in WORKON_HOME.
         if looks_like_dir(name):


### PR DESCRIPTION

### The issue

fix issue #4790 

### The fix

This is to prevent an user from choosing own workon home as the virtual environment or deleting all virtual environments accidentally under the workon dir. pipenv ignores the content with this change, so that it uses project name base virtual environment If an empty .venv is set in root.

### The checklist

* [ ] Associated issue
* [ ] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

<!--
### If this is a patch to the `vendor` directory...

Please try to refrain from submitting patches directly to `vendor` or `patched`, but raise your issue to the upstream project instead, and inform Pipenv to upgrade when the upstream project accepts the fix.

A pull request to upgrade vendor packages is strongly discouraged, unless there is a very good reason (e.g. you need to test Pipenv’s integration to a new vendor feature). Pipenv audits and performs vendor upgrades regularly, generally before a new release is about to drop.

If your patch is not or cannot be accepted by upstream, but is essential to Pipenv (make sure to discuss this with maintainers!), please remember to attach a patch file in `tasks/vendoring/patched`, so this divergence from upstream can be recorded and replayed afterwards.
-->
