### PR TITLE
Use a PackageFinder with `ignore_compatibility` when collecting hashes

### DIFF
--- a/news/4885.bugfix.rst
+++ b/news/4885.bugfix.rst
@@ -1,0 +1,1 @@
+Fix regression where lockfiles would only include the hashes for releases for the platform generating the lockfile

--- a/pipenv/vendor/pip_shims/compat.py
+++ b/pipenv/vendor/pip_shims/compat.py
@@ -693,6 +693,7 @@ def get_package_finder(
         and "ignore_requires_python" in builder_args.args
     ):
         build_kwargs["ignore_requires_python"] = ignore_requires_python
+
     return install_cmd._build_package_finder(**build_kwargs)  # type: ignore
 
 


### PR DESCRIPTION
This fixes https://github.com/pypa/pipenv/issues/4885


### The checklist

* [x] Associated issue
* [X] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

<!--
### If this is a patch to the `vendor` directory...

Please try to refrain from submitting patches directly to `vendor` or `patched`, but raise your issue to the upstream project instead, and inform Pipenv to upgrade when the upstream project accepts the fix.

A pull request to upgrade vendor packages is strongly discouraged, unless there is a very good reason (e.g. you need to test Pipenv’s integration to a new vendor feature). Pipenv audits and performs vendor upgrades regularly, generally before a new release is about to drop.

If your patch is not or cannot be accepted by upstream, but is essential to Pipenv (make sure to discuss this with maintainers!), please remember to attach a patch file in `tasks/vendoring/patched`, so this divergence from upstream can be recorded and replayed afterwards.
-->
