### PR TITLE
More vistir dropping

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,10 @@
 name: CI
+concurrency:
+  group: >-
+    ${{ github.workflow }}-
+    ${{ github.ref_type }}-
+    ${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
 on:
   push:
     paths-ignore:

--- a/news/5078.removal.rst
+++ b/news/5078.removal.rst
@@ -1,0 +1,1 @@
+Remove more usage of misc functions of vistir. Many of this function are availabel in the STL or in another dependency of pipenv.

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -3,6 +3,7 @@ import logging
 import os
 import shutil
 import sys
+import tempfile
 import time
 import warnings
 from pathlib import Path
@@ -1440,7 +1441,7 @@ def write_requirement_to_file(
         with_prefix=True, with_hashes=include_hashes, with_markers=True, as_list=False
     )
 
-    f = vistir.compat.NamedTemporaryFile(
+    f = tempfile.NamedTemporaryFile(
         prefix="pipenv-", suffix="-requirement.txt", dir=requirements_dir, delete=False
     )
     if project.s.is_verbose():

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -1395,7 +1395,7 @@ def get_pip_args(
             arg_set.extend(arg_map.get(key))
         elif key == "selective_upgrade" and not locals().get(key):
             arg_set.append("--exists-action=i")
-    return list(vistir.misc.dedup(arg_set))
+    return list(dict.fromkeys(arg_set))
 
 
 def get_requirement_line(

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -1845,11 +1845,11 @@ def do_py(project, ctx=None, system=False):
 def do_outdated(project, pypi_mirror=None, pre=False, clear=False):
     # TODO: Allow --skip-lock here?
     from collections import namedtuple
+    from collections.abc import Mapping
 
     from .vendor.packaging.utils import canonicalize_name
     from .vendor.requirementslib.models.requirements import Requirement
     from .vendor.requirementslib.models.utils import get_version
-    from .vendor.vistir.compat import Mapping
 
     packages = {}
     package_info = namedtuple("PackageInfo", ["name", "installed", "available"])

--- a/pipenv/environment.py
+++ b/pipenv/environment.py
@@ -16,7 +16,7 @@ from pipenv.environments import is_type_checking
 from pipenv.utils.indexes import prepare_pip_source_args
 from pipenv.utils.processes import subprocess_run
 from pipenv.utils.shell import make_posix, normalize_path
-from pipenv.vendor import vistir
+from pipenv.vendor import click, vistir
 from pipenv.vendor.cached_property import cached_property
 from pipenv.vendor.packaging.utils import canonicalize_name
 
@@ -410,8 +410,8 @@ class Environment:
                     paths[key] = make_posix(paths[key])
             return paths
         else:
-            vistir.misc.echo(f"Failed to load paths: {c.stderr}", fg="yellow")
-            vistir.misc.echo(f"Output: {c.stdout}", fg="yellow")
+            click.echo(f"Failed to load paths: {c.stderr}", fg="yellow")
+            click.echo(f"Output: {c.stdout}", fg="yellow")
         return None
 
     def get_lib_paths(self):
@@ -439,8 +439,8 @@ class Environment:
                     paths[key] = make_posix(paths[key])
             return paths
         else:
-            vistir.misc.echo(f"Failed to load paths: {c.stderr}", fg="yellow")
-            vistir.misc.echo(f"Output: {c.stdout}", fg="yellow")
+            click.secho(f"Failed to load paths: {c.stderr}", fg="yellow")
+            click.secho(f"Output: {c.stdout}", fg="yellow")
         if not paths:
             if not self.prefix.joinpath("lib").exists():
                 return {}
@@ -499,8 +499,8 @@ class Environment:
                     paths[key] = make_posix(paths[key])
             return paths
         else:
-            vistir.misc.echo(f"Failed to load paths: {c.stderr}", fg="yellow")
-            vistir.misc.echo(f"Output: {c.stdout}", fg="yellow")
+            click.secho(f"Failed to load paths: {c.stderr}", fg="yellow")
+            click.secho(f"Output: {c.stdout}", fg="yellow")
         return None
 
     @cached_property

--- a/pipenv/resolver.py
+++ b/pipenv/resolver.py
@@ -247,7 +247,7 @@ class Entry:
 
         if not marker:
             return None
-        from pipenv.vendor.vistir.compat import Mapping
+        from collections.abc import Mapping
 
         marker_str = None
         if isinstance(marker, Mapping):

--- a/pipenv/shells.py
+++ b/pipenv/shells.py
@@ -5,9 +5,10 @@ import re
 import signal
 import subprocess
 import sys
+from pathlib import Path
 
 from pipenv.vendor import shellingham
-from pipenv.vendor.vistir.compat import Path, get_terminal_size
+from pipenv.vendor.vistir.compat import get_terminal_size
 from pipenv.vendor.vistir.contextmanagers import temp_environ
 
 ShellDetectionFailure = shellingham.ShellDetectionFailure

--- a/pipenv/utils/dependencies.py
+++ b/pipenv/utils/dependencies.py
@@ -131,7 +131,6 @@ def translate_markers(pipfile_entry):
     if not isinstance(pipfile_entry, Mapping):
         raise TypeError("Entry is not a pipfile formatted mapping.")
     from pipenv.vendor.packaging.markers import default_environment
-    from pipenv.vendor.vistir.misc import dedup
 
     allowed_marker_keys = ["markers"] + list(default_environment().keys())
     provided_keys = list(pipfile_entry.keys()) if hasattr(pipfile_entry, "keys") else []
@@ -153,7 +152,8 @@ def translate_markers(pipfile_entry):
         new_pipfile["markers"] = str(
             Marker(
                 " or ".join(
-                    f"{s}" if " and " in s else s for s in sorted(dedup(marker_set))
+                    f"{s}" if " and " in s else s
+                    for s in sorted(dict.fromkeys(marker_set))
                 )
             )
         ).replace('"', "'")

--- a/pipenv/utils/resolver.py
+++ b/pipenv/utils/resolver.py
@@ -943,10 +943,11 @@ def venv_resolve_deps(
     """
 
     import json
+    import tempfile
 
     from pipenv import resolver
     from pipenv._compat import decode_for_output
-    from pipenv.vendor.vistir.compat import NamedTemporaryFile, Path
+    from pipenv.vendor.vistir.compat import Path
 
     results = []
     pipfile_section = "dev-packages" if dev else "packages"
@@ -975,7 +976,9 @@ def venv_resolve_deps(
         cmd.append("--system")
     if dev:
         cmd.append("--dev")
-    target_file = NamedTemporaryFile(prefix="resolver", suffix=".json", delete=False)
+    target_file = tempfile.NamedTemporaryFile(
+        prefix="resolver", suffix=".json", delete=False
+    )
     target_file.close()
     cmd.extend(["--write", make_posix(target_file.name)])
     with temp_environ():


### PR DESCRIPTION
Moving to Python version 3.7+ allows us to remove more usage of vistir.
Eventually we can completely drop it, but I prefer doing this gradually instead of a giant PR.

Also, I am not done yet. Will add 2-3 more commits, and we'll continue chopping this vistir with b[i,y]te size steps.

Pun intended :-)