### PR TITLE
use existing function convert_deps_to_pip, added 2 params to convert_…

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,10 @@
 name: CI
+concurrency:
+  group: >-
+    ${{ github.workflow }}-
+    ${{ github.ref_type }}-
+    ${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
 on:
   push:
     paths-ignore:

--- a/news/5070.bugfix.rst
+++ b/news/5070.bugfix.rst
@@ -1,0 +1,1 @@
+Fixes issue of ``requirements`` command problem by modifying to print ``-e`` and path of the editable package.

--- a/news/5076.bugfix.rst
+++ b/news/5076.bugfix.rst
@@ -1,0 +1,1 @@
+Fixes issue of ``requirements`` command where git requirements cause the command to fail, solved by using existing convert_deps_to_pip function.

--- a/news/5078.removal.rst
+++ b/news/5078.removal.rst
@@ -1,0 +1,1 @@
+Remove more usage of misc functions of vistir. Many of this function are availabel in the STL or in another dependency of pipenv.

--- a/news/5081.vendor.rst
+++ b/news/5081.vendor.rst
@@ -1,0 +1,1 @@
+Vendor in ``requirementslib==1.6.4`` to Fix ``SetuptoolsDeprecationWarning`` ``setuptools.config.read_configuration`` became deprecated.

--- a/pipenv/cli/command.py
+++ b/pipenv/cli/command.py
@@ -768,7 +768,7 @@ def requirements(state, dev=False, dev_only=False, hash=False):
     if dev or dev_only:
         deps.update(lockfile['develop'])
 
-    pip_deps = convert_deps_to_pip(deps, r=False, include_index=False, with_hashes=hash, with_markers=False)
+    pip_deps = convert_deps_to_pip(deps, r=False, include_index=False, include_hashes=hash, include_markers=False)
     for pip_dep in pip_deps:
         echo(crayons.normal(pip_dep))
 

--- a/pipenv/cli/command.py
+++ b/pipenv/cli/command.py
@@ -768,7 +768,7 @@ def requirements(state, dev=False, dev_only=False, hash=False):
     if dev or dev_only:
         deps.update(lockfile['develop'])
 
-    pip_deps = convert_deps_to_pip(deps, r=False, include_index=False, include_hashes=hash, include_markers=False)
+    pip_deps = convert_deps_to_pip(deps, r=False, include_index=False, with_hashes=hash, with_markers=False)
     for pip_dep in pip_deps:
         echo(crayons.normal(pip_dep))
 

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -3,6 +3,7 @@ import logging
 import os
 import shutil
 import sys
+import tempfile
 import time
 import warnings
 from pathlib import Path
@@ -1440,7 +1441,7 @@ def write_requirement_to_file(
         with_prefix=True, with_hashes=include_hashes, with_markers=True, as_list=False
     )
 
-    f = vistir.compat.NamedTemporaryFile(
+    f = tempfile.NamedTemporaryFile(
         prefix="pipenv-", suffix="-requirement.txt", dir=requirements_dir, delete=False
     )
     if project.s.is_verbose():

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -1395,7 +1395,7 @@ def get_pip_args(
             arg_set.extend(arg_map.get(key))
         elif key == "selective_upgrade" and not locals().get(key):
             arg_set.append("--exists-action=i")
-    return list(vistir.misc.dedup(arg_set))
+    return list(dict.fromkeys(arg_set))
 
 
 def get_requirement_line(

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -1845,11 +1845,11 @@ def do_py(project, ctx=None, system=False):
 def do_outdated(project, pypi_mirror=None, pre=False, clear=False):
     # TODO: Allow --skip-lock here?
     from collections import namedtuple
+    from collections.abc import Mapping
 
     from .vendor.packaging.utils import canonicalize_name
     from .vendor.requirementslib.models.requirements import Requirement
     from .vendor.requirementslib.models.utils import get_version
-    from .vendor.vistir.compat import Mapping
 
     packages = {}
     package_info = namedtuple("PackageInfo", ["name", "installed", "available"])

--- a/pipenv/environment.py
+++ b/pipenv/environment.py
@@ -16,7 +16,7 @@ from pipenv.environments import is_type_checking
 from pipenv.utils.indexes import prepare_pip_source_args
 from pipenv.utils.processes import subprocess_run
 from pipenv.utils.shell import make_posix, normalize_path
-from pipenv.vendor import vistir
+from pipenv.vendor import click, vistir
 from pipenv.vendor.cached_property import cached_property
 from pipenv.vendor.packaging.utils import canonicalize_name
 
@@ -410,8 +410,8 @@ class Environment:
                     paths[key] = make_posix(paths[key])
             return paths
         else:
-            vistir.misc.echo(f"Failed to load paths: {c.stderr}", fg="yellow")
-            vistir.misc.echo(f"Output: {c.stdout}", fg="yellow")
+            click.echo(f"Failed to load paths: {c.stderr}", fg="yellow")
+            click.echo(f"Output: {c.stdout}", fg="yellow")
         return None
 
     def get_lib_paths(self):
@@ -439,8 +439,8 @@ class Environment:
                     paths[key] = make_posix(paths[key])
             return paths
         else:
-            vistir.misc.echo(f"Failed to load paths: {c.stderr}", fg="yellow")
-            vistir.misc.echo(f"Output: {c.stdout}", fg="yellow")
+            click.secho(f"Failed to load paths: {c.stderr}", fg="yellow")
+            click.secho(f"Output: {c.stdout}", fg="yellow")
         if not paths:
             if not self.prefix.joinpath("lib").exists():
                 return {}
@@ -499,8 +499,8 @@ class Environment:
                     paths[key] = make_posix(paths[key])
             return paths
         else:
-            vistir.misc.echo(f"Failed to load paths: {c.stderr}", fg="yellow")
-            vistir.misc.echo(f"Output: {c.stdout}", fg="yellow")
+            click.secho(f"Failed to load paths: {c.stderr}", fg="yellow")
+            click.secho(f"Output: {c.stdout}", fg="yellow")
         return None
 
     @cached_property

--- a/pipenv/resolver.py
+++ b/pipenv/resolver.py
@@ -247,7 +247,7 @@ class Entry:
 
         if not marker:
             return None
-        from pipenv.vendor.vistir.compat import Mapping
+        from collections.abc import Mapping
 
         marker_str = None
         if isinstance(marker, Mapping):

--- a/pipenv/shells.py
+++ b/pipenv/shells.py
@@ -5,9 +5,10 @@ import re
 import signal
 import subprocess
 import sys
+from pathlib import Path
 
 from pipenv.vendor import shellingham
-from pipenv.vendor.vistir.compat import Path, get_terminal_size
+from pipenv.vendor.vistir.compat import get_terminal_size
 from pipenv.vendor.vistir.contextmanagers import temp_environ
 
 ShellDetectionFailure = shellingham.ShellDetectionFailure

--- a/pipenv/utils/dependencies.py
+++ b/pipenv/utils/dependencies.py
@@ -131,7 +131,6 @@ def translate_markers(pipfile_entry):
     if not isinstance(pipfile_entry, Mapping):
         raise TypeError("Entry is not a pipfile formatted mapping.")
     from pipenv.vendor.packaging.markers import default_environment
-    from pipenv.vendor.vistir.misc import dedup
 
     allowed_marker_keys = ["markers"] + list(default_environment().keys())
     provided_keys = list(pipfile_entry.keys()) if hasattr(pipfile_entry, "keys") else []
@@ -153,7 +152,8 @@ def translate_markers(pipfile_entry):
         new_pipfile["markers"] = str(
             Marker(
                 " or ".join(
-                    f"{s}" if " and " in s else s for s in sorted(dedup(marker_set))
+                    f"{s}" if " and " in s else s
+                    for s in sorted(dict.fromkeys(marker_set))
                 )
             )
         ).replace('"', "'")

--- a/pipenv/utils/dependencies.py
+++ b/pipenv/utils/dependencies.py
@@ -243,7 +243,7 @@ def is_pinned_requirement(ireq):
     return spec.operator in {"==", "==="} and not spec.version.endswith(".*")
 
 
-def convert_deps_to_pip(deps, project=None, r=True, include_index=True):
+def convert_deps_to_pip(deps, project=None, r=True, include_index=True, with_hashes=True, with_markers=True):
     """ "Converts a Pipfile-formatted dependency to a pip-formatted one."""
     from pipenv.vendor.requirementslib.models.requirements import Requirement
 
@@ -252,7 +252,7 @@ def convert_deps_to_pip(deps, project=None, r=True, include_index=True):
         if project:
             project.clear_pipfile_cache()
         indexes = getattr(project, "pipfile_sources", []) if project is not None else []
-        new_dep = Requirement.from_pipfile(dep_name, dep)
+        new_dep = Requirement.from_pipfile(dep_name, dep, with_hashes=with_hashes, with_markers=with_markers)
         if new_dep.index:
             include_index = True
         req = new_dep.as_line(sources=indexes if include_index else None).strip()

--- a/pipenv/utils/dependencies.py
+++ b/pipenv/utils/dependencies.py
@@ -243,7 +243,7 @@ def is_pinned_requirement(ireq):
     return spec.operator in {"==", "==="} and not spec.version.endswith(".*")
 
 
-def convert_deps_to_pip(deps, project=None, r=True, include_index=True, with_hashes=True, with_markers=True):
+def convert_deps_to_pip(deps, project=None, r=True, include_index=True, include_hashes=True, include_markers=True):
     """ "Converts a Pipfile-formatted dependency to a pip-formatted one."""
     from pipenv.vendor.requirementslib.models.requirements import Requirement
 
@@ -252,10 +252,11 @@ def convert_deps_to_pip(deps, project=None, r=True, include_index=True, with_has
         if project:
             project.clear_pipfile_cache()
         indexes = getattr(project, "pipfile_sources", []) if project is not None else []
-        new_dep = Requirement.from_pipfile(dep_name, dep, with_hashes=with_hashes, with_markers=with_markers)
+        new_dep = Requirement.from_pipfile(dep_name, dep)
         if new_dep.index:
             include_index = True
-        req = new_dep.as_line(sources=indexes if include_index else None).strip()
+        sources = indexes if include_index else None
+        req = new_dep.as_line(sources=sources, include_hashes=include_hashes, include_markers=include_markers).strip()
         dependencies.append(req)
     if not r:
         return dependencies

--- a/pipenv/utils/resolver.py
+++ b/pipenv/utils/resolver.py
@@ -943,10 +943,11 @@ def venv_resolve_deps(
     """
 
     import json
+    import tempfile
 
     from pipenv import resolver
     from pipenv._compat import decode_for_output
-    from pipenv.vendor.vistir.compat import NamedTemporaryFile, Path
+    from pipenv.vendor.vistir.compat import Path
 
     results = []
     pipfile_section = "dev-packages" if dev else "packages"
@@ -975,7 +976,9 @@ def venv_resolve_deps(
         cmd.append("--system")
     if dev:
         cmd.append("--dev")
-    target_file = NamedTemporaryFile(prefix="resolver", suffix=".json", delete=False)
+    target_file = tempfile.NamedTemporaryFile(
+        prefix="resolver", suffix=".json", delete=False
+    )
     target_file.close()
     cmd.extend(["--write", make_posix(target_file.name)])
     with temp_environ():

--- a/pipenv/vendor/requirementslib/__init__.py
+++ b/pipenv/vendor/requirementslib/__init__.py
@@ -10,7 +10,7 @@ from .models.lockfile import Lockfile
 from .models.pipfile import Pipfile
 from .models.requirements import Requirement
 
-__version__ = "1.6.3"
+__version__ = "1.6.4"
 
 
 logger = logging.getLogger(__name__)

--- a/pipenv/vendor/requirementslib/models/requirements.py
+++ b/pipenv/vendor/requirementslib/models/requirements.py
@@ -2730,7 +2730,7 @@ class Requirement(object):
         )
 
     @classmethod
-    def from_pipfile(cls, name, pipfile, with_hashes=True, with_markers=True):
+    def from_pipfile(cls, name, pipfile):
         from .markers import PipenvMarkers
 
         _pipfile = {}
@@ -2765,12 +2765,12 @@ class Requirement(object):
             "name": r.name,
             "vcs": vcs,
             "req": r,
-            "markers": markers if with_markers else None,
+            "markers": markers,
             "extras": tuple(_pipfile.get("extras", ())),
             "editable": _pipfile.get("editable", False),
             "index": _pipfile.get("index"),
         }
-        if with_hashes and any(key in _pipfile for key in ["hash", "hashes"]):
+        if any(key in _pipfile for key in ["hash", "hashes"]):
             args["hashes"] = _pipfile.get("hashes", [pipfile.get("hash")])
         cls_inst = cls(**args)
         return cls_inst

--- a/pipenv/vendor/requirementslib/models/requirements.py
+++ b/pipenv/vendor/requirementslib/models/requirements.py
@@ -2730,7 +2730,7 @@ class Requirement(object):
         )
 
     @classmethod
-    def from_pipfile(cls, name, pipfile):
+    def from_pipfile(cls, name, pipfile, with_hashes=True, with_markers=True):
         from .markers import PipenvMarkers
 
         _pipfile = {}
@@ -2765,12 +2765,12 @@ class Requirement(object):
             "name": r.name,
             "vcs": vcs,
             "req": r,
-            "markers": markers,
+            "markers": markers if with_markers else None,
             "extras": tuple(_pipfile.get("extras", ())),
             "editable": _pipfile.get("editable", False),
             "index": _pipfile.get("index"),
         }
-        if any(key in _pipfile for key in ["hash", "hashes"]):
+        if with_hashes and any(key in _pipfile for key in ["hash", "hashes"]):
             args["hashes"] = _pipfile.get("hashes", [pipfile.get("hash")])
         cls_inst = cls(**args)
         return cls_inst

--- a/pipenv/vendor/requirementslib/models/setup_info.py
+++ b/pipenv/vendor/requirementslib/models/setup_info.py
@@ -513,7 +513,11 @@ class SetupReader:
 
 
 def setuptools_parse_setup_cfg(path):
-    from setuptools.config import read_configuration
+    try:
+        # v61.0.0 of setuptools deprecated setuptools.config.read_configuration
+        from setuptools.config.setupcfg import read_configuration
+    except ImportError:
+        from setuptools.config import read_configuration
 
     parsed = read_configuration(path)
     results = parsed.get("metadata", {})

--- a/pipenv/vendor/vendor.txt
+++ b/pipenv/vendor/vendor.txt
@@ -30,7 +30,7 @@ python-dateutil==2.8.2
 python-dotenv==0.19.0
 pythonfinder==1.2.10
 requests==2.26.0
-requirementslib==1.6.3
+requirementslib==1.6.4
 shellingham==1.4.0
 six==1.16.0
 termcolor==1.1.0

--- a/tests/integration/test_requirements.py
+++ b/tests/integration/test_requirements.py
@@ -1,3 +1,5 @@
+import json
+
 import pytest
 
 
@@ -66,3 +68,28 @@ def test_requirements_generates_requirements_from_lockfile_multiple_sources(Pipe
 
         assert '-i https://pypi.org/simple' in c.stdout
         assert '--extra-index-url https://some_other_source.org' in c.stdout
+
+
+@pytest.mark.requirements
+def test_requirements_with_git_requirements(PipenvInstance):
+    req_name, req_hash = 'example-repo', 'cc858e89f19bc0dbd70983f86b811ab625dc9292'
+    lockfile = {
+        "_meta": {"sources": []},
+        "default": {
+            req_name: {
+                "editable": True,
+                "git": F"ssh://git@bitbucket.org/code/{req_name}.git",
+                "ref": req_hash
+            }
+        },
+        "develop": {}
+    }
+
+    with PipenvInstance(chdir=True) as p:
+        with open(p.lockfile_path, 'w') as f:
+            json.dump(lockfile, f)
+
+        c = p.pipenv('requirements')
+        assert c.returncode == 0
+        assert req_name in c.stdout
+        assert req_hash in c.stdout


### PR DESCRIPTION
running pipenv requirements with the below example dependency will fail

"exmple-repo": {
    "editable": true,
    "git": "ssh://git@bitbucket.org/code/exmaple-repo.git",
    "ref": "cc858e89f19bc0dbd70983f86b811ab625dc9292"
}

### Fix
Use the exisiting `pipenv.utils.dependencies.convert_deps_to_pip` function with some added parameters to output the requirements, remove parsing of file in `pipenv.cli.command.requirements` itself

### The checklist

* [x] Associated issue
* [x] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

Fixes #5076