### PR TITLE
Fix usage of deprecated `license_file`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 long_description = file: README.md
 license = MIT
-license_file = LICENSE
+license_files = LICENSE
 
 [flake8]
 extend-exclude =


### PR DESCRIPTION
Fix #5136.

This is an easy one. Found while installing pipenv newest ebuild on gentoo.