### PR TITLE
Removed usage of fs_str from vistir

### DIFF
--- a/news/5062.removal.rst
+++ b/news/5062.removal.rst
@@ -1,0 +1,1 @@
+Removed all usages of ``pipenv.vendor.vistir.compat.fs_str``, since this function was used for PY2-PY3 compatability and is no longer needed.

--- a/pipenv/__init__.py
+++ b/pipenv/__init__.py
@@ -18,15 +18,14 @@ sys.path.insert(0, PIPENV_VENDOR)
 sys.path.insert(0, PIPENV_PATCHED)
 
 from pipenv.vendor.urllib3.exceptions import DependencyWarning
-from pipenv.vendor.vistir.compat import fs_str
 
 warnings.filterwarnings("ignore", category=DependencyWarning)
 warnings.filterwarnings("ignore", category=ResourceWarning)
 warnings.filterwarnings("ignore", category=UserWarning)
 
 # Load patched pip instead of system pip
-os.environ["PIP_SHIMS_BASE_MODULE"] = fs_str("pipenv.patched.notpip")
-os.environ["PIP_DISABLE_PIP_VERSION_CHECK"] = fs_str("1")
+os.environ["PIP_SHIMS_BASE_MODULE"] = "pipenv.patched.notpip"
+os.environ["PIP_DISABLE_PIP_VERSION_CHECK"] = "1"
 
 # Hack to make things work better.
 try:

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -754,7 +754,7 @@ def batch_install(
 
         with vistir.contextmanagers.temp_environ():
             if not allow_global:
-                os.environ["PIP_USER"] = vistir.compat.fs_str("0")
+                os.environ["PIP_USER"] = "0"
                 if "PYTHONHOME" in os.environ:
                     del os.environ["PYTHONHOME"]
             if "GIT_CONFIG" in os.environ and dep.is_vcs:
@@ -967,7 +967,7 @@ def do_create_virtualenv(project, python=None, site_packages=None, pypi_mirror=N
         cmd.append("--system-site-packages")
 
     if pypi_mirror:
-        pip_config = {"PIP_INDEX_URL": vistir.misc.fs_str(pypi_mirror)}
+        pip_config = {"PIP_INDEX_URL": pypi_mirror}
     else:
         pip_config = {}
 
@@ -998,7 +998,7 @@ def do_create_virtualenv(project, python=None, site_packages=None, pypi_mirror=N
     # This mimics Pew's "setproject".
     project_file_name = os.path.join(project.virtualenv_location, ".project")
     with open(project_file_name, "w") as f:
-        f.write(vistir.misc.fs_str(project.project_directory))
+        f.write(project.project_directory)
     from .environment import Environment
 
     sources = project.pipfile_sources
@@ -1561,20 +1561,18 @@ def pip_install(
     DEFAULT_EXISTS_ACTION = "w"
     if selective_upgrade:
         DEFAULT_EXISTS_ACTION = "i"
-    exists_action = vistir.misc.fs_str(
-        project.s.PIP_EXISTS_ACTION or DEFAULT_EXISTS_ACTION
-    )
+    exists_action = project.s.PIP_EXISTS_ACTION or DEFAULT_EXISTS_ACTION
     pip_config = {
-        "PIP_CACHE_DIR": vistir.misc.fs_str(cache_dir.as_posix()),
-        "PIP_WHEEL_DIR": vistir.misc.fs_str(cache_dir.joinpath("wheels").as_posix()),
-        "PIP_DESTINATION_DIR": vistir.misc.fs_str(cache_dir.joinpath("pkgs").as_posix()),
+        "PIP_CACHE_DIR": cache_dir.as_posix(),
+        "PIP_WHEEL_DIR": cache_dir.joinpath("wheels").as_posix(),
+        "PIP_DESTINATION_DIR": cache_dir.joinpath("pkgs").as_posix(),
         "PIP_EXISTS_ACTION": exists_action,
-        "PATH": vistir.misc.fs_str(os.environ.get("PATH")),
+        "PATH": os.environ.get("PATH"),
     }
     if src_dir:
         if project.s.is_verbose():
             click.echo(f"Using source directory: {src_dir!r}", err=True)
-        pip_config.update({"PIP_SRC": vistir.misc.fs_str(src_dir)})
+        pip_config.update({"PIP_SRC": src_dir})
     c = subprocess_run(pip_command, block=block, env=pip_config)
     c.env = pip_config
     return c
@@ -1583,9 +1581,9 @@ def pip_install(
 def pip_download(project, package_name):
     cache_dir = Path(project.s.PIPENV_CACHE_DIR)
     pip_config = {
-        "PIP_CACHE_DIR": vistir.misc.fs_str(cache_dir.as_posix()),
-        "PIP_WHEEL_DIR": vistir.misc.fs_str(cache_dir.joinpath("wheels").as_posix()),
-        "PIP_DESTINATION_DIR": vistir.misc.fs_str(cache_dir.joinpath("pkgs").as_posix()),
+        "PIP_CACHE_DIR": cache_dir.as_posix(),
+        "PIP_WHEEL_DIR": cache_dir.joinpath("wheels").as_posix(),
+        "PIP_DESTINATION_DIR": cache_dir.joinpath("pkgs").as_posix(),
     }
     for source in project.sources:
         cmd = [
@@ -2130,16 +2128,14 @@ def do_install(
                 "Installing...", project.s
             ) as sp:
                 if not system:
-                    os.environ["PIP_USER"] = vistir.compat.fs_str("0")
+                    os.environ["PIP_USER"] = "0"
                     if "PYTHONHOME" in os.environ:
                         del os.environ["PYTHONHOME"]
                 sp.text = f"Resolving {pkg_line}..."
                 try:
                     pkg_requirement = Requirement.from_line(pkg_line)
                 except ValueError as e:
-                    sp.write_err(
-                        vistir.compat.fs_str("{}: {}".format(crayons.red("WARNING"), e))
-                    )
+                    sp.write_err("{}: {}".format(crayons.red("WARNING"), e))
                     sp.red.fail(
                         environments.PIPENV_SPINNER_FAIL_TEXT.format(
                             "Installation Failed"
@@ -2172,23 +2168,15 @@ def do_install(
                                 crayons.red("Error: ", bold=True), crayons.green(pkg_line)
                             ),
                         )
-                        sp.write_err(vistir.compat.fs_str(f"Error text: {c.stdout}"))
-                        sp.write_err(
-                            crayons.cyan(vistir.compat.fs_str(format_pip_error(c.stderr)))
-                        )
+                        sp.write_err(f"Error text: {c.stdout}")
+                        sp.write_err(crayons.cyan(format_pip_error(c.stderr)))
                         if project.s.is_verbose():
-                            sp.write_err(
-                                crayons.cyan(
-                                    vistir.compat.fs_str(format_pip_output(c.stdout))
-                                )
-                            )
+                            sp.write_err(crayons.cyan(format_pip_output(c.stdout)))
                         if "setup.py egg_info" in c.stderr:
                             sp.write_err(
-                                vistir.compat.fs_str(
-                                    "This is likely caused by a bug in {}. "
-                                    "Report this to its maintainers.".format(
-                                        crayons.green(pkg_requirement.name)
-                                    )
+                                "This is likely caused by a bug in {}. "
+                                "Report this to its maintainers.".format(
+                                    crayons.green(pkg_requirement.name)
                                 )
                             )
                         sp.red.fail(
@@ -2198,11 +2186,7 @@ def do_install(
                         )
                         sys.exit(1)
                 except (ValueError, RuntimeError) as e:
-                    sp.write_err(
-                        vistir.compat.fs_str(
-                            "{}: {}".format(crayons.red("WARNING"), e),
-                        )
-                    )
+                    sp.write_err("{}: {}".format(crayons.red("WARNING"), e))
                     sp.red.fail(
                         environments.PIPENV_SPINNER_FAIL_TEXT.format(
                             "Installation Failed",
@@ -2225,16 +2209,14 @@ def do_install(
                         )
                     )
                 sp.write(
-                    vistir.compat.fs_str(
-                        "{} {} {} {}{}".format(
-                            crayons.normal("Adding", bold=True),
-                            crayons.green(f"{pkg_requirement.name}", bold=True),
-                            crayons.normal("to Pipfile's", bold=True),
-                            crayons.yellow(
-                                "[dev-packages]" if dev else "[packages]", bold=True
-                            ),
-                            crayons.normal(fix_utf8("..."), bold=True),
-                        )
+                    "{} {} {} {}{}".format(
+                        crayons.normal("Adding", bold=True),
+                        crayons.green(f"{pkg_requirement.name}", bold=True),
+                        crayons.normal("to Pipfile's", bold=True),
+                        crayons.yellow(
+                            "[dev-packages]" if dev else "[packages]", bold=True
+                        ),
+                        crayons.normal(fix_utf8("..."), bold=True),
                     )
                 )
                 # Add the package to the Pipfile.
@@ -2461,7 +2443,7 @@ def do_shell(
     # Set an environment variable, so we know we're in the environment.
     # Only set PIPENV_ACTIVE after finishing reading virtualenv_location
     # otherwise its value will be changed
-    os.environ["PIPENV_ACTIVE"] = vistir.misc.fs_str("1")
+    os.environ["PIPENV_ACTIVE"] = "1"
 
     os.environ.pop("PIP_SHIMS_BASE_MODULE", None)
 
@@ -2524,7 +2506,7 @@ def inline_activate_virtual_environment(project):
     else:
         _inline_activate_virtualenv(project)
     if "VIRTUAL_ENV" not in os.environ:
-        os.environ["VIRTUAL_ENV"] = vistir.misc.fs_str(root)
+        os.environ["VIRTUAL_ENV"] = root
 
 
 def _launch_windows_subprocess(script, env):
@@ -2630,7 +2612,7 @@ def do_run(
     # Only set PIPENV_ACTIVE after finishing reading virtualenv_location
     # such as in inline_activate_virtual_environment
     # otherwise its value will be changed
-    env["PIPENV_ACTIVE"] = vistir.misc.fs_str("1")
+    env["PIPENV_ACTIVE"] = "1"
     env.pop("PIP_SHIMS_BASE_MODULE", None)
 
     try:

--- a/pipenv/environment.py
+++ b/pipenv/environment.py
@@ -524,8 +524,8 @@ class Environment:
         # type: () -> Dict[str, str]
         paths = {}
         with vistir.contextmanagers.temp_environ(), vistir.contextmanagers.temp_path():
-            os.environ["PYTHONIOENCODING"] = vistir.compat.fs_str("utf-8")
-            os.environ["PYTHONDONTWRITEBYTECODE"] = vistir.compat.fs_str("1")
+            os.environ["PYTHONIOENCODING"] = "utf-8"
+            os.environ["PYTHONDONTWRITEBYTECODE"] = "1"
             paths = self.base_paths
             os.environ["PATH"] = paths["PATH"]
             os.environ["PYTHONPATH"] = paths["PYTHONPATH"]
@@ -954,16 +954,16 @@ class Environment:
         with vistir.contextmanagers.temp_environ(), vistir.contextmanagers.temp_path():
             os.environ["PATH"] = os.pathsep.join(
                 [
-                    vistir.compat.fs_str(self.script_basedir),
-                    vistir.compat.fs_str(self.prefix.as_posix()),
+                    self.script_basedir,
+                    self.prefix.as_posix(),
                     os.environ.get("PATH", ""),
                 ]
             )
-            os.environ["PYTHONIOENCODING"] = vistir.compat.fs_str("utf-8")
-            os.environ["PYTHONDONTWRITEBYTECODE"] = vistir.compat.fs_str("1")
+            os.environ["PYTHONIOENCODING"] = "utf-8"
+            os.environ["PYTHONDONTWRITEBYTECODE"] = "1"
             if self.is_venv:
                 os.environ["PYTHONPATH"] = self.base_paths["PYTHONPATH"]
-                os.environ["VIRTUAL_ENV"] = vistir.compat.fs_str(prefix)
+                os.environ["VIRTUAL_ENV"] = prefix
             else:
                 if not self.project.s.PIPENV_USE_SYSTEM and not os.environ.get(
                     "VIRTUAL_ENV"

--- a/pipenv/environments.py
+++ b/pipenv/environments.py
@@ -8,11 +8,12 @@ from appdirs import user_cache_dir
 from vistir.path import normalize_drive
 
 from pipenv._compat import fix_utf8
-from pipenv.vendor.vistir.misc import _isatty, fs_str
+from pipenv.vendor.vistir.misc import _isatty
 
 # HACK: avoid resolver.py uses the wrong byte code files.
 # I hope I can remove this one day.
-os.environ["PYTHONDONTWRITEBYTECODE"] = fs_str("1")
+
+os.environ["PYTHONDONTWRITEBYTECODE"] = "1"
 _false_values = ("0", "false", "no", "off")
 _true_values = ("1", "true", "yes", "on")
 

--- a/pipenv/utils/dependencies.py
+++ b/pipenv/utils/dependencies.py
@@ -4,8 +4,6 @@ from typing import Mapping, Sequence
 
 from packaging.markers import Marker
 
-from pipenv import fs_str
-
 from .constants import SCHEME_LIST, VCS_LIST
 from .shell import temp_path
 
@@ -299,7 +297,7 @@ def locked_repository(requirement):
     if not requirement.is_vcs:
         return
     original_base = os.environ.pop("PIP_SHIMS_BASE_MODULE", None)
-    os.environ["PIP_SHIMS_BASE_MODULE"] = fs_str("pipenv.patched.notpip")
+    os.environ["PIP_SHIMS_BASE_MODULE"] = "pipenv.patched.notpip"
     src_dir = create_tracked_tempdir(prefix="pipenv-", suffix="-src")
     try:
         with requirement.req.locked_vcs_repo(src_dir=src_dir) as repo:

--- a/pipenv/utils/resolver.py
+++ b/pipenv/utils/resolver.py
@@ -979,7 +979,7 @@ def venv_resolve_deps(
     target_file.close()
     cmd.extend(["--write", make_posix(target_file.name)])
     with temp_environ():
-        os.environ.update({k: val for k, val in os.environ.items()})
+        os.environ.update({k: str(val) for k, val in os.environ.items()})
         if pypi_mirror:
             os.environ["PIPENV_PYPI_MIRROR"] = str(pypi_mirror)
         os.environ["PIPENV_VERBOSITY"] = str(project.s.PIPENV_VERBOSITY)

--- a/pipenv/utils/resolver.py
+++ b/pipenv/utils/resolver.py
@@ -947,7 +947,6 @@ def venv_resolve_deps(
     from pipenv import resolver
     from pipenv._compat import decode_for_output
     from pipenv.vendor.vistir.compat import JSONDecodeError, NamedTemporaryFile, Path
-    from pipenv.vendor.vistir.misc import fs_str
 
     results = []
     pipfile_section = "dev-packages" if dev else "packages"
@@ -980,19 +979,19 @@ def venv_resolve_deps(
     target_file.close()
     cmd.extend(["--write", make_posix(target_file.name)])
     with temp_environ():
-        os.environ.update({fs_str(k): fs_str(val) for k, val in os.environ.items()})
+        os.environ.update({k: val for k, val in os.environ.items()})
         if pypi_mirror:
             os.environ["PIPENV_PYPI_MIRROR"] = str(pypi_mirror)
         os.environ["PIPENV_VERBOSITY"] = str(project.s.PIPENV_VERBOSITY)
-        os.environ["PIPENV_REQ_DIR"] = fs_str(req_dir)
-        os.environ["PIP_NO_INPUT"] = fs_str("1")
+        os.environ["PIPENV_REQ_DIR"] = req_dir
+        os.environ["PIP_NO_INPUT"] = "1"
         pipenv_site_dir = get_pipenv_sitedir()
         if pipenv_site_dir is not None:
             os.environ["PIPENV_SITE_DIR"] = pipenv_site_dir
         else:
             os.environ.pop("PIPENV_SITE_DIR", None)
         if keep_outdated:
-            os.environ["PIPENV_KEEP_OUTDATED"] = fs_str("1")
+            os.environ["PIPENV_KEEP_OUTDATED"] = "1"
         with create_spinner(
             text=decode_for_output("Locking..."), setting=project.s
         ) as sp:

--- a/pipenv/utils/spinner.py
+++ b/pipenv/utils/spinner.py
@@ -4,7 +4,6 @@ import contextlib
 @contextlib.contextmanager
 def create_spinner(text, setting, nospin=None, spinner_name=None):
     from pipenv.vendor.vistir import spin
-    from pipenv.vendor.vistir.misc import fs_str
 
     if not spinner_name:
         spinner_name = setting.PIPENV_SPINNER
@@ -12,7 +11,7 @@ def create_spinner(text, setting, nospin=None, spinner_name=None):
         nospin = setting.PIPENV_NOSPIN
     with spin.create_spinner(
         spinner_name=spinner_name,
-        start_text=fs_str(text),
+        start_text=text,
         nospin=nospin,
         write_to_stdout=False,
     ) as sp:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -22,7 +22,7 @@ from pipenv.cli import cli
 from pipenv.exceptions import VirtualenvActivationException
 from pipenv.utils.processes import subprocess_run
 from pipenv.vendor import toml, tomlkit
-from pipenv.vendor.vistir.compat import fs_encode, fs_str
+from pipenv.vendor.vistir.compat import fs_encode
 from pipenv.vendor.vistir.contextmanagers import temp_environ
 from pipenv.vendor.vistir.misc import run
 from pipenv.vendor.vistir.path import (
@@ -156,7 +156,7 @@ def local_tempdir(request):
     os.environ["TEMP"] = new_temp.as_posix()
 
     def finalize():
-        os.environ['TEMP'] = fs_str(old_temp)
+        os.environ['TEMP'] = old_temp
         _rmtree_func(new_temp.as_posix())
 
     request.addfinalizer(finalize)
@@ -192,13 +192,12 @@ def isolate(create_tmpdir):
         fp.write(
             b"[user]\n\tname = pipenv\n\temail = pipenv@pipenv.org\n"
         )
-    # os.environ["GIT_CONFIG"] = fs_str(git_config_file)
-    os.environ["GIT_CONFIG_NOSYSTEM"] = fs_str("1")
-    os.environ["GIT_AUTHOR_NAME"] = fs_str("pipenv")
-    os.environ["GIT_AUTHOR_EMAIL"] = fs_str("pipenv@pipenv.org")
-    os.environ["GIT_ASK_YESNO"] = fs_str("false")
+    os.environ["GIT_CONFIG_NOSYSTEM"] = "1"
+    os.environ["GIT_AUTHOR_NAME"] = "pipenv"
+    os.environ["GIT_AUTHOR_EMAIL"] = "pipenv@pipenv.org"
+    os.environ["GIT_ASK_YESNO"] = "false"
     workon_home = create_tmpdir()
-    os.environ["WORKON_HOME"] = fs_str(str(workon_home))
+    os.environ["WORKON_HOME"] = str(workon_home)
     os.environ["HOME"] = os.path.abspath(home_dir)
     mkdir_p(os.path.join(home_dir, "projects"))
     # Ignore PIPENV_ACTIVE so that it works as under a bare environment.
@@ -304,11 +303,11 @@ class _PipenvInstance:
         self.index = os.getenv("PIPENV_PYPI_INDEX")
         self.env["PYTHONWARNINGS"] = "ignore:DEPRECATION"
         if ignore_virtualenvs:
-            self.env["PIPENV_IGNORE_VIRTUALENVS"] = fs_str("1")
+            self.env["PIPENV_IGNORE_VIRTUALENVS"] = "1"
         if venv_root:
             self.env["VIRTUAL_ENV"] = venv_root
         if venv_in_project:
-            self.env["PIPENV_VENV_IN_PROJECT"] = fs_str("1")
+            self.env["PIPENV_VENV_IN_PROJECT"] = "1"
         else:
             self.env.pop("PIPENV_VENV_IN_PROJECT", None)
 
@@ -340,9 +339,7 @@ class _PipenvInstance:
         self.chdir = chdir
 
         if self.pypi and "PIPENV_PYPI_URL" not in os.environ:
-            self.env['PIPENV_PYPI_URL'] = fs_str(f'{self.pypi}')
-            # os.environ['PIPENV_PYPI_URL'] = fs_str('{0}'.format(self.pypi.url))
-            # os.environ['PIPENV_TEST_INDEX'] = fs_str('{0}/simple'.format(self.pypi.url))
+            self.env['PIPENV_PYPI_URL'] = f'{self.pypi}'
 
         if pipfile:
             p_path = os.sep.join([self.path, 'Pipfile'])
@@ -372,7 +369,7 @@ class _PipenvInstance:
 
     def pipenv(self, cmd, block=True):
         if self.pipfile_path and os.path.isfile(self.pipfile_path):
-            os.environ['PIPENV_PIPFILE'] = fs_str(self.pipfile_path)
+            os.environ['PIPENV_PIPFILE'] = self.pipfile_path
         # a bit of a hack to make sure the virtualenv is created
 
         with TemporaryDirectory(prefix='pipenv-', suffix='-cache') as tempdir:
@@ -435,7 +432,7 @@ def pip_src_dir(request, vistir_tmpdir):
     os.environ['PIP_SRC'] = vistir_tmpdir.as_posix()
 
     def finalize():
-        os.environ['PIP_SRC'] = fs_str(old_src_dir)
+        os.environ['PIP_SRC'] = old_src_dir
 
     request.addfinalizer(finalize)
     return request
@@ -446,9 +443,9 @@ def PipenvInstance(pip_src_dir, monkeypatch, pypi, capfdbinary):
     with temp_environ(), monkeypatch.context() as m:
         m.setattr(shutil, "rmtree", _rmtree_func)
         original_umask = os.umask(0o007)
-        m.setenv("PIPENV_NOSPIN", fs_str("1"))
-        m.setenv("CI", fs_str("1"))
-        m.setenv('PIPENV_DONT_USE_PYENV', fs_str('1'))
+        m.setenv("PIPENV_NOSPIN", "1")
+        m.setenv("CI", "1")
+        m.setenv('PIPENV_DONT_USE_PYENV', '1')
         m.setenv("PIPENV_TEST_INDEX", f"{pypi.url}/simple")
         m.setenv("PIPENV_PYPI_INDEX", "simple")
         m.setenv("ARTIFACT_PYPI_URL", pypi.url)
@@ -466,9 +463,9 @@ def PipenvInstance_NoPyPI(monkeypatch, pip_src_dir, pypi, capfdbinary):
     with temp_environ(), monkeypatch.context() as m:
         m.setattr(shutil, "rmtree", _rmtree_func)
         original_umask = os.umask(0o007)
-        m.setenv("PIPENV_NOSPIN", fs_str("1"))
-        m.setenv("CI", fs_str("1"))
-        m.setenv('PIPENV_DONT_USE_PYENV', fs_str('1'))
+        m.setenv("PIPENV_NOSPIN", "1")
+        m.setenv("CI", "1")
+        m.setenv('PIPENV_DONT_USE_PYENV', '1')
         m.setenv("PIPENV_TEST_INDEX", f"{pypi.url}/simple")
         m.setenv("ARTIFACT_PYPI_URL", pypi.url)
         warnings.simplefilter("ignore", category=ResourceWarning)


### PR DESCRIPTION
This function was all about compatability of py2-py3.3 versions.
Later versions don't need it.

This PR replaces #5059 as I did too much havoc there with all the CI suggestions.
