### PR TITLE
disallow abbreviated forms of full option names

### DIFF
--- a/pipenv/utils.py
+++ b/pipenv/utils.py
@@ -2053,7 +2053,7 @@ def parse_indexes(line, strict=False):
 
     comment_re = re.compile(r"(?:^|\s+)#.*$")
     line = comment_re.sub("", line)
-    parser = ArgumentParser("indexes")
+    parser = ArgumentParser("indexes", allow_abbrev=False)
     parser.add_argument("-i", "--index-url", dest="index")
     parser.add_argument("--extra-index-url", dest="extra_index")
     parser.add_argument("--trusted-host", dest="trusted_host")


### PR DESCRIPTION
Additional fix for #4899

Previously, due to default behavior of ArgumentParser, global --index-url,
--extra-index-url, and --trusted-host options in requirements files could be
abbreviated (e.g. "--index" == "--index-url"). As a result, unexpected
behavior could occur during processing of a requirements file with these
shortened option names when using Pipenv, which could be exploited by a
malicious actor to surreptitiously insert pip options using non-obvious
abbreviations.

For example, adding a line with "--t example.com" to the
requirements file would cause Pipenv to treat example.com as trusted, even
when example.com presents an invalid TLS certificate.

This commit disables support for abbreviated options in the ArgumentParser,
to align Pipenv's behavior when parsing global options in a requirements
file with the behavior in pip, as expected.