### PR TITLE
Fix for expanding dot env variables in scripts

### DIFF
--- a/news/4975.bugfix.rst
+++ b/news/4975.bugfix.rst
@@ -1,0 +1,1 @@
+Environment variables from dot env files are now properly expanded when included in scripts.

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -103,25 +103,23 @@ def load_dot_env(project, as_dict=False):
             [project_directory, ".env"]
         )
 
-        if os.path.isfile(dotenv_file):
+        if not os.path.isfile(dotenv_file) and project.s.PIPENV_DOTENV_LOCATION:
+            click.echo(
+                "{}: file {}={} does not exist!!\n{}".format(
+                    crayons.red("Warning", bold=True),
+                    crayons.normal("PIPENV_DOTENV_LOCATION", bold=True),
+                    crayons.normal(project.s.PIPENV_DOTENV_LOCATION, bold=True),
+                    crayons.red("Not loading environment variables.", bold=True),
+                ),
+                err=True,
+            )
+        if as_dict:
+            return dotenv.dotenv_values(dotenv_file)
+        else:
             click.echo(
                 crayons.normal(fix_utf8("Loading .env environment variables..."), bold=True),
                 err=True,
             )
-        else:
-            if project.s.PIPENV_DOTENV_LOCATION:
-                click.echo(
-                    "{}: file {}={} does not exist!!\n{}".format(
-                        crayons.red("Warning", bold=True),
-                        crayons.normal("PIPENV_DOTENV_LOCATION", bold=True),
-                        crayons.normal(project.s.PIPENV_DOTENV_LOCATION, bold=True),
-                        crayons.red("Not loading environment variables.", bold=True),
-                    ),
-                    err=True,
-                )
-        if as_dict:
-            return dotenv.dotenv_values(dotenv_file)
-        else:
             dotenv.load_dotenv(dotenv_file, override=True)
             project.s.initialize()
 
@@ -2473,8 +2471,8 @@ def do_run(project, command, args, three=None, python=False, pypi_mirror=None):
         project, three=three, python=python, validate=False, pypi_mirror=pypi_mirror,
     )
 
+    load_dot_env(project)
     env = os.environ.copy()
-    env.update(load_dot_env(project, as_dict=True) or {})
     env.pop("PIP_SHIMS_BASE_MODULE", None)
 
     path = env.get('PATH', '')

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -118,7 +118,7 @@ def load_dot_env(project, as_dict=False):
         else:
             click.echo(
                 crayons.normal(fix_utf8("Loading .env environment variables..."), bold=True),
-                err=True,
+                err=False,
             )
             dotenv.load_dotenv(dotenv_file, override=True)
             project.s.initialize()

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -211,6 +211,27 @@ pyver = "which python"
 
 
 @pytest.mark.cli
+def test_scripts_resolve_dot_env_vars(PipenvInstance):
+    with PipenvInstance() as p:
+        with open(".env", "w") as f:
+            contents = """
+HELLO=WORLD
+            """.strip()
+            f.write(contents)
+
+        with open(p.pipfile_path, "w") as f:
+            contents = """
+[scripts]
+hello = "echo $HELLO"
+            """.strip()
+            f.write(contents)
+        c = p.pipenv('run hello')
+        print(c)
+        print(c.stdout)
+        assert 'WORLD' in c.stdout
+
+
+@pytest.mark.cli
 def test_help(PipenvInstance):
     with PipenvInstance() as p:
         assert p.pipenv('--help').stdout

--- a/tests/integration/test_lock.py
+++ b/tests/integration/test_lock.py
@@ -457,7 +457,7 @@ def test_outdated_setuptools_with_pep517_legacy_build_meta_is_updated(PipenvInst
         assert c.returncode == 0
         c = p.pipenv("run python -c 'import setuptools; print(setuptools.__version__)'")
         assert c.returncode == 0
-        assert c.stdout.strip() == "40.2.0"
+        assert c.stdout.splitlines()[1] == "40.2.0"
         c = p.pipenv("install legacy-backend-package")
         assert c.returncode == 0
         assert "vistir" in p.lockfile["default"]
@@ -481,7 +481,7 @@ def test_outdated_setuptools_with_pep517_cython_import_in_setuppy(PipenvInstance
         assert c.returncode == 0
         c = p.pipenv("run python -c 'import setuptools; print(setuptools.__version__)'")
         assert c.returncode == 0
-        assert c.stdout.strip() == "40.2.0"
+        assert c.stdout.splitlines()[1] == "40.2.0"
         c = p.pipenv("install cython-import-package")
         assert c.returncode == 0
         assert "vistir" in p.lockfile["default"]

--- a/tests/integration/test_project.py
+++ b/tests/integration/test_project.py
@@ -189,7 +189,7 @@ def test_run_in_virtualenv_with_global_context(PipenvInstance, virtualenv):
 
         c = p.pipenv("run python -c 'import click;print(click.__file__)'")
         assert c.returncode == 0, (c.stdout, c.stderr)
-        assert is_in_path(c.stdout.strip(), str(virtualenv)), (c.stdout.strip(), str(virtualenv))
+        assert is_in_path(c.stdout.splitlines()[1], str(virtualenv)), (c.stdout.splitlines()[1], str(virtualenv))
 
         c = p.pipenv("clean --dry-run")
         assert c.returncode == 0, (c.stdout, c.stderr)
@@ -210,7 +210,7 @@ def test_run_in_virtualenv(PipenvInstance):
         assert c.returncode == 0
         c = p.pipenv('run python -c "import click;print(click.__file__)"')
         assert c.returncode == 0
-        assert normalize_path(c.stdout.strip()).startswith(
+        assert normalize_path(c.stdout.splitlines()[1]).startswith(
             normalize_path(str(project.virtualenv_location))
         )
         c = p.pipenv("clean --dry-run")

--- a/tests/integration/test_run.py
+++ b/tests/integration/test_run.py
@@ -36,12 +36,12 @@ multicommand = "bash -c \"cd docs && make html\""
         assert c.returncode == 0
         c = p.pipenv('run printfoo')
         assert c.returncode == 0
-        assert c.stdout.splitlines()[0] == 'foo'
+        assert c.stdout.splitlines()[1] == 'foo'
         assert not c.stderr.strip()
 
         c = p.pipenv('run notfoundscript')
         assert c.returncode != 0
-        assert c.stdout == ''
+        assert c.stdout == 'Loading .env environment variables...\n'
         if os.name != 'nt':     # TODO: Implement this message for Windows.
             assert 'not found' in c.stderr
 
@@ -60,7 +60,7 @@ multicommand = "bash -c \"cd docs && make html\""
             c = p.pipenv("run scriptwithenv")
             assert c.returncode == 0
             if os.name != "nt":  # This doesn't work on CI windows.
-                assert c.stdout.strip() == "WORLD"
+                assert c.stdout.splitlines()[1] == "WORLD"
 
 
 @pytest.mark.run

--- a/tests/integration/test_run.py
+++ b/tests/integration/test_run.py
@@ -80,5 +80,5 @@ def test_run_with_usr_env_shebang(PipenvInstance):
         c = p.pipenv("run ./test_script")
         assert c.returncode == 0
         project = Project()
-        lines = [line.strip() for line in c.stdout.splitlines()]
+        lines = [line.strip() for line in c.stdout.splitlines()[1:]]
         assert all(line == project.virtualenv_location for line in lines)


### PR DESCRIPTION
Ensure that dot env variables are actually in the real environment so they can be exapnded by os.path.expandvars

### The issue

https://github.com/pypa/pipenv/issues/4975
https://github.com/pypa/pipenv/issues/3901

### The fix

The problem is that in the current code we are loading the .env variables into a copy of the environment which is not available to `os.path.expandvars` so they are always treated as a string.  This fixes that by applying it to the environment before copying it.  Also refactor away some of the complexity of `load_dot_env`.


### The checklist

* [X] Associated issue
* [X] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

