### PR TITLE
Fixes installing versions with pyenv-win

### DIFF
--- a/news/4525.bugfix.rst
+++ b/news/4525.bugfix.rst
@@ -1,0 +1,1 @@
+Python versions on Windows can now be installed automatically through pyenv-win

--- a/pipenv/installers.py
+++ b/pipenv/installers.py
@@ -191,11 +191,11 @@ class Pyenv(Installer):
         A ValueError is raised if the given version does not have a match in
         pyenv. A InstallerError is raised if the pyenv command fails.
         """
-        c = self._run(
-            'install', '-s', str(version),
-            timeout=self.project.s.PIPENV_INSTALL_TIMEOUT,
-        )
-        return c
+        args = ['install', '-s', str(version)]
+        if Pyenv.WIN:
+            # pyenv-win skips installed versions by default and does not support -s
+            del args[1]
+        return self._run(*args, timeout=self.project.s.PIPENV_INSTALL_TIMEOUT)
 
 
 class Asdf(Installer):

--- a/pipenv/installers.py
+++ b/pipenv/installers.py
@@ -1,6 +1,7 @@
 import os
 import operator
 import re
+import sys
 from abc import ABCMeta, abstractmethod
 
 from pipenv.vendor import attr
@@ -81,7 +82,7 @@ class Installer(metaclass=ABCMeta):
         installer.
 
         pyenv/asdf are not always present on PATH. Both installers also support a
-        custom environment variable (PYENV_ROOT or ASDF_DIR) which alows them to
+        custom environment variable (PYENV_ROOT or ASDF_DIR) which allows them to
         be installed into a non-default location (the default/suggested source
         install location is in ~/.pyenv or ~/.asdf).
 
@@ -113,11 +114,12 @@ class Installer(metaclass=ABCMeta):
 
     def _run(self, *args, **kwargs):
         timeout = kwargs.pop('timeout', 30)
+        shell = kwargs.pop('shell', False)
         if kwargs:
             k = list(kwargs.keys())[0]
             raise TypeError(f'unexpected keyword argument {k!r}')
         args = (self.cmd,) + tuple(args)
-        c = subprocess_run(args, timeout=timeout)
+        c = subprocess_run(args, timeout=timeout, shell=shell)
         if c.returncode != 0:
             raise InstallerError(f'failed to run {args}', c)
         return c
@@ -162,9 +164,15 @@ class Installer(metaclass=ABCMeta):
 
 
 class Pyenv(Installer):
+    WIN = sys.platform.startswith("win") or (sys.platform == "cli" and os.name == "nt")
 
     def _find_installer(self):
         return self._find_python_installer_by_name_and_env('pyenv', 'PYENV_ROOT')
+
+    def _run(self, *args, **kwargs):
+        if Pyenv.WIN:
+            kwargs['shell'] = True
+        return super(Pyenv, self)._run(*args, **kwargs)
 
     def iter_installable_versions(self):
         """Iterate through CPython versions available for Pipenv to install.


### PR DESCRIPTION
This fixes https://github.com/pypa/pipenv/issues/4525

This issue has two parts: 
1. How `pipenv` calls `pipenv-win.bat` as mentioned by @uranusjr [here](https://github.com/pypa/pipenv/issues/4525#issuecomment-723733593).
2. `pyenv-win` not supporting the `-s/--skip-existing` flags while `pyenv` does, as mentioned by @i3v [here](https://github.com/pypa/pipenv/issues/4525#issuecomment-829641410). Luckily this is done automatically in `pyenv-win`, and it does not ask for user input which I guess it's why it was added in the first place. I initially opened a [PR](https://github.com/pyenv-win/pyenv-win/pull/350) in `pyenv-win` to add support for it but then realized more differences between the original vs the Windows versions which made me finally close it and go for this path.
3. (extra) https://github.com/pypa/pipenv/issues/3551 used to pop up after fixing 1 and 2, but now that it's fixed it doesn't happen anymore and pipenv correctly detects the installed Python version.

To fix it, I have ensured that `shell=True` is passed to `subprocess_run` when running the pyenv install code under Windows, and I've removed the `-s` from the `pyenv install -s <version>` command under the same conditions, since the final behaviour will be the same (no prompts and skip installation if it already exists).

### My local tests, on Windows 10 and Ubuntu 20.04:

#### Test Pipfile:
```
[dev-packages]
click = "*"

[packages]

[requires]
python_version = "3.9.5"
```

#### pipenv output (with `PIPENV_YES=1`)
##### Windows 10
```
(pipenv-hqjmwcWy) pipenvC:\Users\JANDOL\PycharmProjects\pipenv\test_env>pipenv install
Warning: Python 3.9.5 was not found on your system...
Installing CPython 3.9.5 with C:\Users\JANDOL\.pyenv\pyenv-win\bin\pyenv (this may take a few minutes)...
Success!
:: [Info] ::  Mirror: https://www.python.org/ftp/python
:: [Installing] ::  3.9.5 ...
:: [Info] :: completed! 3.9.5

Creating a virtualenv for this project...
Pipfile: C:\Users\JANDOL\PycharmProjects\pipenv\test_env\Pipfile
Using C:/Users/JANDOL/.pyenv/pyenv-win/versions/3.9.5/python3.exe (3.9.5) to create virtualenv...
[=== ] Creating virtual environment...created virtual environment CPython3.9.5.final.0-64 in 887ms
  creator CPython3Windows(dest=C:\Users\JANDOL\.virtualenvs\test_env-H1w2rDID, clear=False, no_vcs_ignore=False, global=False)
  seeder FromAppData(download=False, pip=bundle, setuptools=bundle, wheel=bundle, via=copy, app_data_dir=C:\Users\JANDOL\AppData\Local\pypa\virtualenv)
    added seed packages: pip==21.3.1, setuptools==60.5.0, wheel==0.37.1
  activators BashActivator,BatchActivator,FishActivator,NushellActivator,PowerShellActivator,PythonActivator

Successfully created virtual environment!
Virtualenv location: C:\Users\JANDOL\.virtualenvs\test_env-H1w2rDID
Installing dependencies from Pipfile.lock (04419a)...
  ================================ 0/0 - 00:00:00


(pipenv-hqjmwcWy) pipenvC:\Users\JANDOL\PycharmProjects\pipenv\test_env>pipenv install
Installing dependencies from Pipfile.lock (04419a)...
  ================================ 0/0 - 00:00:00
```

##### Ubuntu 20.04
```
((pipenv) ) aalvarez@aalvarez-Precision-7550:~/src/personal/pipenv/test_env (main)$ pipenv install
Warning: Python 3.9.5 was not found on your system...
Installing CPython 3.9.5 with /home/aalvarez/.pyenv/bin/pyenv (this may take a few minutes)...
✔ Success! 

Creating a virtualenv for this project...
Pipfile: /home/aalvarez/src/personal/pipenv/test_env/Pipfile
Using /home/aalvarez/.pyenv/versions/3.9.5/bin/python3.9 (3.9.5) to create virtualenv...
⠸ Creating virtual environment...created virtual environment CPython3.9.5.final.0-64 in 228ms
  creator CPython3Posix(dest=/home/aalvarez/.local/share/virtualenvs/test_env-6zfULtvW, clear=False, no_vcs_ignore=False, global=False)
  seeder FromAppData(download=False, pip=bundle, setuptools=bundle, wheel=bundle, via=copy, app_data_dir=/home/aalvarez/.local/share/virtualenv)
    added seed packages: pip==21.3.1, setuptools==60.5.0, wheel==0.37.1
  activators BashActivator,CShellActivator,FishActivator,NushellActivator,PowerShellActivator,PythonActivator
✔ Successfully created virtual environment! 
Virtualenv location: /home/aalvarez/.local/share/virtualenvs/test_env-6zfULtvW
Installing dependencies from Pipfile.lock (04419a)...
  🐍   ▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉ 0/0 — 00:00:00
To activate this project's virtualenv, run pipenv shell.
Alternatively, run a command inside the virtualenv with pipenv run.


((pipenv) ) aalvarez@aalvarez-Precision-7550:~/src/personal/pipenv/test_env (main)$ pipenv install
Installing dependencies from Pipfile.lock (04419a)...
  🐍   ▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉ 0/0 — 00:00:00
To activate this project's virtualenv, run pipenv shell.
Alternatively, run a command inside the virtualenv with pipenv run.
```
Thank you very much for your time, I'll be happy to change/update things if required :smile: 
