### PR TITLE
sphinx formatting change and fix CLI docs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,7 +3,6 @@ name: CI
 on:
   push:
     paths-ignore:
-      - "docs/**"
       - "news/**"
       - "examples/**"
       - "peeps/**"
@@ -19,7 +18,6 @@ on:
       - main
   pull_request:
     paths-ignore:
-      - "docs/**"
       - "news/**"
       - "examples/**"
       - "peeps/**"

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -50,11 +50,11 @@ unless it already exists in which case the existing name with be reused when pin
     In prior versions of ``pipenv`` you could specify ``--extra-index-urls`` to the ``pip`` resolver and avoid
     specifically matching the expected index by name.   That functionality was deprecated in favor of index restricted
     packages, which is a simplifying assumption that is more security mindful.  The pip documentation has the following
-    warning around the ``--extra-index-urls`` option::
+    warning around the ``--extra-index-urls`` option:
 
-    Using this option to search for packages which are not in the main repository (such as private packages) is unsafe,
+    *Using this option to search for packages which are not in the main repository (such as private packages) is unsafe,
     per a security vulnerability called dependency confusion: an attacker can claim the package on the public repository
-    in a way that will ensure it gets chosen over the private package.
+    in a way that will ensure it gets chosen over the private package.*
 
 Should you wish to use an alternative default index other than PyPI: simply do not specify PyPI as one of the
 sources in your ``Pipfile``.  When PyPI is omitted, then any public packages required either directly or
@@ -246,6 +246,7 @@ flag::
 Note that using this approach, packages newly added to the Pipfile will still be
 included in requirements.txt. If you really want to use Pipfile.lock and
 Pipfile.lock only, you can generate the requirements using::
+
     $ pipenv requirements
     chardet==3.0.4
     requests==2.18.4
@@ -333,7 +334,7 @@ Example::
 
 .. note::
 
-    Each month, `PyUp.io`_ updates the ``safety`` database of
+    Each month, `PyUp.io <https://pyup.io>`_ updates the ``safety`` database of
     insecure Python packages and `makes it available to the
     community for free <https://pyup.io/safety/>`__. Pipenv
     makes an API call to retrieve those results and use them

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -46,14 +46,15 @@ the following command:
 Alternatively the index may be specified by full url, and it will be added to the ``Pipfile`` with a generated name
 unless it already exists in which case the existing name with be reused when pinning the package index.
 
-**Note:** In prior versions of ``pipenv`` you could specify ``--extra-index-urls`` to the ``pip`` resolver and avoid
-specifically matching the expected index by name.   That functionality was deprecated in favor of index restricted
-packages, which is a simplifying assumption that is more security mindful.  The pip documentation has the following
-warning around the ``--extra-index-urls`` option::
+.. note::
+    In prior versions of ``pipenv`` you could specify ``--extra-index-urls`` to the ``pip`` resolver and avoid
+    specifically matching the expected index by name.   That functionality was deprecated in favor of index restricted
+    packages, which is a simplifying assumption that is more security mindful.  The pip documentation has the following
+    warning around the ``--extra-index-urls`` option::
 
-> Using this option to search for packages which are not in the main repository (such as private packages) is unsafe,
-per a security vulnerability called dependency confusion: an attacker can claim the package on the public repository
-in a way that will ensure it gets chosen over the private package.
+    Using this option to search for packages which are not in the main repository (such as private packages) is unsafe,
+    per a security vulnerability called dependency confusion: an attacker can claim the package on the public repository
+    in a way that will ensure it gets chosen over the private package.
 
 Should you wish to use an alternative default index other than PyPI: simply do not specify PyPI as one of the
 sources in your ``Pipfile``.  When PyPI is omitted, then any public packages required either directly or
@@ -332,15 +333,15 @@ Example::
 
 .. note::
 
-   Each month, `PyUp.io`_ updates the ``safety`` database of
-   insecure Python packages and `makes it available to the
-   community for free <https://pyup.io/safety/>`__. Pipenv
-   makes an API call to retrieve those results and use them
-   each time you run ``pipenv check`` to show you vulnerable
-   dependencies.
+    Each month, `PyUp.io`_ updates the ``safety`` database of
+    insecure Python packages and `makes it available to the
+    community for free <https://pyup.io/safety/>`__. Pipenv
+    makes an API call to retrieve those results and use them
+    each time you run ``pipenv check`` to show you vulnerable
+    dependencies.
 
-   For more up-to-date vulnerability data, you may also use your own safety
-   API key by setting the environment variable ``PIPENV_PYUP_API_KEY``.
+    For more up-to-date vulnerability data, you may also use your own safety
+    API key by setting the environment variable ``PIPENV_PYUP_API_KEY``.
 
 
 ☤ Community Integrations

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,7 +26,9 @@ with open(os.path.join(here, "..", "pipenv", "__version__.py")) as f:
 
 # Hackery to get the CLI docs to generate
 import click
+
 import pipenv.vendor.click
+
 click.BaseCommand = pipenv.vendor.click.BaseCommand
 
 # -- General configuration ------------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,6 +24,11 @@ about = {}
 with open(os.path.join(here, "..", "pipenv", "__version__.py")) as f:
     exec(f.read(), about)
 
+# Hackery to get the CLI docs to generate
+import click
+import pipenv.vendor.click
+click.BaseCommand = pipenv.vendor.click.BaseCommand
+
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,7 +38,7 @@ extensions = [
     "sphinx.ext.todo",
     "sphinx.ext.coverage",
     "sphinx.ext.viewcode",
-    "sphinx_click.ext",
+    "sphinx_click",
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -124,7 +124,7 @@ html_static_path = ["_static"]
 
 
 def setup(app):
-    app.add_stylesheet("custom.css")
+    app.add_css_file("custom.css")
 
 
 # -- Options for HTMLHelp output ------------------------------------------

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -11,7 +11,7 @@ Jinja2==2.10
 MarkupSafe==1.1.0
 pbr==5.1.1
 -e .
-Pygments==2.3.0
+Pygments==2.11.2
 pythonz-bd==1.11.4
 pytz==2018.5
 requests==2.20.1

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -18,8 +18,8 @@ requests==2.20.1
 resumable-urlretrieve==0.1.5
 six==1.11.0
 snowballstemmer==1.2.1
-Sphinx==1.6.3
-sphinx-click==1.3.0
+Sphinx==4.5.0
+sphinx-click==3.1.0
 sphinxcontrib-spelling==4.2.1
 sphinxcontrib-websupport==1.1.0
 urllib3==1.24.1

--- a/news/4778.doc.rst
+++ b/news/4778.doc.rst
@@ -1,0 +1,2 @@
+Pipenv CLI documentation generation has been fixed.  It had broke when ``click`` was vendored into the project in
+``2021.11.9`` because by default ``sphinx-click`` could no longer determine the CLI inherited from click.


### PR DESCRIPTION
### The issue

Actually build sphinx docs locally and see if what I did for formatting here made the most sense: https://github.com/pypa/pipenv/pull/5029/files

I found a few warnings to clean up and wanted to improve the consistency and formatting of the note.

Also Fix for the CLI docs not generating.
Fixes #4778 

### Before

![image](https://user-images.githubusercontent.com/479892/161949081-627f52a5-a124-4a3a-a020-8fcf866713a6.png)

### After

![image](https://user-images.githubusercontent.com/479892/161953048-fd322bfe-d5f6-45de-bc8a-06c2ff0032f2.png)


### The checklist
I figure this change is covered by the other news fragments added and issues we resolved.

* [X] Associated issue
* [X] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.
