### PR TITLE
fixed review from #4780, closes #4537

### DIFF
--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -483,11 +483,11 @@ def ensure_virtualenv(project, three=None, python=None, site_packages=None, pypi
         # about, so confirm first.
         if "VIRTUAL_ENV" in os.environ:
             if not (
-                project.s.PIPENV_YES or click.confirm("Remove existing virtualenv?", default=True)
+                project.s.PIPENV_YES or click.confirm("Use existing virtualenv?", default=True)
             ):
                 abort()
         click.echo(
-            crayons.normal(fix_utf8("Removing existing virtualenv..."), bold=True), err=True
+            crayons.normal(fix_utf8("Using existing virtualenv..."), bold=True), err=True
         )
         # Remove the virtualenv.
         cleanup_virtualenv(project, bare=True)
@@ -517,7 +517,7 @@ def ensure_project(
     """Ensures both Pipfile and virtualenv exist for the project."""
 
     # Automatically use an activated virtualenv.
-    if project.s.PIPENV_USE_SYSTEM:
+    if project.s.PIPENV_USE_SYSTEM or project.virtualenv_exists:
         system = True
     if not project.pipfile_exists and deploy:
         raise exceptions.PipfileNotFound


### PR DESCRIPTION
### The issue #4537

This pull request should fixes #4537 . 

### The fix

The behavior where `PIPENV_SITE_PACKAGES=1` always deletes and recreates an existing environment when typing `pipenv` is eliminated by this pull request.


### The checklist

* [x] Associated issue
* [ ] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

### Comment
Unfortunately I don't know what to insert the news/ folder and how it should look like. Please give me an example or explanation.

