### PR TITLE
Refactor and allow some support of extra-index-urls again

### DIFF
--- a/pipenv/utils/resolver.py
+++ b/pipenv/utils/resolver.py
@@ -26,7 +26,7 @@ from .dependencies import (
     translate_markers,
 )
 from .indexes import parse_indexes, prepare_pip_source_args
-from .internet import _get_requests_session
+from .internet import _get_requests_session, is_pypi_url
 from .locking import format_requirement_for_lockfile, prepare_lockfile
 from .shell import make_posix, subprocess_run, temp_environ
 from .spinner import create_spinner
@@ -243,7 +243,8 @@ class Resolver:
                 raise ResolutionFailure(
                     f"Failed to resolve requirement from line: {line!s}"
                 )
-        if index:
+        # Apply index restriction when it is a non-pypi index, or when no extra indexes
+        if index and (not is_pypi_url(index) or not extra_index):
             try:
                 index_lookup[req.normalized_name] = project.get_source(
                     url=index, refresh=True
@@ -744,10 +745,7 @@ class Resolver:
             sources = list(
                 filter(lambda s: s.get("name") == self.index_lookup[ireq.name], sources)
             )
-        if any(
-            "python.org" in source["url"] or "pypi.org" in source["url"]
-            for source in sources
-        ):
+        if any(is_pypi_url(source["url"]) for source in sources):
             hashes = self._get_hashes_from_pypi(ireq)
             if hashes:
                 return hashes


### PR DESCRIPTION
This PR tries to strike a balance between enforcing security in the new package restrictions, while still allowing extra indexes be specified loosely.   I am not convinced that we should be doing this longer term -- in other words I think we should be aiming to pin our packages to specifically which index the package should need to be pulled from, a specific index if not the primary index, which is usually pypi.

As the pip documentation points out:

>Using this option to search for packages which are not in the main repository (such as private packages) is unsafe, per a security vulnerability called [dependency confusion](https://azure.microsoft.com/en-us/resources/3-ways-to-mitigate-risk-using-private-package-feeds/): an attacker can claim the package on the public repository in a way that will ensure it gets chosen over the private package.


**There is another caveat to not pinning your index explicitly**, in the case of Torch.   The caveat is that in this current incantation of the pipenv code, the pinned index correctly picks up all 8 hashes from the pinned index; however, if you rely on the extra index searching to find your dependency in the extra index (without explicitly pinning the requirement to the alternate index) it for some reason only pulls in the 1 hash that matches your system architecture out of the 8.   I am not sure that is going to be sorted out readily as the hash aggregation logic is, well complicated and dependent on other factors in the resolution process as well.

I wanted to put this out there as a fix for the reported issues in the near term and gather feedback on what the real use case is for not pinning the index requirement in the first place?  Note that the logic implicitly pins all packages with a non-specified index to be the default, which is usually pypi.   So you can see how just having a second extra index here with this change makes all unpinned packages less predictable as to where they will be pulled from--it at least becomes not explicit.

### The issue

Fixes #5022 
Fixes #5021 

### The fix

@DanielPerezJensen @Bananaman and @masato-yasuda  Could you review my concerns and potential change and provide feedback on the issues at hand.   This technically fixes the issue being reported of the package not resolving when the index is not explicitly pinned, but I don't love the caveat that the hash collection is now incomplete when relying on this feature (I'm not entirely sure why yet).  Plus I don't want to invest a lot of time into supporting it when there exists the security advisory from last year, it feels ultimately safer to be explicit in pinning indexes.    Should we accept this patch?  Will it really be improving quality of life and a legitimate use case, or will it be weakening the security of the tool?  I am willing to consider it, since that was the prior behavior--but also willing to consider longer term deprecating it in favor of always pinning the non primary index packages to a specific index by name and potentially improving what CLI arguments are available to help manage this.

### The checklist

* [X] Associated issue
* [ ] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.
