### PR TITLE
Issue 4650 Remove unsupported feature selective upgrade

### DIFF
--- a/news/4650.removal.rst
+++ b/news/4650.removal.rst
@@ -1,0 +1,1 @@
+Removal of undocumented and broken install feature flag `--selective-upgrade` in favor of the flag `--keep-outdated`

--- a/pipenv/cli/command.py
+++ b/pipenv/cli/command.py
@@ -207,7 +207,6 @@ def install(
         code=state.installstate.code,
         deploy=state.installstate.deploy,
         keep_outdated=state.installstate.keep_outdated,
-        selective_upgrade=state.installstate.selective_upgrade,
         index_url=state.index,
         extra_index_url=state.extra_index_urls,
         packages=state.installstate.packages,

--- a/pipenv/cli/options.py
+++ b/pipenv/cli/options.py
@@ -75,7 +75,6 @@ class InstallState:
     def __init__(self):
         self.dev = False
         self.pre = False
-        self.selective_upgrade = False
         self.keep_outdated = False
         self.skip_lock = False
         self.ignore_pipfile = False
@@ -158,16 +157,6 @@ def keep_outdated_option(f):
     return option("--keep-outdated", is_flag=True, default=False, expose_value=False,
                   help="Keep out-dated dependencies from being updated in Pipfile.lock.",
                   callback=callback, type=click_types.BOOL, show_envvar=True)(f)
-
-
-def selective_upgrade_option(f):
-    def callback(ctx, param, value):
-        state = ctx.ensure_object(State)
-        state.installstate.selective_upgrade = value
-        return value
-    return option("--selective-upgrade", is_flag=True, default=False, type=click_types.BOOL,
-                  help="Update specified packages.", callback=callback,
-                  expose_value=False)(f)
 
 
 def ignore_pipfile_option(f):
@@ -462,7 +451,6 @@ def install_options(f):
     f = index_option(f)
     f = extra_index_option(f)
     f = requirementstxt_option(f)
-    f = selective_upgrade_option(f)
     f = ignore_pipfile_option(f)
     f = editable_option(f)
     f = package_arg(f)


### PR DESCRIPTION
I am proposing via PR we remove the flag `--selective-upgrade` on several grounds:
* It doesn't work and hasn't for a long time
* The suggestion for people using it are to use `--keep-outdated` instead.
* There is no documentation for the code path.
* The code path doesn't make sense and exists in overly complex method we aim to simplify anyway.
* It does things like uses Pip feature 
  * to-satisfy-only (undocumented, please avoid) - packages are not upgraded (not even direct requirements) unless the currently installed version fails to satisfy a requirement (either explicitly specified or a dependency).
    * This is actually the “default” upgrade strategy when --upgrade is not set, i.e. pip install AlreadyInstalled and pip install --upgrade --upgrade-strategy=to-satisfy-only AlreadyInstalled yield the same behavior.
    * Ref:  https://pip.pypa.io/en/stable/development/architecture/upgrade-options/#controlling-what-gets-installed
* the https://pip.pypa.io/en/stable/cli/pip/#exists-action-option usage also doesn't seem to be anything special or make extra sense why its would be needed over `--keep-outdated`.   
* More reasons to follow if necessary ...


### The issue

https://github.com/pypa/pipenv/issues/4650
https://github.com/pypa/pipenv/issues/4626
https://github.com/pypa/pipenv/issues/4351
https://github.com/pypa/pipenv/issues/3461
https://github.com/pypa/pipenv/issues/2412
And more:  https://github.com/pypa/pipenv/issues?q=is%3Aissue+is%3Aopen+selective-upgrade

### The fix

I removed the code for `--selective-upgrade`

### The checklist

* [X] Associated issue
* [X] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.
