### PR TITLE
Issue 5023 Fix hash link generation

### DIFF
--- a/news/5023.bugfix.rst
+++ b/news/5023.bugfix.rst
@@ -1,0 +1,2 @@
+Fix an edge case of hash collection in index restricted packages whereby the hashes for some packages would
+be missing from the ``Pipfile.lock`` following package index restrictions added in ``pipenv==2022.3.23``.

--- a/pipenv/utils/resolver.py
+++ b/pipenv/utils/resolver.py
@@ -570,6 +570,12 @@ class Resolver:
             # we'd rather avoid touching.
             ignore_compatibility_finder._ignore_compatibility = True
             self._ignore_compatibility_finder = ignore_compatibility_finder
+            self._ignore_compatibility_finder._link_collector.index_lookup = (
+                self.index_lookup
+            )
+            self._ignore_compatibility_finder._link_collector.search_scope.index_lookup = (
+                self.index_lookup
+            )
         return self._ignore_compatibility_finder
 
     @property
@@ -730,9 +736,14 @@ class Resolver:
         if not is_pinned_requirement(ireq):
             return set()
 
+        sources = self.sources  # Enforce index restrictions
+        if ireq.name in self.index_lookup:
+            sources = list(
+                filter(lambda s: s.get("name") == self.index_lookup[ireq.name], sources)
+            )
         if any(
             "python.org" in source["url"] or "pypi.org" in source["url"]
-            for source in self.sources
+            for source in sources
         ):
             hashes = self._get_hashes_from_pypi(ireq)
             if hashes:

--- a/pipenv/utils/resolver.py
+++ b/pipenv/utils/resolver.py
@@ -744,10 +744,14 @@ class Resolver:
         applicable_candidates = self.ignore_compatibility_finder.find_best_candidate(
             ireq.name, ireq.specifier
         ).iter_applicable()
-        return {
-            self._get_hash_from_link(candidate.link)
-            for candidate in applicable_candidates
-        }
+        applicable_candidates = list(applicable_candidates)
+        if applicable_candidates:
+            return {
+                self._get_hash_from_link(candidate.link)
+                for candidate in applicable_candidates
+            }
+        elif ireq.link:
+            return {self._get_hash_from_link(ireq.link)}
 
     def resolve_hashes(self):
         if self.results is not None:

--- a/pipenv/utils/resolver.py
+++ b/pipenv/utils/resolver.py
@@ -723,12 +723,9 @@ class Resolver:
             return None
 
     def collect_hashes(self, ireq):
-        if ireq.link:
-            link = ireq.link
-            if link.is_vcs or (link.is_file and link.is_existing_dir()):
-                return set()
-            if ireq.original_link:
-                return {self._get_hash_from_link(ireq.original_link)}
+        link = ireq.link  # Handle VCS and file links first
+        if link and (link.is_vcs or (link.is_file and link.is_existing_dir())):
+            return set()
 
         if not is_pinned_requirement(ireq):
             return set()
@@ -750,8 +747,11 @@ class Resolver:
                 self._get_hash_from_link(candidate.link)
                 for candidate in applicable_candidates
             }
-        elif ireq.link:
-            return {self._get_hash_from_link(ireq.link)}
+        if link:
+            return {self._get_hash_from_link(link)}
+        if ireq.original_link:
+            return {self._get_hash_from_link(ireq.original_link)}
+        return set()
 
     def resolve_hashes(self):
         if self.results is not None:


### PR DESCRIPTION
### The issue

Fixes: #5023 

### The fix

Re-organize the logic and fallback to generating the hash from the link, if pypi is not applicable, and there are no applicable candidates.  This also applies the index restrictions to the hash finder so it too can find the right hashes.

#### Pipfile.lock Before
```
{
    "_meta": {
        "hash": {
            "sha256": "dd84b90e2afa892488dc59130dc48898573afeee5ba3aa45d8c64c54be6be39c"
        },
        "pipfile-spec": 6,
        "requires": {
            "python_version": "3.10"
        },
        "sources": [
            {
                "name": "pypi",
                "url": "https://pypi.org/simple",
                "verify_ssl": true
            },
            {
                "name": "downloadpytorch",
                "url": "https://download.pytorch.org/whl/cu113/",
                "verify_ssl": true
            },
            {
                "name": "downloadpytorch-390",
                "url": "https://download.pytorch.org/whl/",
                "verify_ssl": true
            }
        ]
    },
    "default": {
        "torch": {
            "index": "downloadpytorch-390",
            "version": "==1.11.0+cu113"
        },
        "typing-extensions": {
            "hashes": [
                "sha256:1a9462dcc3347a79b1f1c0271fbe79e844580bb598bafa1ed208b94da3cdcd42",
                "sha256:21c85e0fe4b9a155d0799430b0ad741cdce7e359660ccbd8b530613e8df88ce2"
            ],
            "markers": "python_version >= '3.6'",
            "version": "==4.1.1"
        }
    },
    "develop": {}
}
```

#### Pilfile.lock After
```
{
    "_meta": {
        "hash": {
            "sha256": "a22d7bb22d610cc3aad6f7c9c0a955c862618ad63d3a5f1ada90f4a4e0d6e9cd"
        },
        "pipfile-spec": 6,
        "requires": {
            "python_version": "3.10"
        },
        "sources": [
            {
                "name": "pypi",
                "url": "https://pypi.org/simple",
                "verify_ssl": true
            },
            {
                "name": "downloadpytorch",
                "url": "https://download.pytorch.org/whl/cu113/",
                "verify_ssl": true
            },
            {
                "name": "downloadpytorch-390",
                "url": "https://download.pytorch.org/whl/",
                "verify_ssl": true
            }
        ]
    },
    "default": {
        "torch": {
            "hashes": [
                "sha256:7fd4751bbf39bbb04ec6116c7243ce6528aded4197afcf380537340e1eebd19a",
                "sha256:a68c33657a546131eb9bc44e2a98d2fa704aafae861460b051b82813852ccb44",
                "sha256:b6a799bdb6ee3d914e5e62bddb4276d4a10248c1af4f2d217738e5f9ee27485b",
                "sha256:ddc57495195aa2456e78bfc7d8d3f45dabbb8b7b268b3b5dbed4f0e4db492f33",
                "sha256:e4bb14d953db9aad5bdb945a328410638721d77e3e622d0a8d77063c01daf40b",
                "sha256:e9126b0a5d95704bee40a9d0ef1cbd82d8dc7863e4638a376bef702dfd659370",
                "sha256:e9df65c1fb2d80283b276114878fd38f411b70880e0b406c451d000e6159f451",
                "sha256:f56333470daea3c97078b37607e0035cccf72fc5c36fd84546e1a4b8d9944f2b"
            ],
            "index": "downloadpytorch",
            "version": "==1.11.0+cu113"
        },
        "typing-extensions": {
            "hashes": [
                "sha256:1a9462dcc3347a79b1f1c0271fbe79e844580bb598bafa1ed208b94da3cdcd42",
                "sha256:21c85e0fe4b9a155d0799430b0ad741cdce7e359660ccbd8b530613e8df88ce2"
            ],
            "markers": "python_version >= '3.6'",
            "version": "==4.1.1"
        }
    },
    "develop": {}
}
``` 


### The checklist

* [X] Associated issue
* [X] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.
