### PR TITLE
Update docs and add deprecation warning for lock -r

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -231,9 +231,10 @@ Anaconda uses Conda to manage packages. To reuse Conda–installed Python packag
 ☤ Generating a ``requirements.txt``
 -----------------------------------
 
+Sometimes, you would want to generate a requirements file based on your current
+environment, for example to include tooling that only supports requirements.txt.
 You can convert a ``Pipfile`` and ``Pipfile.lock`` into a ``requirements.txt``
-file very easily, and get all the benefits of extras and other goodies we have
-included.
+file very easily.
 
 Let's take this ``Pipfile``::
 
@@ -249,7 +250,8 @@ Let's take this ``Pipfile``::
 
 And generate a set of requirements out of it with only the default dependencies::
 
-    $ pipenv lock -r
+    $ pipenv requirements
+    -i https://pypi.org/simple
     chardet==3.0.4
     requests==2.18.4
     certifi==2017.7.27.1
@@ -259,7 +261,8 @@ And generate a set of requirements out of it with only the default dependencies:
 As with other commands, passing ``--dev`` will include both the default and
 development dependencies::
 
-    $ pipenv lock -r --dev
+    $ pipenv requirements --dev
+    -i https://pypi.org/simple
     chardet==3.0.4
     requests==2.18.4
     certifi==2017.7.27.1
@@ -272,59 +275,27 @@ If you wish to generate a requirements file with only the
 development requirements you can do that too, using the ``--dev-only``
 flag::
 
-    $ pipenv lock -r --dev-only
+    $ pipenv requirements --dev-only
+    -i https://pypi.org/simple
     py==1.4.34
     pytest==3.2.3
 
-Sometimes, you would want to generate a requirements file based on your current
-environment. However, using pipenv lock -r will still do the locking process which
-could update package versions. To keep the packages as is, use the ``--keep-outdated``
-flag::
-
-    $ pipenv lock -r --keep-outdated
-    chardet==3.0.4
-    requests==2.18.4
-    certifi==2017.7.27.1
-    idna==2.6
-    urllib3==1.22
-
-Note that using this approach, packages newly added to the Pipfile will still be
-included in requirements.txt. If you really want to use Pipfile.lock and
-Pipfile.lock only, you can generate the requirements using::
-
-    $ pipenv requirements
-    chardet==3.0.4
-    requests==2.18.4
-    certifi==2017.7.27.1
-    idna==2.6
-    urllib3==1.22
-
-This will bypass the locking process completely. As with other commands,
-passing ``--dev`` will include both the default and development dependencies.
-Passing ``--dev-only`` will include only development dependencies and ``--hash`` will
-add package hashes to the output for extra security.
+Adding the ``--hash`` flag will add package hashes to the output for extra security.
 
 The locked requirements are written to stdout, with shell output redirection
 used to write them to a file::
 
-    $ pipenv lock -r > requirements.txt
-    $ pipenv lock -r --dev-only > dev-requirements.txt
-    $ pipenv requirements --dev > all-requirements.txt
+    $ pipenv requirements > requirements.txt
+    $ pipenv requirements --dev-only > dev-requirements.txt
     $ cat requirements.txt
+    -i https://pypi.org/simple
     chardet==3.0.4
     requests==2.18.4
     certifi==2017.7.27.1
     idna==2.6
     urllib3==1.22
     $ cat dev-requirements.txt
-    py==1.4.34
-    pytest==3.2.3
-    $ cat all-requirements.txt
-    chardet==3.0.4
-    requests==2.18.4
-    certifi==2017.7.27.1
-    idna==2.6
-    urllib3==1.22
+    -i https://pypi.org/simple
     py==1.4.34
     pytest==3.2.3
 

--- a/pipenv/cli/command.py
+++ b/pipenv/cli/command.py
@@ -323,6 +323,11 @@ def lock(ctx, state, **kwargs):
     dev_only = state.lockoptions.dev_only
     pre = state.installstate.pre
     if emit_requirements:
+        echo(crayons.yellow("""
+            Warning: The lock flags -r/--requirements, along with it's options (--keep-outdated, --dev, --dev-only)
+            will be deprecated in a future version of pipenv in favor of the new requirements command.
+            For more info see https://pipenv.pypa.io/en/latest/advanced/#generating-a-requirements-txt
+            """))
         # Emit requirements file header (unless turned off with --no-header)
         if state.lockoptions.emit_requirements_header:
             header_options = ["--requirements"]

--- a/pipenv/cli/command.py
+++ b/pipenv/cli/command.py
@@ -35,6 +35,7 @@ from pipenv.vendor.click import (
     option,
     pass_context,
     secho,
+    style,
     version_option,
 )
 
@@ -324,12 +325,15 @@ def lock(ctx, state, **kwargs):
     pre = state.installstate.pre
     if emit_requirements:
         echo(
-            crayons.yellow(
+            style(
                 """
-            Warning: The lock flags -r/--requirements, along with it's options (--keep-outdated, --dev, --dev-only)
-            will be deprecated in a future version of pipenv in favor of the new requirements command.
-            For more info see https://pipenv.pypa.io/en/latest/advanced/#generating-a-requirements-txt
-            """
+            Warning: The lock flag -r/--requirements will be deprecated in a future version
+            of pipenv in favor of the new requirements command. For more info see
+            https://pipenv.pypa.io/en/latest/advanced/#generating-a-requirements-txt
+            NOTE: the requirements command parses Pipfile.lock directly without performing any
+            locking operations. Updating packages should be done by running pipenv lock
+            """,
+                fg="yellow",
             )
         )
         # Emit requirements file header (unless turned off with --no-header)

--- a/pipenv/cli/command.py
+++ b/pipenv/cli/command.py
@@ -323,11 +323,15 @@ def lock(ctx, state, **kwargs):
     dev_only = state.lockoptions.dev_only
     pre = state.installstate.pre
     if emit_requirements:
-        echo(crayons.yellow("""
+        echo(
+            crayons.yellow(
+                """
             Warning: The lock flags -r/--requirements, along with it's options (--keep-outdated, --dev, --dev-only)
             will be deprecated in a future version of pipenv in favor of the new requirements command.
             For more info see https://pipenv.pypa.io/en/latest/advanced/#generating-a-requirements-txt
-            """))
+            """
+            )
+        )
         # Emit requirements file header (unless turned off with --no-header)
         if state.lockoptions.emit_requirements_header:
             header_options = ["--requirements"]


### PR DESCRIPTION
@matteius I gave `pipenv lock -r` some more thought and I think we should over time deprecate it in favor of `pipenv requirements`. This PR contains a deprecation warning and an update to the docs. Please let me know your thoughts