### PR TITLE
Bugfix: Not loading .env when quiet

### DIFF
--- a/news/5010.bugfix.md
+++ b/news/5010.bugfix.md
@@ -1,0 +1,1 @@
+Environment variables were not being loaded when the `--quiet` flag was set

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -115,11 +115,12 @@ def load_dot_env(project, as_dict=False, quiet=False):
             )
         if as_dict:
             return dotenv.dotenv_values(dotenv_file)
-        elif os.path.isfile(dotenv_file) and not quiet:
-            click.echo(
-                crayons.normal(fix_utf8("Loading .env environment variables..."), bold=True),
-                err=True,
-            )
+        elif os.path.isfile(dotenv_file):
+            if not quiet:
+                click.echo(
+                    crayons.normal(fix_utf8("Loading .env environment variables..."), bold=True),
+                    err=True,
+                )
             dotenv.load_dotenv(dotenv_file, override=True)
         project.s.initialize()
 


### PR DESCRIPTION
### The issue

When the output is quieted, pipenv no longer loads the `.env` file

### The fix

Load .env but only print the message if quiet is False


### The checklist

* [ ] Associated issue
* [x] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

<!--
### If this is a patch to the `vendor` directory...

Please try to refrain from submitting patches directly to `vendor` or `patched`, but raise your issue to the upstream project instead, and inform Pipenv to upgrade when the upstream project accepts the fix.

A pull request to upgrade vendor packages is strongly discouraged, unless there is a very good reason (e.g. you need to test Pipenv’s integration to a new vendor feature). Pipenv audits and performs vendor upgrades regularly, generally before a new release is about to drop.

If your patch is not or cannot be accepted by upstream, but is essential to Pipenv (make sure to discuss this with maintainers!), please remember to attach a patch file in `tasks/vendoring/patched`, so this divergence from upstream can be recorded and replayed afterwards.
-->
