### PR TITLE
Fix the assumption that all sources are named.

### DIFF
--- a/news/5002.bugfix.rst
+++ b/news/5002.bugfix.rst
@@ -1,0 +1,2 @@
+Fixes issue with new index safety restriction, whereby an unnamed extra sources index
+caused and error to be thrown during install.

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -1403,7 +1403,7 @@ def pip_install(
     if index and not extra_indexes:
         extra_indexes = []
         if requirement.index:
-            extra_indexes = list(filter(lambda d: d['name'] == requirement.index, project.sources))
+            extra_indexes = list(filter(lambda d: d.get('name') == requirement.index, project.sources))
         if not extra_indexes:
             extra_indexes = list(project.sources)
     if requirement and requirement.vcs or requirement.editable:

--- a/tests/integration/test_install_basic.py
+++ b/tests/integration/test_install_basic.py
@@ -497,3 +497,30 @@ extras = ["socks"]
         assert 'six = {version = "*"}' in contents
         assert 'requests = {version = "*"' in contents
         assert 'flask = "*"' in contents
+
+
+@flaky
+@pytest.mark.dev
+@pytest.mark.basic
+@pytest.mark.install
+@pytest.mark.needs_internet
+def test_install_with_unnamed_source(PipenvInstance):
+    """Ensure that running `pipenv install` doesn't break with an unamed index"""
+    with PipenvInstance(chdir=True) as p:
+        with open(p.pipfile_path, "w") as f:
+            contents = """
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+
+[packages]
+requests = {version="*", index="pypi"}
+            """.strip()
+            f.write(contents)
+        c = p.pipenv("install")
+        assert c.returncode == 0


### PR DESCRIPTION
### The issue

https://github.com/pypa/pipenv/issues/5002

### The fix

Check the indexes safely, the problem will still be that if you don't name an index, then it is just an extra source, but if you call out the name of an index it won't be able to resolve to an index that is unamed, and that should be fine.

### The checklist

* [X] Associated issue
* [X] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

