### PR TITLE
Don't use sys.executable when inside a venv

### DIFF
--- a/news/4852.bugfix.rst
+++ b/news/4852.bugfix.rst
@@ -1,0 +1,1 @@
+Don't use ``sys.executable`` when inside an activated venv.

--- a/pipenv/environments.py
+++ b/pipenv/environments.py
@@ -357,7 +357,6 @@ class Setting:
         self.PIPENV_VIRTUALENV = None
         if "PIPENV_ACTIVE" not in os.environ and not self.PIPENV_IGNORE_VIRTUALENVS:
             self.PIPENV_VIRTUALENV = os.environ.get("VIRTUAL_ENV")
-            self.PIPENV_USE_SYSTEM = bool(self.PIPENV_VIRTUALENV)
 
         # Internal, tells Pipenv to skip case-checking (slow internet connections).
         # This is currently always set to True for performance reasons.


### PR DESCRIPTION
Fix #4852