### PR TITLE
improve detection of CI

### DIFF
--- a/news/4944.bugfix.mdB
+++ b/news/4944.bugfix.mdB
@@ -1,0 +1,1 @@
+Use `CI` environment value, over mere existence of name

--- a/pipenv/environments.py
+++ b/pipenv/environments.py
@@ -99,7 +99,7 @@ def normalize_pipfile_path(p):
 os.environ.pop("__PYVENV_LAUNCHER__", None)
 # Internal, to tell whether the command line session is interactive.
 SESSION_IS_INTERACTIVE = _isatty(sys.stdout)
-PIPENV_IS_CI = bool("CI" in os.environ or "TF_BUILD" in os.environ)
+PIPENV_IS_CI = env_to_bool(os.environ.get('CI') or os.environ.get('TF_BUILD') or False)
 PIPENV_COLORBLIND = bool(os.environ.get("PIPENV_COLORBLIND"))
 """If set, disable terminal colors.
 


### PR DESCRIPTION
Thank you for contributing to Pipenv!

### The issue

`CI` can sometimes be set to `false` or a non-truthy value, in which case, `PIPENV_IS_CI` should not assume it is always true just because it exists.

### The fix

check the actual values of the environment variable, instead of just the existence of the name in the environment

### The checklist

* [ ] Associated issue
* [x] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

<!--
### If this is a patch to the `vendor` directory...

Please try to refrain from submitting patches directly to `vendor` or `patched`, but raise your issue to the upstream project instead, and inform Pipenv to upgrade when the upstream project accepts the fix.

A pull request to upgrade vendor packages is strongly discouraged, unless there is a very good reason (e.g. you need to test Pipenv’s integration to a new vendor feature). Pipenv audits and performs vendor upgrades regularly, generally before a new release is about to drop.

If your patch is not or cannot be accepted by upstream, but is essential to Pipenv (make sure to discuss this with maintainers!), please remember to attach a patch file in `tasks/vendoring/patched`, so this divergence from upstream can be recorded and replayed afterwards.
-->
