### PR TITLE
Fix the index parsing to reject illegal requirements

### DIFF
--- a/news/4899.bugfix.rst
+++ b/news/4899.bugfix.rst
@@ -1,0 +1,1 @@
+Fix the index parsing to reject illegal requirements.txt.

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -163,9 +163,13 @@ def import_requirements(project, r=None, dev=False):
     trusted_hosts = []
     # Find and add extra indexes.
     for line in contents.split("\n"):
-        line_indexes, _trusted_hosts, _ = parse_indexes(line.strip())
-        indexes.extend(line_indexes)
-        trusted_hosts.extend(_trusted_hosts)
+        index, extra_index, trusted_host, _ = parse_indexes(line.strip(), strict=True)
+        if index:
+            indexes = [index]
+        if extra_index:
+            indexes.append(extra_index)
+        if trusted_host:
+            trusted_hosts.append(trusted_host)
     indexes = sorted(set(indexes))
     trusted_hosts = sorted(set(trusted_hosts))
     reqs = [install_req_from_parsed_requirement(f) for f in parse_requirements(r, session=pip_requests)]

--- a/pipenv/patched/notpip/_internal/build_env.py
+++ b/pipenv/patched/notpip/_internal/build_env.py
@@ -17,7 +17,7 @@ from pipenv.patched.notpip._vendor.certifi import where
 from pipenv.patched.notpip._vendor.packaging.requirements import Requirement
 from pipenv.patched.notpip._vendor.packaging.version import Version
 
-from pipenv.patched.notpip import __file__ as pip_location
+from pip import __file__ as pip_location
 from pipenv.patched.notpip._internal.cli.spinners import open_spinner
 from pipenv.patched.notpip._internal.locations import get_platlib, get_prefixed_libs, get_purelib
 from pipenv.patched.notpip._internal.metadata import get_environment

--- a/pipenv/resolver.py
+++ b/pipenv/resolver.py
@@ -649,7 +649,7 @@ def parse_packages(packages, pre, clear, system, requirements_dir=None):
     from pipenv.utils import parse_indexes
     parsed_packages = []
     for package in packages:
-        indexes, trusted_hosts, line = parse_indexes(package)
+        *_, line = parse_indexes(package)
         line = " ".join(line)
         pf = dict()
         req = Requirement.from_line(line)

--- a/pipenv/utils.py
+++ b/pipenv/utils.py
@@ -2050,7 +2050,9 @@ def looks_like_dir(path):
 
 def parse_indexes(line, strict=False):
     from argparse import ArgumentParser
-    line = line.split("#")[0].strip()
+
+    comment_re = re.compile(r"(?:^|\s+)#.*$")
+    line = comment_re.sub("", line)
     parser = ArgumentParser("indexes")
     parser.add_argument("-i", "--index-url", dest="index")
     parser.add_argument("--extra-index-url", dest="extra_index")

--- a/pipenv/utils.py
+++ b/pipenv/utils.py
@@ -2051,7 +2051,7 @@ def looks_like_dir(path):
 def parse_indexes(line, strict=False):
     from argparse import ArgumentParser
     line = line.split("#")[0].strip()
-    parser = ArgumentParser("indexes", exit_on_error=False)
+    parser = ArgumentParser("indexes")
     parser.add_argument("-i", "--index-url", dest="index")
     parser.add_argument("--extra-index-url", dest="extra_index")
     parser.add_argument("--trusted-host", dest="trusted_host")

--- a/tasks/vendoring/patches/patched/_post_pip_import.patch
+++ b/tasks/vendoring/patches/patched/_post_pip_import.patch
@@ -26,3 +26,16 @@ index 0ba06c52..6fdb59b7 100644
  
  
  class LinkCandidate(_InstallRequirementBackedCandidate):
+diff --git a/pipenv/patched/notpip/_internal/build_env.py b/pipenv/patched/notpip/_internal/build_env.py
+index 05457c5a..d8c66b3f 100644
+--- a/pipenv/patched/notpip/_internal/build_env.py
++++ b/pipenv/patched/notpip/_internal/build_env.py
+@@ -17,7 +17,7 @@ from pipenv.patched.notpip._vendor.certifi import where
+ from pipenv.patched.notpip._vendor.packaging.requirements import Requirement
+ from pipenv.patched.notpip._vendor.packaging.version import Version
+ 
+-from pipenv.patched.notpip import __file__ as pip_location
++from pip import __file__ as pip_location
+ from pipenv.patched.notpip._internal.cli.spinners import open_spinner
+ from pipenv.patched.notpip._internal.locations import get_platlib, get_prefixed_libs, get_purelib
+ from pipenv.patched.notpip._internal.metadata import get_environment

--- a/tests/integration/test_install_basic.py
+++ b/tests/integration/test_install_basic.py
@@ -285,18 +285,23 @@ def test_requirements_to_pipfile(PipenvInstance, pypi):
 
         # Write a requirements file
         with open("requirements.txt", "w") as f:
-            f.write(f"-i {pypi.url}\nrequests[socks]==2.19.1\n")
+            f.write(
+                f"-i {pypi.url}\n"
+                "# -i https://private.pypi.org/simple\n"
+                "requests[socks]==2.19.1\n"
+            )
 
         c = p.pipenv("install")
         assert c.returncode == 0
         print(c.stdout)
         print(c.stderr)
-        print(subprocess_run(["ls", "-l"]).stdout)
-
         # assert stuff in pipfile
         assert "requests" in p.pipfile["packages"]
         assert "extras" in p.pipfile["packages"]["requests"]
-
+        assert not any(
+            source['url'] == 'https://private.pypi.org/simple'
+            for source in p.pipfile['source']
+        )
         # assert stuff in lockfile
         assert "requests" in p.lockfile["default"]
         assert "chardet" in p.lockfile["default"]

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -137,6 +137,29 @@ def test_convert_deps_to_pip_unicode():
     assert deps[0] == "django==1.10"
 
 
+@pytest.mark.parametrize("line,result", [
+    ("-i https://example.com/simple/", ("https://example.com/simple/", None, None, [])),
+    ("--extra-index-url=https://example.com/simple/", (None, "https://example.com/simple/", None, [])),
+    ("--trusted-host=example.com", (None, None, "example.com", [])),
+    ("# -i https://example.com/simple/", (None, None, None, [])),
+    ("requests", (None, None, None, ["requests"]))
+])
+@pytest.mark.utils
+def test_parse_indexes(line, result):
+    assert pipenv.utils.parse_indexes(line) == result
+
+
+@pytest.mark.parametrize("line", [
+    "-i https://example.com/simple/ --extra-index-url=https://extra.com/simple/",
+    "--extra-index-url https://example.com/simple/ --trusted-host=example.com",
+    "requests -i https://example.com/simple/",
+])
+@pytest.mark.utils
+def test_parse_indexes_individual_lines(line):
+    with pytest.raises(ValueError):
+        pipenv.utils.parse_indexes(line, strict=True)
+
+
 class TestUtils:
     """Test utility functions in pipenv"""
 


### PR DESCRIPTION

### The issue

- Global options such as `--index-url`, `--extra-index-url` must be on their own lines
- Text following a `#` is ignored as comment string