### PR TITLE
This could improve the case of upstream dependencies that mess up the…

### DIFF
--- a/pipenv/utils.py
+++ b/pipenv/utils.py
@@ -905,7 +905,7 @@ class Resolver:
                                 result.req.marker = marker
                         except TypeError as e:
                             click_echo(
-                                f"Error generating python specifier for {candidate}.  "
+                                f"Error generating python marker for {candidate}.  "
                                 f"Is the specifier {requires_python} incorrectly quoted or otherwise wrong?"
                                 f"Full error: {e}", err=True
                             )

--- a/pipenv/utils.py
+++ b/pipenv/utils.py
@@ -897,11 +897,18 @@ class Resolver:
                 if candidate:
                     requires_python = candidate.link.requires_python
                     if requires_python:
-                        marker = marker_from_specifier(requires_python)
-                        self.markers[result.name] = marker
-                        result.markers = marker
-                        if result.req:
-                            result.req.marker = marker
+                        try:
+                            marker = marker_from_specifier(requires_python)
+                            self.markers[result.name] = marker
+                            result.markers = marker
+                            if result.req:
+                                result.req.marker = marker
+                        except TypeError as e:
+                            click_echo(
+                                f"Error generating python specifier for {candidate}.  "
+                                f"Is the specifier {requires_python} incorrectly quoted or otherwise wrong?"
+                                f"Full error: {e}", err=True
+                            )
             new_tree.add(result)
         self.resolved_tree = new_tree
 


### PR DESCRIPTION
This adds error handling around badly formed python specifiers which pip happily installs the packages for, and the resolver spits out whatever is in the setup.py, however it will be wrongly parsed when quoted.  My proposal here is that we simply alert the user and proceed to finish their package locking, since the python specifier is hardly the most important part of the Pipfile.lock.  Even the current specifiers are non deterministic in Pip 21.x which we have other issue reports about and seems to be resolved in Pip 22.x.

### The issue

https://github.com/pypa/pipenv/issues/4681

### The fix

Try/except and Alert/continue

### The checklist

* [X] Associated issue
* [ ] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.
