### PR TITLE
vendor in requirementslib==1.6.4

### DIFF
--- a/news/5081.vendor.rst
+++ b/news/5081.vendor.rst
@@ -1,0 +1,1 @@
+Vendor in ``requirementslib==1.6.4`` to Fix ``SetuptoolsDeprecationWarning`` ``setuptools.config.read_configuration`` became deprecated.

--- a/pipenv/vendor/requirementslib/__init__.py
+++ b/pipenv/vendor/requirementslib/__init__.py
@@ -10,7 +10,7 @@ from .models.lockfile import Lockfile
 from .models.pipfile import Pipfile
 from .models.requirements import Requirement
 
-__version__ = "1.6.3"
+__version__ = "1.6.4"
 
 
 logger = logging.getLogger(__name__)

--- a/pipenv/vendor/requirementslib/models/setup_info.py
+++ b/pipenv/vendor/requirementslib/models/setup_info.py
@@ -513,7 +513,11 @@ class SetupReader:
 
 
 def setuptools_parse_setup_cfg(path):
-    from setuptools.config import read_configuration
+    try:
+        # v61.0.0 of setuptools deprecated setuptools.config.read_configuration
+        from setuptools.config.setupcfg import read_configuration
+    except ImportError:
+        from setuptools.config import read_configuration
 
     parsed = read_configuration(path)
     results = parsed.get("metadata", {})

--- a/pipenv/vendor/vendor.txt
+++ b/pipenv/vendor/vendor.txt
@@ -30,7 +30,7 @@ python-dateutil==2.8.2
 python-dotenv==0.19.0
 pythonfinder==1.2.10
 requests==2.26.0
-requirementslib==1.6.3
+requirementslib==1.6.4
 shellingham==1.4.0
 six==1.16.0
 termcolor==1.1.0


### PR DESCRIPTION
Fixes deprecation warnings with new `setuptools` versions by vendoring in new `requirementslib` fix.


### The issue

Fixes #5081 

### The fix

How does this pull request fix your problem? Did you consider any alternatives? Why is this the *best* solution, in your opinion?


### The checklist

* [X] Associated issue
* [X] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

