### PR TITLE
revert setuptools required upgrade.

### DIFF
--- a/news/5075.bugfix.rst
+++ b/news/5075.bugfix.rst
@@ -1,0 +1,1 @@
+Revert specifier of ``setuptools`` requirement in ``setup.py`` back to what it was in order to fix ``FileNotFoundError: [Errno 2]`` issue report.

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ if sys.argv[-1] == "publish":
 required = [
     "pip>=22.0.4",
     "certifi",
-    "setuptools>=60.0.0",
+    "setuptools>=36.2.1",
     "virtualenv-clone>=0.2.5",
     "virtualenv",
 ]


### PR DESCRIPTION
Setuptools upgrade in setup.py causing issues for some users.

### The fix

Fixes: https://github.com/pypa/pipenv/issues/5075


### The checklist

* [X] Associated issue
* [X] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.
