### PR TITLE
Fix MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -9,35 +9,22 @@ recursive-include pipenv/vendor *.c
 recursive-include pipenv *.md *.APACHE *.BSD
 recursive-include pipenv Makefile
 recursive-include pipenv/vendor vendor.txt
-recursive-include pipenv README
 recursive-include pipenv *.json
 recursive-include pipenv *.rst
 
 include pipenv/patched/notpip/_vendor/vendor.txt
-include pipenv/patched/safety.zip pipenv/patched/patched.txt
-include pipenv/vendor/*.txt pipenv/vendor/pexpect/bashrc.sh
+include  pipenv/patched/patched.txt
 include pipenv/vendor/Makefile
 include pipenv/pipenv.1
 
-exclude .gitmodules
-exclude .editorconfig .travis.yml .env appveyor.yml tox.ini pytest.ini
-exclude Pipfile* CHANGELOG.draft.rst
-exclude run-tests.sh run-tests.bat
 
 recursive-include docs Makefile *.rst *.py *.bat
 recursive-include docs/_templates *.html
 recursive-include docs/_static *.js *.css *.png
-recursive-exclude docs requirements*.txt
-recursive-exclude pipenv *.pyi
-recursive-exclude pipenv *.typed
-recursive-exclue tests/test_artifacts *.pyd *.so *.pyc *.egg-info PKG-INFO
+recursive-exclude tests/test_artifacts *.pyd *.so *.pyc *.egg-info PKG-INFO
 
 prune peeps
 prune .azure-pipelines
 prune .github
-prune docs/build
-prune news
-prune tasks
-prune tests
 prune pipenv/vendor/importlib_metadata/tests
 prune pipenv/vendor/importlib_resources/tests


### PR DESCRIPTION
When building a source distribution for pipenv, many warning are omitted
since the MANIFEST.in was long time neglected and includes much stuff
which is no longer in the repository or wasn't even there.