### PR TITLE
Fix typo in docker documnetation

### DIFF
--- a/docs/basics.rst
+++ b/docs/basics.rst
@@ -468,7 +468,7 @@ doing a multi stage build for your application::
 
   USER coolio
 
-  CMD ["/venv/bin/python", "-m", "run.py"]
+  CMD ["./venv/bin/python", "-m", "run.py"]
 
 .. Note::
 


### PR DESCRIPTION
This is now the correct path for running the application code.
