### PR TITLE
[fix] allow the user to overwrite the `no_input` flag to pip

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -106,6 +106,38 @@ Environment variables in the URL part of requirement specifiers can also be expa
 
 Keep in mind that environment variables are expanded in runtime, leaving the entries in ``Pipfile`` or ``Pipfile.lock`` untouched. This is to avoid the accidental leakage of credentials in the source code.
 
+☤ Injecting credentials through keychain support
+------------------------------------------------
+
+Private regirstries on Google Cloud, Azure and AWS support dynamic credentials using
+the keychain implementation. Due to the way the keychain is structured, it might ask
+the user for input. Asking the user for input is disabled. This will disable the keychain
+support completely, unfortunately.
+
+If you want to work with private registries that use the keychain for authentication, you
+can disable the "enforcement of no input".
+
+**Note:** Please be sure that the keychain will really not ask for
+input. Otherwise the process will hang forever!
+
+    [[source]]
+    url = "https://pypi.org/simple"
+    verify_ssl = true
+    name = "pypi"
+
+    [[source]]
+    url = "https://europe-python.pkg.dev/my-project/python/simple"
+    verify_ssl = true
+    name = "private-gcp"
+
+    [packages]
+    flask = "*"
+    private-test-package = {version = "*", index = "private-gcp"}
+
+    [pipenv]
+    disable_pip_input = false
+
+Above example will install ``flask`` and a private package ``private-test-package`` from GCP.
 
 ☤ Specifying Basically Anything
 -------------------------------

--- a/news/4706.bugfix.rst
+++ b/news/4706.bugfix.rst
@@ -1,0 +1,1 @@
+allow the user to disable the ``no_input`` flag, so the use of e.g Google Artifact Registry is possible.

--- a/pipenv/utils/resolver.py
+++ b/pipenv/utils/resolver.py
@@ -518,7 +518,7 @@ class Resolver:
             pip_options, _ = self.pip_command.parser.parse_args(self.pip_args)
             pip_options.cache_dir = self.project.s.PIPENV_CACHE_DIR
             pip_options.no_python_version_warning = True
-            pip_options.no_input = True
+            pip_options.no_input = self.project.settings.get("disable_pip_input", True)
             pip_options.progress_bar = "off"
             pip_options.ignore_requires_python = True
             pip_options.pre = self.pre or self.project.settings.get(


### PR DESCRIPTION
this is required if you want to e.g. use a keyring to authenticate
against Google Artifact Registry. fixes https://github.com/pypa/pipenv/issues/4706

Thank you for contributing to Pipenv!


### The issue

What is the thing you want to fix? Is it associated with an issue on GitHub? Please mention it.

Always consider opening an issue first to describe your problem, so we can discuss what is the best way to amend it.  Note that if you do not describe the goal of this change or link to a related issue, the maintainers may close the PR without further review.

If your pull request makes a non-insignificant change to Pipenv, such as the user interface or intended functionality, please file a PEEP.

    https://github.com/pypa/pipenv/blob/master/peeps/PEEP-000.md

### The fix

How does this pull request fix your problem? Did you consider any alternatives? Why is this the *best* solution, in your opinion?


### The checklist

* [x] Associated issue: https://github.com/pypa/pipenv/issues/4706
* [x] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

<!--
### If this is a patch to the `vendor` directory...

Please try to refrain from submitting patches directly to `vendor` or `patched`, but raise your issue to the upstream project instead, and inform Pipenv to upgrade when the upstream project accepts the fix.

A pull request to upgrade vendor packages is strongly discouraged, unless there is a very good reason (e.g. you need to test Pipenv’s integration to a new vendor feature). Pipenv audits and performs vendor upgrades regularly, generally before a new release is about to drop.

If your patch is not or cannot be accepted by upstream, but is essential to Pipenv (make sure to discuss this with maintainers!), please remember to attach a patch file in `tasks/vendoring/patched`, so this divergence from upstream can be recorded and replayed afterwards.
-->
