### PR TITLE
Drop crayons in exceptions.py

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,10 @@
 name: CI
+concurrency:
+  group: >-
+    ${{ github.workflow }}-
+    ${{ github.ref_type }}-
+    ${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
 on:
   push:
     paths-ignore:


### PR DESCRIPTION
As discussed, we should remove crayons in favor of `click.echo` and `click.secho`.
`click` has a large user base and thus a better support across all major platform.
This PR is a test balloon. If it is merged, it allows us to carefully test that no drastic UI changes have
been introduced, without completely removing crayons.

Once we completely removed crayons, it's easy to fix #5057.