### PR TITLE
Subdirectory vcs installs are never passing the subdirectory in requirementslib which is now required by setuptools

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,0 @@
-HELLO=WORLD

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -83,7 +83,7 @@ jobs:
           PYTHONIOENCODING: "utf-8"
           GIT_SSH_COMMAND: ssh -o StrictHostKeyChecking=accept-new -o CheckHostIP=no
         run: |
-          pipenv run pytest -ra -n auto --fulltrace tests -k test_lock_nested_vcs_direct_url -sv
+          pipenv run pytest -ra -n auto --fulltrace tests
 
   build:
     name: Build Package

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -83,7 +83,7 @@ jobs:
           PYTHONIOENCODING: "utf-8"
           GIT_SSH_COMMAND: ssh -o StrictHostKeyChecking=accept-new -o CheckHostIP=no
         run: |
-          pipenv run pytest -ra -n auto --fulltrace tests
+          pipenv run pytest -ra -n auto --fulltrace tests -k test_lock_nested_vcs_direct_url -sv
 
   build:
     name: Build Package

--- a/news/5010.bugfix.md
+++ b/news/5010.bugfix.md
@@ -1,0 +1,1 @@
+Environment variables were not being loaded when the `--quiet` flag was set

--- a/news/5011.trivial.rst
+++ b/news/5011.trivial.rst
@@ -1,0 +1,1 @@
+Adds missing unit test coverage for recent bug fixes.

--- a/news/5019.bugfix.rst
+++ b/news/5019.bugfix.rst
@@ -1,0 +1,4 @@
+It would appear that ``requirementslib`` was not fully specifying the subdirectory to ``build_pep517`` and
+and when a new version of ``setuptools`` was released, the test ``test_lock_nested_vcs_direct_url``
+broke indicating the Pipfile.lock no longer contained the extra dependencies that should have been resolved.
+This regression affected ``pipenv>=2021.11.9`` but has been fixed by a patch to ``requirementslib``.

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -115,11 +115,12 @@ def load_dot_env(project, as_dict=False, quiet=False):
             )
         if as_dict:
             return dotenv.dotenv_values(dotenv_file)
-        elif os.path.isfile(dotenv_file) and not quiet:
-            click.echo(
-                crayons.normal(fix_utf8("Loading .env environment variables..."), bold=True),
-                err=True,
-            )
+        elif os.path.isfile(dotenv_file):
+            if not quiet:
+                click.echo(
+                    crayons.normal(fix_utf8("Loading .env environment variables..."), bold=True),
+                    err=True,
+                )
             dotenv.load_dotenv(dotenv_file, override=True)
         project.s.initialize()
 

--- a/pipenv/vendor/requirementslib/models/setup_info.py
+++ b/pipenv/vendor/requirementslib/models/setup_info.py
@@ -13,7 +13,7 @@ import sys
 from collections.abc import Iterable, Mapping
 from functools import lru_cache, partial
 from pathlib import Path
-from urllib.parse import urlparse, urlunparse, parse_qs
+from urllib.parse import parse_qs, urlparse, urlunparse
 from weakref import finalize
 
 import pipenv.vendor.attr as attr

--- a/pipenv/vendor/requirementslib/models/setup_info.py
+++ b/pipenv/vendor/requirementslib/models/setup_info.py
@@ -13,7 +13,7 @@ import sys
 from collections.abc import Iterable, Mapping
 from functools import lru_cache, partial
 from pathlib import Path
-from urllib.parse import urlparse, urlunparse
+from urllib.parse import urlparse, urlunparse, parse_qs
 from weakref import finalize
 
 import pipenv.vendor.attr as attr
@@ -1230,8 +1230,15 @@ build-backend = "{1}"
                 )
             )
             need_delete = True
+
+        parsed = urlparse(str(self.ireq.link))
+        subdir = parse_qs(parsed.fragment).get('subdirectory', [])
+        if subdir:
+            directory = f"{self.base_dir}/{subdir[0]}"
+        else:
+            directory = self.base_dir
         result = build_pep517(
-            self.base_dir,
+            directory,
             self.extra_kwargs["build_dir"],
             config_settings=self.pep517_config,
             dist_type="wheel",

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ if sys.argv[-1] == "publish":
 required = [
     "pip>=18.0",
     "certifi",
-    "setuptools>=36.2.1,<61.0.0",
+    "setuptools>=36.2.1",
     "virtualenv-clone>=0.2.5",
     "virtualenv"
 ]

--- a/tasks/vendoring/patches/vendor/requirementslib-subdir-fix.patch
+++ b/tasks/vendoring/patches/vendor/requirementslib-subdir-fix.patch
@@ -1,0 +1,30 @@
+diff --git a/pipenv/vendor/requirementslib/models/setup_info.py b/pipenv/vendor/requirementslib/models/setup_info.py
+index 772a4d81..dc001f36 100644
+--- a/pipenv/vendor/requirementslib/models/setup_info.py
++++ b/pipenv/vendor/requirementslib/models/setup_info.py
+@@ -13,7 +13,7 @@ import sys
+ from collections.abc import Iterable, Mapping
+ from functools import lru_cache, partial
+ from pathlib import Path
+-from urllib.parse import urlparse, urlunparse
++from urllib.parse import parse_qs, urlparse, urlunparse
+ from weakref import finalize
+
+ import pipenv.vendor.attr as attr
+@@ -1230,8 +1230,15 @@ build-backend = "{1}"
+                 )
+             )
+             need_delete = True
++
++        parsed = urlparse(str(self.ireq.link))
++        subdir = parse_qs(parsed.fragment).get('subdirectory', [])
++        if subdir:
++            directory = f"{self.base_dir}/{subdir[0]}"
++        else:
++            directory = self.base_dir
+         result = build_pep517(
+-            self.base_dir,
++            directory,
+             self.extra_kwargs["build_dir"],
+             config_settings=self.pep517_config,
+             dist_type="wheel",

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -211,27 +211,6 @@ pyver = "which python"
 
 
 @pytest.mark.cli
-def test_scripts_resolve_dot_env_vars(PipenvInstance):
-    with PipenvInstance() as p:
-        with open(".env", "w") as f:
-            contents = """
-HELLO=WORLD
-            """.strip()
-            f.write(contents)
-
-        with open(p.pipfile_path, "w") as f:
-            contents = """
-[scripts]
-hello = "echo $HELLO"
-            """.strip()
-            f.write(contents)
-        c = p.pipenv('run hello')
-        print(c)
-        print(c.stdout)
-        assert 'WORLD' in c.stdout
-
-
-@pytest.mark.cli
 def test_help(PipenvInstance):
     with PipenvInstance() as p:
         assert p.pipenv('--help').stdout


### PR DESCRIPTION
It would appear that potentially a recent change to setuptools revealed that we weren't actually passing in the subdirectory properly to generate the pep517 wheels, and that was revealed ~3 days ago when the CI started failing on a change that was merged in but had passed the CI the day before. 

Fixes #5019
Fixes #5014