### PR TITLE
Fix for: Pipenv Does Not Respect Index Specified For A Package

### DIFF
--- a/news/4637.bugfix.rst
+++ b/news/4637.bugfix.rst
@@ -1,0 +1,1 @@
+Patched our vendored Pip to fix: Pipenv Lock (Or Install) Does Not Respect Index Specified For A Package.

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -1437,7 +1437,7 @@ def pip_install(
         project, index, extra_indexes=extra_indexes, trusted_hosts=trusted_hosts,
         pypi_mirror=pypi_mirror
     )
-    sources = list(filter(lambda d: d['name'] == requirement.index, sources))
+    sources = list(filter(lambda d: d.get('name') == requirement.index, sources))
     if r:
         with open(r, "r") as fh:
             if "--hash" not in fh.read():

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -1413,9 +1413,8 @@ def pip_install(
             ignore_hashes = False
     line = None
     # Try installing for each source in project.sources.
-    if requirement.index:
+    if not index and requirement.index:
         index = requirement.index
-        extra_indexes = []
     if index and not extra_indexes:
         extra_indexes = list(project.sources)
         extra_indexes = list(filter(lambda d: d['name'] == requirement.index, extra_indexes))
@@ -1462,7 +1461,8 @@ def pip_install(
         pip_command.extend(["-r", vistir.path.normalize_path(r)])
     elif line:
         pip_command.extend(line)
-    pip_command.extend(prepare_pip_source_args(sources))
+    pip_source_args = prepare_pip_source_args(sources)
+    pip_command.extend(pip_source_args)
     if project.s.is_verbose():
         click.echo(f"$ {cmd_list_to_shell(pip_command)}", err=True)
     cache_dir = Path(project.s.PIPENV_CACHE_DIR)

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -1413,9 +1413,10 @@ def pip_install(
             ignore_hashes = False
     line = None
     # Try installing for each source in project.sources.
-    if not index and requirement.index:
+    if requirement.index:
         index = requirement.index
-    if index and not extra_indexes:
+        extra_indexes = []
+    elif index and not extra_indexes:
         extra_indexes = list(project.sources)
     if requirement and requirement.vcs or requirement.editable:
         requirement.index = None

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -1416,9 +1416,11 @@ def pip_install(
     if not index and requirement.index:
         index = requirement.index
     if index and not extra_indexes:
-        extra_indexes = list(project.sources)
+        extra_indexes = []
         if requirement.index:
-            extra_indexes = list(filter(lambda d: d['name'] == requirement.index, extra_indexes))
+            extra_indexes = list(filter(lambda d: d['name'] == requirement.index, project.sources))
+        if not extra_indexes:
+            extra_indexes = list(project.sources)
     if requirement and requirement.vcs or requirement.editable:
         requirement.index = None
         # Install dependencies when a package is a non-editable VCS dependency.

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -1417,7 +1417,8 @@ def pip_install(
         index = requirement.index
     if index and not extra_indexes:
         extra_indexes = list(project.sources)
-        extra_indexes = list(filter(lambda d: d['name'] == requirement.index, extra_indexes))
+        if requirement.index:
+            extra_indexes = list(filter(lambda d: d['name'] == requirement.index, extra_indexes))
     if requirement and requirement.vcs or requirement.editable:
         requirement.index = None
         # Install dependencies when a package is a non-editable VCS dependency.
@@ -1437,7 +1438,8 @@ def pip_install(
         project, index, extra_indexes=extra_indexes, trusted_hosts=trusted_hosts,
         pypi_mirror=pypi_mirror
     )
-    sources = list(filter(lambda d: d.get('name') == requirement.index, sources))
+    if requirement.index in sources:
+        sources = list(filter(lambda d: d.get('name') == requirement.index, sources))
     if r:
         with open(r, "r") as fh:
             if "--hash" not in fh.read():

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -1463,8 +1463,7 @@ def pip_install(
         pip_command.extend(["-r", vistir.path.normalize_path(r)])
     elif line:
         pip_command.extend(line)
-    pip_source_args = prepare_pip_source_args(sources)
-    pip_command.extend(pip_source_args)
+    pip_command.extend(prepare_pip_source_args(sources))
     if project.s.is_verbose():
         click.echo(f"$ {cmd_list_to_shell(pip_command)}", err=True)
     cache_dir = Path(project.s.PIPENV_CACHE_DIR)

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -1416,8 +1416,9 @@ def pip_install(
     if requirement.index:
         index = requirement.index
         extra_indexes = []
-    elif index and not extra_indexes:
+    if index and not extra_indexes:
         extra_indexes = list(project.sources)
+        extra_indexes = list(filter(lambda d: d['name'] == requirement.index, extra_indexes))
     if requirement and requirement.vcs or requirement.editable:
         requirement.index = None
         # Install dependencies when a package is a non-editable VCS dependency.
@@ -1437,6 +1438,7 @@ def pip_install(
         project, index, extra_indexes=extra_indexes, trusted_hosts=trusted_hosts,
         pypi_mirror=pypi_mirror
     )
+    sources = list(filter(lambda d: d['name'] == requirement.index, sources))
     if r:
         with open(r, "r") as fh:
             if "--hash" not in fh.read():

--- a/pipenv/patched/notpip/_internal/index/collector.py
+++ b/pipenv/patched/notpip/_internal/index/collector.py
@@ -445,15 +445,18 @@ class LinkCollector:
         self,
         session: PipSession,
         search_scope: SearchScope,
+        index_lookup: dict = None,
     ) -> None:
         self.search_scope = search_scope
         self.session = session
+        self.index_lookup = index_lookup if index_lookup else {}
 
     @classmethod
     def create(
         cls, session: PipSession,
         options: Values,
-        suppress_no_index: bool = False
+        suppress_no_index: bool = False,
+        index_lookup: dict = None,
     ) -> "LinkCollector":
         """
         :param session: The Session to use to make requests.
@@ -472,10 +475,10 @@ class LinkCollector:
         find_links = options.find_links or []
 
         search_scope = SearchScope.create(
-            find_links=find_links, index_urls=index_urls,
+            find_links=find_links, index_urls=index_urls, index_lookup=index_lookup
         )
         link_collector = LinkCollector(
-            session=session, search_scope=search_scope,
+            session=session, search_scope=search_scope, index_lookup=index_lookup
         )
         return link_collector
 

--- a/pipenv/patched/notpip/_internal/index/collector.py
+++ b/pipenv/patched/notpip/_internal/index/collector.py
@@ -17,6 +17,7 @@ from optparse import Values
 from typing import (
     Callable,
     Iterable,
+    Dict,
     List,
     MutableMapping,
     NamedTuple,
@@ -445,7 +446,7 @@ class LinkCollector:
         self,
         session: PipSession,
         search_scope: SearchScope,
-        index_lookup: dict = None,
+        index_lookup: Optional[Dict[str, List[str]]] = None,
     ) -> None:
         self.search_scope = search_scope
         self.session = session
@@ -456,7 +457,7 @@ class LinkCollector:
         cls, session: PipSession,
         options: Values,
         suppress_no_index: bool = False,
-        index_lookup: dict = None,
+        index_lookup: Optional[Dict[str, List[str]]] = None,
     ) -> "LinkCollector":
         """
         :param session: The Session to use to make requests.

--- a/pipenv/patched/notpip/_internal/models/search_scope.py
+++ b/pipenv/patched/notpip/_internal/models/search_scope.py
@@ -20,13 +20,14 @@ class SearchScope:
     Encapsulates the locations that pip is configured to search.
     """
 
-    __slots__ = ["find_links", "index_urls"]
+    __slots__ = ["find_links", "index_urls", "index_lookup"]
 
     @classmethod
     def create(
         cls,
         find_links: List[str],
         index_urls: List[str],
+        index_lookup: dict = None,
     ) -> "SearchScope":
         """
         Create a SearchScope object after normalizing the `find_links`.
@@ -60,15 +61,18 @@ class SearchScope:
         return cls(
             find_links=built_find_links,
             index_urls=index_urls,
+            index_lookup=index_lookup
         )
 
     def __init__(
         self,
         find_links: List[str],
         index_urls: List[str],
+        index_lookup: dict = None,
     ) -> None:
         self.find_links = find_links
         self.index_urls = index_urls
+        self.index_lookup = index_lookup if index_lookup else {}
 
     def get_formatted_locations(self) -> str:
         lines = []
@@ -123,4 +127,7 @@ class SearchScope:
                 loc = loc + '/'
             return loc
 
-        return [mkurl_pypi_url(url) for url in self.index_urls]
+        index_urls = self.index_urls
+        if project_name in self.index_lookup:
+            index_urls = [self.index_lookup[project_name]]
+        return [mkurl_pypi_url(url) for url in index_urls]

--- a/pipenv/patched/notpip/_internal/models/search_scope.py
+++ b/pipenv/patched/notpip/_internal/models/search_scope.py
@@ -3,7 +3,7 @@ import logging
 import os
 import posixpath
 import urllib.parse
-from typing import List
+from typing import Dict, List, Optional
 
 from pipenv.patched.notpip._vendor.packaging.utils import canonicalize_name
 
@@ -27,7 +27,7 @@ class SearchScope:
         cls,
         find_links: List[str],
         index_urls: List[str],
-        index_lookup: dict = None,
+        index_lookup: Optional[Dict[str, List[str]]] = None,
     ) -> "SearchScope":
         """
         Create a SearchScope object after normalizing the `find_links`.
@@ -68,7 +68,7 @@ class SearchScope:
         self,
         find_links: List[str],
         index_urls: List[str],
-        index_lookup: dict = None,
+        index_lookup: Optional[Dict[str, List[str]]] = None,
     ) -> None:
         self.find_links = find_links
         self.index_urls = index_urls

--- a/pipenv/utils.py
+++ b/pipenv/utils.py
@@ -496,6 +496,14 @@ class Resolver:
             # directories into the initial constraint pool to be resolved with the
             # rest of the dependencies, while adding the files/vcs deps/paths themselves
             # to the lockfile directly
+            if req.name in index_lookup:
+                use_sources = list(filter(lambda d: d['name'] == index_lookup[req.name], sources))
+            else:
+                use_sources = sources
+            transient_resolver = cls(
+                [], req_dir, project, use_sources, index_lookup=index_lookup,
+                markers_lookup=markers_lookup, clear=clear, pre=pre
+            )
             constraint_update, lockfile_update = cls.get_deps_from_req(
                 req, resolver=transient_resolver, resolve_vcs=project.s.PIPENV_RESOLVE_VCS
             )
@@ -818,10 +826,13 @@ class Resolver:
     def parsed_constraints(self):
         from pipenv.vendor.pip_shims import shims
 
+        pip_options = self.pip_options
+        print("pip_options", pip_options)
+        pip_options.extra_index_urls = []
         if self._parsed_constraints is None:
             self._parsed_constraints = shims.parse_requirements(
                 self.constraint_file, finder=self.finder, session=self.session,
-                options=self.pip_options
+                options=pip_options
             )
         return self._parsed_constraints
 

--- a/pipenv/utils.py
+++ b/pipenv/utils.py
@@ -897,10 +897,9 @@ class Resolver:
         from pipenv.vendor.pip_shims.shims import InstallationError
         from pipenv.exceptions import ResolutionFailure
 
-        constraints = self.constraints
         with temp_environ(), self.get_resolver() as resolver:
             try:
-                results = resolver.resolve(constraints, check_supported_wheels=False)
+                results = resolver.resolve(self.constraints, check_supported_wheels=False)
             except InstallationError as e:
                 raise ResolutionFailure(message=str(e))
             else:

--- a/pipenv/utils.py
+++ b/pipenv/utils.py
@@ -496,9 +496,10 @@ class Resolver:
             # directories into the initial constraint pool to be resolved with the
             # rest of the dependencies, while adding the files/vcs deps/paths themselves
             # to the lockfile directly
+            use_sources = None
             if req.name in index_lookup:
-                use_sources = list(filter(lambda d: d['name'] == index_lookup[req.name], sources))
-            else:
+                use_sources = list(filter(lambda s: s.get('name') == index_lookup[req.name], sources))
+            if not use_sources:
                 use_sources = sources
             transient_resolver = cls(
                 [], req_dir, project, use_sources, index_lookup=index_lookup,
@@ -806,10 +807,12 @@ class Resolver:
             )
         index_mapping = {}
         for source in self.sources:
-            index_mapping[source['name']] = source['url']
+            if source.get('name'):
+                index_mapping[source['name']] = source['url']
         alt_index_lookup = {}
         for req_name, index in self.index_lookup.items():
-            alt_index_lookup[req_name] = index_mapping[index]
+            if index_mapping.get(index):
+                alt_index_lookup[req_name] = index_mapping[index]
         self._finder._link_collector.index_lookup = alt_index_lookup
         self._finder._link_collector.search_scope.index_lookup = alt_index_lookup
         return self._finder

--- a/pipenv/utils.py
+++ b/pipenv/utils.py
@@ -897,6 +897,7 @@ class Resolver:
         from pipenv.vendor.pip_shims.shims import InstallationError
         from pipenv.exceptions import ResolutionFailure
 
+        self.constraints  # For some reason its important to evaluate constraints before resolver context
         with temp_environ(), self.get_resolver() as resolver:
             try:
                 results = resolver.resolve(self.constraints, check_supported_wheels=False)

--- a/tasks/vendoring/patches/patched/pip_index_safety.patch
+++ b/tasks/vendoring/patches/patched/pip_index_safety.patch
@@ -54,7 +54,7 @@ index 4b700407..58154c31 100644
 -from typing import List
 +from typing import Dict, List, Optional
 
- from pipenv.patched.notpip._vendor.packaging.utils import canonicalize_name
+ from pip._vendor.packaging.utils import canonicalize_name
 
 @@ -20,13 +20,14 @@ class SearchScope:
      Encapsulates the locations that pip is configured to search.

--- a/tasks/vendoring/patches/patched/pip_index_safety.patch
+++ b/tasks/vendoring/patches/patched/pip_index_safety.patch
@@ -1,0 +1,102 @@
+diff --git a/pipenv/patched/pip/_internal/index/collector.py b/pipenv/patched/pip/_internal/index/collector.py
+index 98ac9d2e..fc532c40 100644
+--- a/pipenv/patched/pip/_internal/index/collector.py
++++ b/pipenv/patched/pip/_internal/index/collector.py
+@@ -17,6 +17,7 @@ from optparse import Values
+ from typing import (
+     Callable,
+     Iterable,
++    Dict,
+     List,
+     MutableMapping,
+     NamedTuple,
+@@ -445,15 +446,18 @@ class LinkCollector:
+         self,
+         session: PipSession,
+         search_scope: SearchScope,
++        index_lookup: Optional[Dict[str, List[str]]] = None,
+     ) -> None:
+         self.search_scope = search_scope
+         self.session = session
++        self.index_lookup = index_lookup if index_lookup else {}
+
+     @classmethod
+     def create(
+         cls, session: PipSession,
+         options: Values,
+-        suppress_no_index: bool = False
++        suppress_no_index: bool = False,
++        index_lookup: Optional[Dict[str, List[str]]] = None,
+     ) -> "LinkCollector":
+         """
+         :param session: The Session to use to make requests.
+@@ -472,10 +476,10 @@ class LinkCollector:
+         find_links = options.find_links or []
+
+         search_scope = SearchScope.create(
+-            find_links=find_links, index_urls=index_urls,
++            find_links=find_links, index_urls=index_urls, index_lookup=index_lookup
+         )
+         link_collector = LinkCollector(
+-            session=session, search_scope=search_scope,
++            session=session, search_scope=search_scope, index_lookup=index_lookup
+         )
+         return link_collector
+
+diff --git a/pipenv/patched/pip/_internal/models/search_scope.py b/pipenv/patched/pip/_internal/models/search_scope.py
+index 4b700407..58154c31 100644
+--- a/pipenv/patched/pip/_internal/models/search_scope.py
++++ b/pipenv/patched/pip/_internal/models/search_scope.py
+@@ -3,7 +3,7 @@ import logging
+ import os
+ import posixpath
+ import urllib.parse
+-from typing import List
++from typing import Dict, List, Optional
+
+ from pipenv.patched.notpip._vendor.packaging.utils import canonicalize_name
+
+@@ -20,13 +20,14 @@ class SearchScope:
+     Encapsulates the locations that pip is configured to search.
+     """
+
+-    __slots__ = ["find_links", "index_urls"]
++    __slots__ = ["find_links", "index_urls", "index_lookup"]
+
+     @classmethod
+     def create(
+         cls,
+         find_links: List[str],
+         index_urls: List[str],
++        index_lookup: Optional[Dict[str, List[str]]] = None,
+     ) -> "SearchScope":
+         """
+         Create a SearchScope object after normalizing the `find_links`.
+@@ -60,15 +61,18 @@ class SearchScope:
+         return cls(
+             find_links=built_find_links,
+             index_urls=index_urls,
++            index_lookup=index_lookup
+         )
+
+     def __init__(
+         self,
+         find_links: List[str],
+         index_urls: List[str],
++        index_lookup: Optional[Dict[str, List[str]]] = None,
+     ) -> None:
+         self.find_links = find_links
+         self.index_urls = index_urls
++        self.index_lookup = index_lookup if index_lookup else {}
+
+     def get_formatted_locations(self) -> str:
+         lines = []
+@@ -123,4 +127,7 @@ class SearchScope:
+                 loc = loc + '/'
+             return loc
+
+-        return [mkurl_pypi_url(url) for url in self.index_urls]
++        index_urls = self.index_urls
++        if project_name in self.index_lookup:
++            index_urls = [self.index_lookup[project_name]]
++        return [mkurl_pypi_url(url) for url in index_urls]


### PR DESCRIPTION
Code changes that fix the indexes not being respected.   Acknowledged that this modifies code in pip, and so I will need extra considerations on how to proceed  I have opened a PR against Pip as well (https://github.com/pypa/pip/pull/10964) to propose my modifications of pip from here.   Yet without this logic, there is no way to enforce the index specifications are abided by during resolution and installation.   After several iterations of trying to understand this code and how to fix it, it feels like the `LinkCollector`''s `SearchScope` should have the knowledge it needs to return the right indexes at the right times.

### The issue
Pipenv Lock (Or Install) Does Not Respect Index Specified For A Package  https://github.com/pypa/pipenv/issues/4637


### The fix

Without this or similar logic, there is no way to enforce the index specifications are abided by during resolution and installation.   After several iterations of trying to understand this code and how to fix it, it feels like the `LinkCollector`''s `SearchScope` should have the knowledge it needs to return the right indexes at the right times.  Otherwise the pipenv resolver is totally disconnected from the pip resolver in terms of these specifications.

_The example test script is very non-trivial and I have gotten much of it into an integration test locally, but there are some stumbling blocks, such as it involves running two private pypi servers locally each pointing at one of the generated package versions of an `example` generated wheel package._

### The checklist

* [X] Associated issue
* [X] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.
