### PR TITLE
Fixes #4788: incorrect returncode

### DIFF
--- a/pipenv/cli/command.py
+++ b/pipenv/cli/command.py
@@ -120,7 +120,7 @@ def cli(
             do_where(state.project, bare=True)
             return 0
         elif py:
-            do_py(state.project)
+            do_py(state.project, ctx=ctx)
             return 0
         # --support was passed...
         elif support:

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -1717,7 +1717,7 @@ def ensure_lockfile(project, keep_outdated=False, pypi_mirror=None):
         do_lock(project, keep_outdated=keep_outdated, pypi_mirror=pypi_mirror)
 
 
-def do_py(project, system=False):
+def do_py(project, ctx=None, system=False):
     if not project.virtualenv_exists:
         click.echo(
             "{}({}){}".format(
@@ -1727,7 +1727,7 @@ def do_py(project, system=False):
             ),
             err=True,
         )
-        return
+        ctx.abort()
 
     try:
         click.echo(project._which("python", allow_global=system))


### PR DESCRIPTION
### The issue
As described in issue #4788 , `--py` option returns incorrect return code if no virtualenv is found. 

```
bash-3.2$ pipenv --version
pipenv, version 2021.5.29
bash-3.2$ cd / && pipenv --py
No virtualenv has been created for this project (/) yet!
bash-3.2$ echo $?
0
```

### The fix

pass ctx to `do_py` and abort if virtualenv is not found.  The output is like this.

```
root@61d7aec9b3fc:/pipenv# python pipenv --py
No virtualenv has been created for this project (/pipenv) yet!
Aborted!
root@61d7aec9b3fc:/pipenv# echo $?
1
```

### The checklist

* [ ] Associated issue
* [ ] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

<!--
### If this is a patch to the `vendor` directory...

Please try to refrain from submitting patches directly to `vendor` or `patched`, but raise your issue to the upstream project instead, and inform Pipenv to upgrade when the upstream project accepts the fix.

A pull request to upgrade vendor packages is strongly discouraged, unless there is a very good reason (e.g. you need to test Pipenv’s integration to a new vendor feature). Pipenv audits and performs vendor upgrades regularly, generally before a new release is about to drop.

If your patch is not or cannot be accepted by upstream, but is essential to Pipenv (make sure to discuss this with maintainers!), please remember to attach a patch file in `tasks/vendoring/patched`, so this divergence from upstream can be recorded and replayed afterwards.
-->
