### PR TITLE
CI improvements

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,4 @@
 name: CI
-
 on:
   push:
     paths-ignore:
@@ -29,10 +28,38 @@ on:
       - ".gitmodules"
       - ".gitattributes"
       - ".editorconfig"
-
 jobs:
+  lint:
+    name: Check code linting
+    runs-on: ubuntu-latest
+    env:
+      PIPENV_DEFAULT_PYTHON_VERSION: ${{ matrix.python-version }}
+      PYTHONWARNINGS: ignore:DEPRECATION
+      PYTHONIOENCODING: "utf-8"
+      GIT_ASK_YESNO: "false"
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+      - run: |
+          python -m pip install pre-commit
+          pre-commit run --all-files --verbose --show-diff-on-failure
+  vendor:
+    name: Vendoring
+    needs: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+      - run: |
+          python -m pip install --upgrade wheel invoke parver bs4 vistir towncrier
+          python -m invoke vendoring.update
   tests:
     name: ${{matrix.os}} / ${{ matrix.python-version }}
+    needs: lint
     runs-on: ${{ matrix.os }}-latest
     strategy:
       fail-fast: false
@@ -52,7 +79,6 @@ jobs:
         id: python-path
         run: |
           echo ::set-output name=path::$(python -c "import sys; print(sys.executable)")
-
       - name: Install latest pip, setuptools, wheel
         run: |
           python -m pip install --upgrade pip setuptools wheel --upgrade-strategy=eager
@@ -67,14 +93,6 @@ jobs:
           git submodule update --init --recursive
           python -m pip install -e . --upgrade
           pipenv install --deploy --dev --python=${{ steps.python-path.outputs.path }}
-      - name: Lint check of the code
-        env:
-          PIPENV_DEFAULT_PYTHON_VERSION: ${{ matrix.python-version }}
-          PYTHONWARNINGS: ignore:DEPRECATION
-          PYTHONIOENCODING: "utf-8"
-          GIT_ASK_YESNO: "false"
-        run: |
-          pipenv run pre-commit run --all-files --verbose --show-diff-on-failure
       - name: Run tests
         env:
           PIPENV_DEFAULT_PYTHON_VERSION: ${{ matrix.python-version }}
@@ -90,6 +108,7 @@ jobs:
 
   build:
     name: Build Package
+    needs: lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -100,15 +119,3 @@ jobs:
       - run: |
           python -m build
           twine check dist/*
-
-  vendor:
-    name: Vendoring
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-        with:
-          python-version: 3.9
-      - run: |
-          python -m pip install --upgrade wheel invoke parver bs4 vistir towncrier
-          python -m invoke vendoring.update

--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,13 @@ tests: virtualenv submodules test-install
 	. $(get_venv_path)/bin/activate && \
 		pipenv run pytest -ra -vvv --full-trace --tb=long
 
+.PHONY: vendor
+vendor: virtualenv
+	. $(get_venv_path)/bin/activate && \
+		python -m pip install invoke && \
+		python -m pip install -e .[dev] && \
+		python -m invoke vendoring.update
+
 .PHONY: test-specific
 test-specific: submodules virtualenv test-install
 	. $(get_venv_path)/bin/activate && pipenv run pytest -ra -k '$(tests)'

--- a/news/5061.process.rst
+++ b/news/5061.process.rst
@@ -1,0 +1,1 @@
+Make all CI jobs run only after the lint stage. Also added a makefile target for vendoring the packages.


### PR DESCRIPTION
This PR suggests a couple of improvements for the build pipeline:
1) We only lint the code once (as compared to previous situation where linting was run on all architectures).
2) Linting is a prerequisite for all other jobs which run in parallel if it succeeds.

Also, this PR adds a Makefile target for running the vendoring stage locally.
This PR is cherry-picking of the CI parts from #5059.