### PR TITLE
Fix 2021.11.5 support drop version notice from 3.6 to 3.5

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -71,7 +71,7 @@ Improved Documentation
 ----------------------
 
 - remove prefixes on install commands for easy copy/pasting  `#4792 <https://github.com/pypa/pipenv/issues/4792>`_
-- Officially drop support for Python 2.7 and Python 3.6.  `#4261 <https://github.com/pypa/pipenv/issues/4261>`_
+- Officially drop support for Python 2.7 and Python 3.5.  `#4261 <https://github.com/pypa/pipenv/issues/4261>`_
 
 
 2021.5.29 (2021-05-29)


### PR DESCRIPTION
### The issue

- Based on https://github.com/pypa/pipenv/issues/4261#issuecomment-962948608, 3.5 support is dropped, not 3.6.

### The fix

- Fix typo
- Resolves #4844

### The checklist

* [x] Associated issue
* [ ] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.