### PR TITLE
Restore this message as stderr because it affects requirements.txt generation

### DIFF
--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -118,7 +118,7 @@ def load_dot_env(project, as_dict=False):
         else:
             click.echo(
                 crayons.normal(fix_utf8("Loading .env environment variables..."), bold=True),
-                err=False,
+                err=True,
             )
             dotenv.load_dotenv(dotenv_file, override=True)
             project.s.initialize()

--- a/tests/integration/test_lock.py
+++ b/tests/integration/test_lock.py
@@ -457,7 +457,7 @@ def test_outdated_setuptools_with_pep517_legacy_build_meta_is_updated(PipenvInst
         assert c.returncode == 0
         c = p.pipenv("run python -c 'import setuptools; print(setuptools.__version__)'")
         assert c.returncode == 0
-        assert c.stdout.splitlines()[1] == "40.2.0"
+        assert c.stdout.strip() == "40.2.0"
         c = p.pipenv("install legacy-backend-package")
         assert c.returncode == 0
         assert "vistir" in p.lockfile["default"]
@@ -481,7 +481,7 @@ def test_outdated_setuptools_with_pep517_cython_import_in_setuppy(PipenvInstance
         assert c.returncode == 0
         c = p.pipenv("run python -c 'import setuptools; print(setuptools.__version__)'")
         assert c.returncode == 0
-        assert c.stdout.splitlines()[1] == "40.2.0"
+        assert c.stdout.strip() == "40.2.0"
         c = p.pipenv("install cython-import-package")
         assert c.returncode == 0
         assert "vistir" in p.lockfile["default"]

--- a/tests/integration/test_project.py
+++ b/tests/integration/test_project.py
@@ -189,7 +189,7 @@ def test_run_in_virtualenv_with_global_context(PipenvInstance, virtualenv):
 
         c = p.pipenv("run python -c 'import click;print(click.__file__)'")
         assert c.returncode == 0, (c.stdout, c.stderr)
-        assert is_in_path(c.stdout.splitlines()[1], str(virtualenv)), (c.stdout.splitlines()[1], str(virtualenv))
+        assert is_in_path(c.stdout.strip(), str(virtualenv)), (c.stdout.strip(), str(virtualenv))
 
         c = p.pipenv("clean --dry-run")
         assert c.returncode == 0, (c.stdout, c.stderr)
@@ -210,7 +210,7 @@ def test_run_in_virtualenv(PipenvInstance):
         assert c.returncode == 0
         c = p.pipenv('run python -c "import click;print(click.__file__)"')
         assert c.returncode == 0
-        assert normalize_path(c.stdout.splitlines()[1]).startswith(
+        assert normalize_path(c.stdout.strip()).startswith(
             normalize_path(str(project.virtualenv_location))
         )
         c = p.pipenv("clean --dry-run")

--- a/tests/integration/test_run.py
+++ b/tests/integration/test_run.py
@@ -36,12 +36,12 @@ multicommand = "bash -c \"cd docs && make html\""
         assert c.returncode == 0
         c = p.pipenv('run printfoo')
         assert c.returncode == 0
-        assert c.stdout.splitlines()[1] == 'foo'
+        assert c.stdout.strip() == 'foo'
         assert not c.stderr.strip()
 
         c = p.pipenv('run notfoundscript')
         assert c.returncode != 0
-        assert c.stdout == 'Loading .env environment variables...\n'
+        assert c.stdout == ''
         if os.name != 'nt':     # TODO: Implement this message for Windows.
             assert 'not found' in c.stderr
 
@@ -80,5 +80,5 @@ def test_run_with_usr_env_shebang(PipenvInstance):
         c = p.pipenv("run ./test_script")
         assert c.returncode == 0
         project = Project()
-        lines = [line.strip() for line in c.stdout.splitlines()[1:]]
+        lines = [line.strip() for line in c.stdout.splitlines()]
         assert all(line == project.virtualenv_location for line in lines)


### PR DESCRIPTION
### The issue

- https://github.com/pypa/pipenv/issues/5003

### The fix

Restore the logging back to be stderr.


### The checklist

* [X] Associated issue
* [ ] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

