### PR TITLE
Fix issue where .env file is not loaded when quiet mode is used (#4027, #5006)

### DIFF
--- a/news/4027.bugfix.rst
+++ b/news/4027.bugfix.rst
@@ -1,0 +1,2 @@
+Fixes issue where silencing the ``Loading .env environment variables`` message also disables loading
+of the ``.env`` file.

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -115,11 +115,12 @@ def load_dot_env(project, as_dict=False, quiet=False):
             )
         if as_dict:
             return dotenv.dotenv_values(dotenv_file)
-        elif os.path.isfile(dotenv_file) and not quiet:
-            click.echo(
-                crayons.normal(fix_utf8("Loading .env environment variables..."), bold=True),
-                err=True,
-            )
+        elif os.path.isfile(dotenv_file):
+            if not quiet:
+                click.echo(
+                    crayons.normal(fix_utf8("Loading .env environment variables..."), bold=True),
+                    err=True,
+                )
             dotenv.load_dotenv(dotenv_file, override=True)
         project.s.initialize()
 


### PR DESCRIPTION
### The issue

#4027 is incomplete because it stops the `.env` file from being loaded at all in quiet mode

### The checklist

* [x] Associated issue
* [x] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.
