### PR TITLE
fixes issue with infinite iteration, infinite locking. Makes lock deterministic, again

### DIFF
--- a/pipenv/patched/notpip/_internal/resolution/resolvelib/factory.py
+++ b/pipenv/patched/notpip/_internal/resolution/resolvelib/factory.py
@@ -325,6 +325,7 @@ class Factory:
             base_cand = as_base_candidate(lookup_cand)
             assert base_cand is not None, "no extras here"
             yield self._make_extras_candidate(base_cand, extras)
+        raise StopIteration
 
     def _iter_candidates_from_constraints(
         self,
@@ -348,6 +349,7 @@ class Factory:
             )
             if candidate:
                 yield candidate
+        raise StopIteration
 
     def find_candidates(
         self,

--- a/pipenv/patched/notpip/_internal/resolution/resolvelib/factory.py
+++ b/pipenv/patched/notpip/_internal/resolution/resolvelib/factory.py
@@ -325,7 +325,6 @@ class Factory:
             base_cand = as_base_candidate(lookup_cand)
             assert base_cand is not None, "no extras here"
             yield self._make_extras_candidate(base_cand, extras)
-        raise StopIteration
 
     def _iter_candidates_from_constraints(
         self,
@@ -349,7 +348,6 @@ class Factory:
             )
             if candidate:
                 yield candidate
-        raise StopIteration
 
     def find_candidates(
         self,

--- a/pipenv/patched/notpip/_internal/resolution/resolvelib/factory.py
+++ b/pipenv/patched/notpip/_internal/resolution/resolvelib/factory.py
@@ -295,6 +295,8 @@ class Factory:
                 )
                 yield ican.version, func
 
+            raise StopIteration
+
         return FoundCandidates(
             iter_index_candidate_infos,
             _get_installed_candidate(),

--- a/pipenv/patched/notpip/_internal/resolution/resolvelib/found_candidates.py
+++ b/pipenv/patched/notpip/_internal/resolution/resolvelib/found_candidates.py
@@ -32,8 +32,9 @@ def _iter_built(infos: Iterator[IndexCandidateInfo]) -> Iterator[Candidate]:
         candidate = func()
         if candidate is None:
             continue
-        yield candidate
         versions_found.add(version)
+        yield candidate
+    raise StopIteration
 
 
 def _iter_built_with_prepended(
@@ -46,8 +47,10 @@ def _iter_built_with_prepended(
     always yielded first, and candidates from index come later in their
     normal ordering, except skipped when the version is already installed.
     """
-    yield installed
-    versions_found: Set[_BaseVersion] = {installed.version}
+    versions_found: Set[_BaseVersion] = set()
+    if installed:
+        versions_found.add(installed.version)
+        yield installed
     for version, func in infos:
         if version in versions_found:
             continue
@@ -56,6 +59,7 @@ def _iter_built_with_prepended(
             continue
         yield candidate
         versions_found.add(version)
+    raise StopIteration
 
 
 def _iter_built_with_inserted(
@@ -88,6 +92,8 @@ def _iter_built_with_inserted(
     # If the installed candidate is older than all other candidates.
     if installed.version not in versions_found:
         yield installed
+
+    raise StopIteration
 
 
 class FoundCandidates(collections_abc.Sequence):

--- a/pipenv/patched/notpip/_internal/resolution/resolvelib/found_candidates.py
+++ b/pipenv/patched/notpip/_internal/resolution/resolvelib/found_candidates.py
@@ -34,7 +34,6 @@ def _iter_built(infos: Iterator[IndexCandidateInfo]) -> Iterator[Candidate]:
             continue
         versions_found.add(version)
         yield candidate
-    raise StopIteration
 
 
 def _iter_built_with_prepended(
@@ -59,7 +58,6 @@ def _iter_built_with_prepended(
             continue
         yield candidate
         versions_found.add(version)
-    raise StopIteration
 
 
 def _iter_built_with_inserted(
@@ -92,8 +90,6 @@ def _iter_built_with_inserted(
     # If the installed candidate is older than all other candidates.
     if installed.version not in versions_found:
         yield installed
-
-    raise StopIteration
 
 
 class FoundCandidates(collections_abc.Sequence):


### PR DESCRIPTION
### The issue
In debugging the infinity lock issue reports, this should solve for:
* https://github.com/pypa/pipenv/issues/4651
* https://github.com/pypa/pipenv/issues/4926

### The fix

This fixes the problem of of a series of methods that return a `Iterator[IndexCandidateInfo]` but this inner most method would sometimes have a empty list of `icans` and the function returned None, which lead to an infinite iteration when trying to evaluate `Criterion.candidates` for certain dependencies being resolved.    Before this change, the locking would eventually fail once it reached max iterations here: https://github.com/pypa/pipenv/blob/main/pipenv/patched/notpip/_internal/resolution/resolvelib/resolver.py#L93

### The checklist

* [X] Associated issue
* [ ] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

### If this is a patch to the `vendor` directory...

> Please try to refrain from submitting patches directly to `vendor` or `patched`, but raise your issue to the upstream project instead, and inform Pipenv to upgrade when the upstream project accepts the fix.

This is the `patched/notpip/_internal` which seems to only be implementation specific to `pipenv`.  I doubt there is somewhere upstream to fix this.
