### PR TITLE
Remove mention of the --two flag and python2

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,9 +106,8 @@ activate a virtualenv, run `$ pipenv shell`).
 -   A virtualenv will automatically be created, when one doesn\'t exist.
 -   When no parameters are passed to `install`, all packages
     `[packages]` specified will be installed.
--   To initialize a Python 3 virtual environment, run
+-   To initialize a virtual environment with system python3, run
     `$ pipenv --three`.
--   To initialize a Python 2 virtual environment, run `$ pipenv --two`.
 -   Otherwise, whatever virtualenv defaults to will be the default.
 
 ### Other Commands
@@ -154,7 +153,7 @@ Magic shell completions are now enabled!
       --rm             Remove the virtualenv.
       --bare           Minimal output.
       --man            Display manpage.
-      --three / --two  Use Python 3/2 when creating virtualenv.
+      --three          Use Python 3 when creating virtualenv.
       --python TEXT    Specify which version of Python virtualenv should use.
       --site-packages  Enable site-packages for the virtualenv.
       --version        Show the version and exit.
@@ -162,8 +161,8 @@ Magic shell completions are now enabled!
 
 
     Usage Examples:
-       Create a new project using Python 3.7, specifically:
-       $ pipenv --python 3.7
+       Create a new project using Python 3.9, specifically:
+       $ pipenv --python 3.9
 
        Remove project virtualenv (inferred from current directory):
        $ pipenv --rm

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -636,4 +636,4 @@ You can force Pipenv to use a different cache location by setting the environmen
 ☤ Changing Default Python Versions
 ----------------------------------
 
-By default, Pipenv will initialize a project using whatever version of python the python3 is. Besides starting a project with the ``--three`` or ``--two`` flags, you can also use ``PIPENV_DEFAULT_PYTHON_VERSION`` to specify what version to use when starting a project when ``--three`` or ``--two`` aren't used.
+By default, Pipenv will initialize a project using whatever version of python the system has as default. Besides starting a project with the ``--python`` or ``--three`` flags, you can also use ``PIPENV_DEFAULT_PYTHON_VERSION`` to specify what version to use when starting a project when ``--python`` or ``--three`` aren't used.

--- a/docs/basics.rst
+++ b/docs/basics.rst
@@ -306,7 +306,6 @@ Along with the basic install command, which takes the form::
 
 The user can provide these additional parameters:
 
-    - ``--two`` — Performs the installation in a virtualenv using the system ``python2`` link.
     - ``--three`` — Performs the installation in a virtualenv using the system ``python3`` link.
     - ``--python`` — Performs the installation in a virtualenv using the provided Python interpreter.
 
@@ -437,7 +436,7 @@ doing a multi stage build for your application::
   ENV PIPENV_VENV_IN_PROJECT=1
 
   # Pipefile contains requests
-  ADD Pipfile.lock Pipfile /usr/src/ 
+  ADD Pipfile.lock Pipfile /usr/src/
 
   WORKDIR /usr/src
 
@@ -448,13 +447,13 @@ doing a multi stage build for your application::
 
   # RUN apt install -y libcurl3-gnutls libcurl4-gnutls-dev
 
-  RUN /root/.local/bin/pipenv sync 
+  RUN /root/.local/bin/pipenv sync
 
   RUN /usr/src/.venv/bin/python -c "import requests; print(requests.__version__)"
 
   FROM docker.io/python:3.9 AS runtime
 
-  RUN mkdir -v /usr/src/venv 
+  RUN mkdir -v /usr/src/venv
 
   COPY --from=builder /usr/src/.venv/ /usr/src/venv/
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -99,7 +99,6 @@ Basic Concepts
 - A virtualenv will automatically be created, when one doesn't exist.
 - When no parameters are passed to ``install``, all packages ``[packages]`` specified will be installed.
 - To initialize a Python 3 virtual environment, run ``$ pipenv --three``.
-- To initialize a Python 2 virtual environment, run ``$ pipenv --two``.
 - Otherwise, whatever virtualenv defaults to will be the default.
 
 

--- a/news/4938.bugfix.rst
+++ b/news/4938.bugfix.rst
@@ -1,0 +1,1 @@
+Remove remaining mention of python2 and --two flag from codebase.

--- a/pipenv/cli/command.py
+++ b/pipenv/cli/command.py
@@ -156,7 +156,7 @@ def cli(
                     err=True,
                 )
                 ctx.abort()
-    # --two / --three was passed...
+    # --python or --three was passed...
     if (state.python or state.three is not None) or state.site_packages:
         ensure_project(
             state.project,

--- a/pipenv/cli/options.py
+++ b/pipenv/cli/options.py
@@ -225,9 +225,8 @@ def three_option(f):
         state = ctx.ensure_object(State)
         if value is not None:
             state.three = value
-            state.two = not value
         return value
-    return option("--three/--two", is_flag=True, default=None,
+    return option("--three", is_flag=True, default=None,
                   help="Use Python 3/2 when creating virtualenv.", callback=callback,
                   expose_value=False)(f)
 

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -469,7 +469,7 @@ def ensure_virtualenv(project, three=None, python=None, site_packages=None, pypi
             # If interrupted, cleanup the virtualenv.
             cleanup_virtualenv(project, bare=False)
             sys.exit(1)
-    # If --three, --two, or --python were passed...
+    # If --python or --three were passed...
     elif (python) or (three is not None) or (site_packages is not None):
         project.s.USING_DEFAULT_PYTHON = False
         # Ensure python is installed before deleting existing virtual env

--- a/pipenv/environments.py
+++ b/pipenv/environments.py
@@ -135,9 +135,9 @@ class Setting:
         self.PIPENV_DEFAULT_PYTHON_VERSION = os.environ.get("PIPENV_DEFAULT_PYTHON_VERSION")
         """Use this Python version when creating new virtual environments by default.
 
-        This can be set to a version string, e.g. ``3.6``, or a path. Default is to use
+        This can be set to a version string, e.g. ``3.9``, or a path. Default is to use
         whatever Python Pipenv is installed under (i.e. ``sys.executable``). Command
-        line flags (e.g. ``--python``, ``--three``, and ``--two``) are prioritized over
+        line flags (e.g. ``--python`` and ``--three``) are prioritized over
         this configuration.
         """
 
@@ -320,7 +320,7 @@ class Setting:
         because locking is an inherently slow operation.
 
         Default is to lock dependencies and update ``Pipfile.lock`` on each run.
-        
+
         Usage: `export PIPENV_SKIP_LOCK=true` OR `export PIPENV_SKIP_LOCK=1` to skip automatic locking
 
         NOTE: This only affects the ``install`` and ``uninstall`` commands.


### PR DESCRIPTION
Remove mention of the --two flag and python2


### The issue

https://github.com/pypa/pipenv/issues/4938

### The fix

Seems it was mostly removed already.  This tries to clean up remaining references.


### The checklist

* [X] Associated issue
* [X] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.
