### PR TITLE
Remove leftover include of jinja2 files

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,21 +2,24 @@ include LICENSE README.md CONTRIBUTING.md CHANGELOG.rst NOTICES HISTORY.txt
 include Makefile pyproject.toml get-pipenv.py *.yml
 include examples/Pipfil*
 include *.md
+
 recursive-include pipenv LICENSE LICENSE* *LICENSE* *COPYING* t32.exe t64.exe w32.exe w64.exe cacert.pem
 recursive-include pipenv *.cfg
-recursive-include pipenv/vendor *.c *.j2
+recursive-include pipenv/vendor *.c
 recursive-include pipenv *.md *.APACHE *.BSD
 recursive-include pipenv Makefile
 recursive-include pipenv/vendor vendor.txt
 recursive-include pipenv README
 recursive-include pipenv *.json
 recursive-include pipenv *.rst
+
 include pipenv/patched/notpip/_vendor/vendor.txt
 include pipenv/patched/safety.zip pipenv/patched/patched.txt
 include pipenv/vendor/pipreqs/stdlib pipenv/vendor/pipreqs/mapping
 include pipenv/vendor/*.txt pipenv/vendor/pexpect/bashrc.sh
 include pipenv/vendor/Makefile
 include pipenv/pipenv.1
+
 exclude .gitmodules
 exclude .editorconfig .travis.yml .env appveyor.yml tox.ini pytest.ini
 exclude Pipfile* CHANGELOG.draft.rst


### PR DESCRIPTION
This was probably due to pipenv relying on Jinja2 in the
past.
However, Jinja2 was removed in 11229406ba8ac966bd4def4612847317c4d82455

