### PR TITLE
duplicate parentheses removed

### DIFF
--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -892,7 +892,7 @@ def do_create_virtualenv(project, python=None, site_packages=None, pypi_mirror=N
         Path(sys.executable).absolute().as_posix(),
         "-m",
         "virtualenv",
-        f"--prompt=({project.name}) ",
+        f"--prompt={project.name}",
         f"--python={python}",
         project.get_location_for_virtualenv(),
     ]


### PR DESCRIPTION
**The issue**
- Duplicate parentheses show when virtualenv is activated. It is happening because of a recent update in the virtualenv package(v20.10.0). In this version, the activated virtualenv prompt is now always wrapped in parentheses. This affects venvs created with the --prompt attribute, and matches virtualenv’s behaviour on par with venv.
https://virtualenv.pypa.io/en/latest/changelog.html#v20-10-0-2021-11-01

**The fix**
- Removed parentheses when virtualenv is created.

Previous behaviour:
```
$ pwd
/code/myproject

$ pipenv shell
((myproject) )$ 
```

New behaviour:
```
$ pipenv shell
(myproject) $
```