### PR TITLE
Windows: locate pyenv from PATH correctly

### DIFF
--- a/pipenv/utils.py
+++ b/pipenv/utils.py
@@ -14,7 +14,6 @@ import sys
 import warnings
 
 from contextlib import contextmanager
-from distutils.spawn import find_executable
 from pathlib import Path
 from urllib.parse import urlparse
 

--- a/pipenv/utils.py
+++ b/pipenv/utils.py
@@ -1623,7 +1623,7 @@ def find_windows_executable(bin_path, exe_name):
             if os.path.isfile(path):
                 return path
 
-    return find_executable(exe_name)
+    return shutil.which(exe_name)
 
 
 def path_to_url(path):


### PR DESCRIPTION
### The issue

In debugging other Windows related pipenv issues, I had to patch this locally to get windows to find pyenv which was already on the PATH.  This combined with the latest fix:  https://github.com/pypa/pipenv/pull/4929 allowed pipenv to finally use pyenv-win on windows successfully to install other versions of python beyond what I had installed at a system level or manually using pyenv-win.  

What is the thing you want to fix? Is it associated with an issue on GitHub? Please mention it.

Pipenv should be able to use the pyenv already on the path in windows, instead of printing:
```
$ pipenv sync
Warning: Python 3.9 was not found on your system...
Neither 'pyenv' nor 'asdf' could be found to install Python.
You can specify specific versions of Python with:
$ pipenv --python path\to\python
```

If your pull request makes a non-insignificant change to Pipenv, such as the user interface or intended functionality, please file a PEEP.

    Non-significant change.

### The fix

How does this pull request fix your problem? Did you consider any alternatives? Why is this the *best* solution, in your opinion?

After chatting with @oz123 he suggested trying `shutil.which` and that resolved the issue.  Apparently `shutil` should be able to do job and is more modern than `distutils` which is scheduled to go away in Python 3.12


### The checklist

* [ ] Associated issue
* [ ] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.
