### PR TITLE
rollback `pipenv run` behavior to before 2021.11.5 on Windows

### DIFF
--- a/news/4935.behavior.rst
+++ b/news/4935.behavior.rst
@@ -1,0 +1,1 @@
+Pattern expansion for arguments was disabled on Windows.

--- a/pipenv/cli/options.py
+++ b/pipenv/cli/options.py
@@ -46,6 +46,12 @@ class PipenvGroup(DYMMixin, Group):
             help="Show this message and exit.",
         )
 
+    def main(self, *args, **kwargs):
+        """
+        to add the windows_expand_args option to avoid exceptions on Windows
+        see: https://github.com/pallets/click/issues/1901
+        """
+        return super().main(*args, **kwargs, windows_expand_args=False)
 
 class State:
     def __init__(self):

--- a/pipenv/cli/options.py
+++ b/pipenv/cli/options.py
@@ -48,7 +48,7 @@ class PipenvGroup(DYMMixin, Group):
 
     def main(self, *args, **kwargs):
         """
-        to add the windows_expand_args option to avoid exceptions on Windows
+        to specify the windows_expand_args option to avoid exceptions on Windows
         see: https://github.com/pallets/click/issues/1901
         """
         return super().main(*args, **kwargs, windows_expand_args=False)

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -291,3 +291,9 @@ sqlalchemy = "<=1.2.3"
             f.write(contents)
         c = p.pipenv('update --pre --outdated')
         assert c.returncode == 0
+
+@pytest.mark.cli
+def test_pipenv_run_with_special_chars(PipenvInstance):
+    with PipenvInstance():
+        c = subprocess_run(["pipenv", "run", "echo", "[3-1]"])
+        assert c.returncode == 0, c.stderr

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -291,9 +291,3 @@ sqlalchemy = "<=1.2.3"
             f.write(contents)
         c = p.pipenv('update --pre --outdated')
         assert c.returncode == 0
-
-@pytest.mark.cli
-def test_pipenv_run_with_special_chars(PipenvInstance):
-    with PipenvInstance():
-        c = subprocess_run(["pipenv", "run", "echo", "[3-1]"])
-        assert c.returncode == 0, c.stderr

--- a/tests/integration/test_windows.py
+++ b/tests/integration/test_windows.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 import pytest
 
+from pipenv.utils import subprocess_run
 
 # This module is run only on Windows.
 pytestmark = pytest.mark.skipif(os.name != 'nt', reason="only relevant on windows")
@@ -78,3 +79,10 @@ def test_pipenv_clean_windows(PipenvInstance):
         c = p.pipenv('clean --dry-run')
         assert c.returncode == 0
         assert 'click' in c.stdout.strip()
+
+
+@pytest.mark.cli
+def test_pipenv_run_with_special_chars_windows(PipenvInstance):
+    with PipenvInstance():
+        c = subprocess_run(["pipenv", "run", "echo", "[3-1]"])
+        assert c.returncode == 0, c.stderr

--- a/tests/integration/test_windows.py
+++ b/tests/integration/test_windows.py
@@ -80,7 +80,6 @@ def test_pipenv_clean_windows(PipenvInstance):
         assert c.returncode == 0
         assert 'click' in c.stdout.strip()
 
-
 @pytest.mark.cli
 def test_pipenv_run_with_special_chars_windows(PipenvInstance):
     with PipenvInstance():


### PR DESCRIPTION
### The issue

Fixes #4935 

### The fix

We have two options about this issue.

- disable `windows_expand_args` for avoid exception.
  - If you disable this, you will not be able to expand the arguments on Windows. However, this is the same behavior as before version 2021.11.5.
  - This PR provides this solution.
- report this issue to upstream project and continue to use `windows_expand_args` feature.
  - If you select this choice, please close this PR.
  - Upstream project may not be consider this issue a problem.


### The checklist

* [x] Associated issue
* [x] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

<!--
### If this is a patch to the `vendor` directory...

Please try to refrain from submitting patches directly to `vendor` or `patched`, but raise your issue to the upstream project instead, and inform Pipenv to upgrade when the upstream project accepts the fix.

A pull request to upgrade vendor packages is strongly discouraged, unless there is a very good reason (e.g. you need to test Pipenv’s integration to a new vendor feature). Pipenv audits and performs vendor upgrades regularly, generally before a new release is about to drop.

If your patch is not or cannot be accepted by upstream, but is essential to Pipenv (make sure to discuss this with maintainers!), please remember to attach a patch file in `tasks/vendoring/patched`, so this divergence from upstream can be recorded and replayed afterwards.
-->
