### PR TITLE
Fix for #5134

### DIFF
--- a/news/5134.bugfix.rst
+++ b/news/5134.bugfix.rst
@@ -1,0 +1,1 @@
+Stopped expanding environment variables when using ``pipenv requirements``

--- a/pipenv/cli/command.py
+++ b/pipenv/cli/command.py
@@ -768,7 +768,7 @@ def requirements(state, dev=False, dev_only=False, hash=False):
 
     from pipenv.utils.dependencies import convert_deps_to_pip
 
-    lockfile = state.project.lockfile_content
+    lockfile = state.project.load_lockfile(expand_env_vars=False)
 
     for i, package_index in enumerate(lockfile["_meta"]["sources"]):
         prefix = "-i" if i == 0 else "--extra-index-url"

--- a/tests/integration/test_requirements.py
+++ b/tests/integration/test_requirements.py
@@ -1,13 +1,16 @@
 import json
+import os
 import pytest
+
+from pipenv.utils.shell import temp_environ
 
 
 @pytest.mark.requirements
 def test_requirements_generates_requirements_from_lockfile(PipenvInstance):
     with PipenvInstance(chdir=True) as p:
-        packages = ('requests', '2.14.0')
-        dev_packages = ('flask', '0.12.2')
-        with open(p.pipfile_path, 'w') as f:
+        packages = ("requests", "2.14.0")
+        dev_packages = ("flask", "0.12.2")
+        with open(p.pipfile_path, "w") as f:
             contents = f"""
             [packages]
             {packages[0]}= "=={packages[1]}"
@@ -15,36 +18,38 @@ def test_requirements_generates_requirements_from_lockfile(PipenvInstance):
             {dev_packages[0]}= "=={dev_packages[1]}"
             """.strip()
             f.write(contents)
-        p.pipenv('lock')
-        c = p.pipenv('requirements')
+        p.pipenv("lock")
+        c = p.pipenv("requirements")
         assert c.returncode == 0
-        assert f'{packages[0]}=={packages[1]}' in c.stdout
-        assert f'{dev_packages[0]}=={dev_packages[1]}' not in c.stdout
+        assert f"{packages[0]}=={packages[1]}" in c.stdout
+        assert f"{dev_packages[0]}=={dev_packages[1]}" not in c.stdout
 
-        d = p.pipenv('requirements --dev')
+        d = p.pipenv("requirements --dev")
         assert d.returncode == 0
-        assert f'{packages[0]}=={packages[1]}' in d.stdout
-        assert f'{dev_packages[0]}=={dev_packages[1]}' in d.stdout
+        assert f"{packages[0]}=={packages[1]}" in d.stdout
+        assert f"{dev_packages[0]}=={dev_packages[1]}" in d.stdout
 
-        e = p.pipenv('requirements --dev-only')
+        e = p.pipenv("requirements --dev-only")
         assert e.returncode == 0
-        assert f'{packages[0]}=={packages[1]}' not in e.stdout
-        assert f'{dev_packages[0]}=={dev_packages[1]}' in e.stdout
+        assert f"{packages[0]}=={packages[1]}" not in e.stdout
+        assert f"{dev_packages[0]}=={dev_packages[1]}" in e.stdout
 
-        e = p.pipenv('requirements --hash')
+        e = p.pipenv("requirements --hash")
         assert e.returncode == 0
-        assert f'{packages[0]}=={packages[1]}' in e.stdout
-        for value in p.lockfile['default'].values():
-            for hash in value['hashes']:
-                assert f' --hash={hash}' in e.stdout
+        assert f"{packages[0]}=={packages[1]}" in e.stdout
+        for value in p.lockfile["default"].values():
+            for hash in value["hashes"]:
+                assert f" --hash={hash}" in e.stdout
 
 
 @pytest.mark.requirements
-def test_requirements_generates_requirements_from_lockfile_multiple_sources(PipenvInstance):
+def test_requirements_generates_requirements_from_lockfile_multiple_sources(
+    PipenvInstance,
+):
     with PipenvInstance(chdir=True) as p:
-        packages = ('requests', '2.14.0')
-        dev_packages = ('flask', '0.12.2')
-        with open(p.pipfile_path, 'w') as f:
+        packages = ("requests", "2.14.0")
+        dev_packages = ("flask", "0.12.2")
+        with open(p.pipfile_path, "w") as f:
             contents = f"""
             [[source]]
             name = "pypi"
@@ -60,34 +65,68 @@ def test_requirements_generates_requirements_from_lockfile_multiple_sources(Pipe
             {dev_packages[0]}= "=={dev_packages[1]}"
             """.strip()
             f.write(contents)
-        l = p.pipenv('lock')
+        l = p.pipenv("lock")
         assert l.returncode == 0
-        c = p.pipenv('requirements')
+        c = p.pipenv("requirements")
         assert c.returncode == 0
 
-        assert '-i https://pypi.org/simple' in c.stdout
-        assert '--extra-index-url https://some_other_source.org' in c.stdout
+        assert "-i https://pypi.org/simple" in c.stdout
+        assert "--extra-index-url https://some_other_source.org" in c.stdout
+
 
 @pytest.mark.requirements
 def test_requirements_with_git_requirements(PipenvInstance):
-    req_name, req_hash = 'example-repo', 'cc858e89f19bc0dbd70983f86b811ab625dc9292'
+    req_name, req_hash = "example-repo", "cc858e89f19bc0dbd70983f86b811ab625dc9292"
     lockfile = {
         "_meta": {"sources": []},
         "default": {
             req_name: {
                 "editable": True,
-                "git": F"ssh://git@bitbucket.org/code/{req_name}.git",
-                "ref": req_hash
+                "git": f"ssh://git@bitbucket.org/code/{req_name}.git",
+                "ref": req_hash,
             }
         },
-        "develop": {}
+        "develop": {},
     }
 
     with PipenvInstance(chdir=True) as p:
-        with open(p.lockfile_path, 'w') as f:
+        with open(p.lockfile_path, "w") as f:
             json.dump(lockfile, f)
 
-        c = p.pipenv('requirements')
+        c = p.pipenv("requirements")
         assert c.returncode == 0
         assert req_name in c.stdout
         assert req_hash in c.stdout
+
+
+@pytest.mark.requirements
+def test_requirements_generates_requirements_from_lockfile_without_env_var_expansion(
+    PipenvInstance,
+):
+    lockfile = {
+        "_meta": {
+            "sources": [
+                {
+                    "name": "private_source",
+                    "url": "https://${redacted_user}:${redacted_pwd}@private_source.org",
+                    "verify_ssl": True,
+                }
+            ]
+        },
+        "default": {},
+    }
+
+    with PipenvInstance(chdir=True) as p:
+        with open(p.lockfile_path, "w") as f:
+            json.dump(lockfile, f)
+
+        with temp_environ():
+            os.environ['redacted_user'] = "example_user"
+            os.environ['redacted_pwd'] = "example_pwd"
+            c = p.pipenv("requirements")
+            assert c.returncode == 0
+
+            assert (
+                "-i https://${redacted_user}:${redacted_pwd}@private_source.org"
+                in c.stdout
+            )

--- a/tests/integration/test_requirements.py
+++ b/tests/integration/test_requirements.py
@@ -8,9 +8,9 @@ from pipenv.utils.shell import temp_environ
 @pytest.mark.requirements
 def test_requirements_generates_requirements_from_lockfile(PipenvInstance):
     with PipenvInstance(chdir=True) as p:
-        packages = ("requests", "2.14.0")
-        dev_packages = ("flask", "0.12.2")
-        with open(p.pipfile_path, "w") as f:
+        packages = ('requests', '2.14.0')
+        dev_packages = ('flask', '0.12.2')
+        with open(p.pipfile_path, 'w') as f:
             contents = f"""
             [packages]
             {packages[0]}= "=={packages[1]}"
@@ -18,38 +18,36 @@ def test_requirements_generates_requirements_from_lockfile(PipenvInstance):
             {dev_packages[0]}= "=={dev_packages[1]}"
             """.strip()
             f.write(contents)
-        p.pipenv("lock")
-        c = p.pipenv("requirements")
+        p.pipenv('lock')
+        c = p.pipenv('requirements')
         assert c.returncode == 0
-        assert f"{packages[0]}=={packages[1]}" in c.stdout
-        assert f"{dev_packages[0]}=={dev_packages[1]}" not in c.stdout
+        assert f'{packages[0]}=={packages[1]}' in c.stdout
+        assert f'{dev_packages[0]}=={dev_packages[1]}' not in c.stdout
 
-        d = p.pipenv("requirements --dev")
+        d = p.pipenv('requirements --dev')
         assert d.returncode == 0
-        assert f"{packages[0]}=={packages[1]}" in d.stdout
-        assert f"{dev_packages[0]}=={dev_packages[1]}" in d.stdout
+        assert f'{packages[0]}=={packages[1]}' in d.stdout
+        assert f'{dev_packages[0]}=={dev_packages[1]}' in d.stdout
 
-        e = p.pipenv("requirements --dev-only")
+        e = p.pipenv('requirements --dev-only')
         assert e.returncode == 0
-        assert f"{packages[0]}=={packages[1]}" not in e.stdout
-        assert f"{dev_packages[0]}=={dev_packages[1]}" in e.stdout
+        assert f'{packages[0]}=={packages[1]}' not in e.stdout
+        assert f'{dev_packages[0]}=={dev_packages[1]}' in e.stdout
 
-        e = p.pipenv("requirements --hash")
+        e = p.pipenv('requirements --hash')
         assert e.returncode == 0
-        assert f"{packages[0]}=={packages[1]}" in e.stdout
-        for value in p.lockfile["default"].values():
-            for hash in value["hashes"]:
-                assert f" --hash={hash}" in e.stdout
+        assert f'{packages[0]}=={packages[1]}' in e.stdout
+        for value in p.lockfile['default'].values():
+            for hash in value['hashes']:
+                assert f' --hash={hash}' in e.stdout
 
 
 @pytest.mark.requirements
-def test_requirements_generates_requirements_from_lockfile_multiple_sources(
-    PipenvInstance,
-):
+def test_requirements_generates_requirements_from_lockfile_multiple_sources(PipenvInstance):
     with PipenvInstance(chdir=True) as p:
-        packages = ("requests", "2.14.0")
-        dev_packages = ("flask", "0.12.2")
-        with open(p.pipfile_path, "w") as f:
+        packages = ('requests', '2.14.0')
+        dev_packages = ('flask', '0.12.2')
+        with open(p.pipfile_path, 'w') as f:
             contents = f"""
             [[source]]
             name = "pypi"
@@ -65,35 +63,34 @@ def test_requirements_generates_requirements_from_lockfile_multiple_sources(
             {dev_packages[0]}= "=={dev_packages[1]}"
             """.strip()
             f.write(contents)
-        l = p.pipenv("lock")
+        l = p.pipenv('lock')
         assert l.returncode == 0
-        c = p.pipenv("requirements")
+        c = p.pipenv('requirements')
         assert c.returncode == 0
 
-        assert "-i https://pypi.org/simple" in c.stdout
-        assert "--extra-index-url https://some_other_source.org" in c.stdout
-
+        assert '-i https://pypi.org/simple' in c.stdout
+        assert '--extra-index-url https://some_other_source.org' in c.stdout
 
 @pytest.mark.requirements
 def test_requirements_with_git_requirements(PipenvInstance):
-    req_name, req_hash = "example-repo", "cc858e89f19bc0dbd70983f86b811ab625dc9292"
+    req_name, req_hash = 'example-repo', 'cc858e89f19bc0dbd70983f86b811ab625dc9292'
     lockfile = {
         "_meta": {"sources": []},
         "default": {
             req_name: {
                 "editable": True,
-                "git": f"ssh://git@bitbucket.org/code/{req_name}.git",
-                "ref": req_hash,
+                "git": F"ssh://git@bitbucket.org/code/{req_name}.git",
+                "ref": req_hash
             }
         },
-        "develop": {},
+        "develop": {}
     }
 
     with PipenvInstance(chdir=True) as p:
-        with open(p.lockfile_path, "w") as f:
+        with open(p.lockfile_path, 'w') as f:
             json.dump(lockfile, f)
 
-        c = p.pipenv("requirements")
+        c = p.pipenv('requirements')
         assert c.returncode == 0
         assert req_name in c.stdout
         assert req_hash in c.stdout


### PR DESCRIPTION
Note: This is my first time ever contributing to an open source project. I'm super grateful for the work all of you are putting into the project. Keep it up!

### The issue

According to issue #5134, environment variables are expanded when generating a `requirements.txt` file with `pipenv requirements`. This leads to credentials being leaked. 

### The fix

The culprit can be found [here](https://github.com/pypa/pipenv/blob/b923d577a1e7dc5ee0b94a5b75e54bcac9dea106/pipenv/cli/command.py#L771).
How I understand the code, when calling `pipenv requirements` the lockfile is loaded using the `lockfile_content` property of the `project` object. This contains the lockfile as it used during runtime.
However, when generating a `requirements.txt` file this is not what we want, since environment variables are expanded.
Luckily, the lockfile can be loaded without expanding environment variables.
`def load_lockfile(self, expand_env_vars=True):`
https://github.com/pypa/pipenv/blob/main/pipenv/project.py#L974

This is what I have done.


### The checklist

* [x] Associated issue
* [x] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

