### PR TITLE
Make pipenv work with the `venv` install scheme if it is detected

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,6 @@ concurrency:
 on:
   push:
     paths-ignore:
-      - "news/**"
       - "examples/**"
       - "peeps/**"
       - "*.ini"

--- a/news/5096.bugfix.rst
+++ b/news/5096.bugfix.rst
@@ -1,0 +1,2 @@
+Adjust pipenv to work with the newly added ``venv`` install scheme in Python.
+First check if ``venv`` is among the available install schemes, and use it if it is. Otherwise fall back to the ``nt`` or ``posix_prefix`` install schemes as before. This should produce no change for environments where the install schemes were not redefined.

--- a/pipenv/environment.py
+++ b/pipenv/environment.py
@@ -7,7 +7,7 @@ import os
 import site
 import sys
 from pathlib import Path
-from sysconfig import get_paths, get_python_version
+from sysconfig import get_paths, get_python_version, get_scheme_names
 
 import pkg_resources
 
@@ -175,6 +175,15 @@ class Environment:
         return path
 
     @cached_property
+    def install_scheme(self):
+        if "venv" in get_scheme_names():
+            return "venv"
+        elif os.name == "nt":
+            return "nt"
+        else:
+            return "posix_prefix"
+
+    @cached_property
     def base_paths(self):
         # type: () -> Dict[str, str]
         """
@@ -213,9 +222,8 @@ class Environment:
             try:
                 paths = self.get_paths()
             except Exception:
-                install_scheme = "nt" if (os.name == "nt") else "posix_prefix"
                 paths = get_paths(
-                    install_scheme,
+                    self.install_scheme,
                     vars={
                         "base": prefix,
                         "platbase": prefix,
@@ -236,9 +244,8 @@ class Environment:
                     paths.update(self.get_lib_paths())
                     paths["scripts"] = self.script_basedir
         if not paths:
-            install_scheme = "nt" if (os.name == "nt") else "posix_prefix"
             paths = get_paths(
-                install_scheme,
+                self.install_scheme,
                 vars={
                     "base": prefix,
                     "platbase": prefix,
@@ -266,9 +273,8 @@ class Environment:
         # type: () -> str
         """Path to the environment scripts dir"""
         prefix = make_posix(self.prefix.as_posix())
-        install_scheme = "nt" if (os.name == "nt") else "posix_prefix"
         paths = get_paths(
-            install_scheme,
+            self.install_scheme,
             vars={
                 "base": prefix,
                 "platbase": prefix,


### PR DESCRIPTION
### The issue

Python 3.10 introduced sysconfig._get_preferred_schemes[1], a mechanism to allow downstream distributors to overwrite the default install scheme.
This is done to support downstream modifications where distributors change the installation layout (eg. different site-packages directory). So, distributors will change the default scheme to one that correctly represents their layout.

This presents an issue for projects/people that need to bootstrap virtual environments, like virtualenv (see [2]) and pipenv too. As distributors might now be customizing the default install scheme, there is no guarantee that the information returned by sysconfig.get_default_scheme/get_paths is correct for the virtual environment, the only guarantee we have is that it is correct for the *current* environment. When bootstrapping a virtual environment, we need to know its layout, so that we can place the files in the correct locations.

[1] https://docs.python.org/3/library/sysconfig.html#sysconfig._get_preferred_schemes
[2] https://github.com/pypa/virtualenv/issues/2208

### The fix

To solve this issue, CPython upstream added in issue45413 [3] a new "venv" install scheme, for virtual environments. And this new install scheme has already been implemented in virtualenv [4] and the Python `build` frontend [5]. This PR is similar, it first checks if “venv” is among the available install schemes and uses it if it is. Otherwise it fallbacks to the standard `nt` or `posix_prefix` install schemes as before. This should produce no change for environments where default schemes were not changed.

[3] https://bugs.python.org/issue45413
[4] https://github.com/pypa/virtualenv/pull/2209
[5] https://github.com/pypa/build/pull/434

I’d like to deploy this fix in Fedora [6] and test it there, because Fedora changes the default install schemes and therefore pipenv fails there. But first I wanted to ask for feedback, if you see any obvious issues with the change. If not we’ll test it downstream, and then I’d like to ask you to merge it here as well.

[6] https://src.fedoraproject.org/rpms/pipenv/pull-request/53


### The checklist

* [x] Associated issue - #5109
* [x] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.
