### PR TITLE
Allow more --system operations in pipenv

### DIFF
--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -251,13 +251,6 @@ def ensure_pipfile(project, validate=True, skip_requirements=False, system=False
         else None
     )
     if project.pipfile_is_empty:
-        # Show an error message and exit if system is passed and no pipfile exists
-        if system and not project.s.PIPENV_VIRTUALENV:
-            raise exceptions.PipenvOptionsError(
-                "--system",
-                "--system is intended to be used for pre-existing Pipfile "
-                "installation, not installation of specific packages. Aborting.",
-            )
         # If there's a requirements file, but no Pipfile...
         if project.requirements_exists and not skip_requirements:
             requirements_dir_path = os.path.dirname(project.requirements_location)

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -248,7 +248,7 @@ def ensure_pipfile(project, validate=True, skip_requirements=False, system=False
     python = (
         project._which("python")
         if not (project.s.USING_DEFAULT_PYTHON or system)
-        else None
+        else project._which("python", allow_global=True)
     )
     if project.pipfile_is_empty:
         # If there's a requirements file, but no Pipfile...

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -1304,30 +1304,20 @@ def do_init(
                 )
     # Write out the lockfile if it doesn't exist.
     if not project.lockfile_exists and not skip_lock:
-        # Unless we're in a virtualenv not managed by pipenv, abort if we're
-        # using the system's python.
-        if (system or allow_global) and not (project.s.PIPENV_VIRTUALENV):
-            raise exceptions.PipenvOptionsError(
-                "--system",
-                "--system is intended to be used for Pipfile installation, "
-                "not installation of specific packages. Aborting.\n"
-                "See also: --deploy flag.",
-            )
-        else:
-            click.echo(
-                crayons.normal(
-                    fix_utf8("Pipfile.lock not found, creating..."), bold=True
-                ),
-                err=True,
-            )
-            do_lock(
-                project,
-                system=system,
-                pre=pre,
-                keep_outdated=keep_outdated,
-                write=True,
-                pypi_mirror=pypi_mirror,
-            )
+        click.echo(
+            crayons.normal(
+                fix_utf8("Pipfile.lock not found, creating..."), bold=True
+            ),
+            err=True,
+        )
+        do_lock(
+            project,
+            system=system,
+            pre=pre,
+            keep_outdated=keep_outdated,
+            write=True,
+            pypi_mirror=pypi_mirror,
+        )
     do_install_dependencies(
         project,
         dev=dev,

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -1305,9 +1305,7 @@ def do_init(
     # Write out the lockfile if it doesn't exist.
     if not project.lockfile_exists and not skip_lock:
         click.echo(
-            crayons.normal(
-                fix_utf8("Pipfile.lock not found, creating..."), bold=True
-            ),
+            crayons.normal(fix_utf8("Pipfile.lock not found, creating..."), bold=True),
             err=True,
         )
         do_lock(

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -1967,10 +1967,6 @@ def do_install(
     if not keep_outdated:
         keep_outdated = project.settings.get("keep_outdated")
     remote = requirementstxt and is_valid_url(requirementstxt)
-    # Warn and exit if --system is used without a pipfile.
-    if (system and package_args) and not project.s.PIPENV_VIRTUALENV:
-        raise exceptions.SystemUsageError
-    # Automatically use an activated virtualenv.
     if project.s.PIPENV_USE_SYSTEM:
         system = True
     if system:


### PR DESCRIPTION
### The issue

We get a lot of issue reports about how pipenv cannot be used at the system level, which is actually quite common in Docker containers for people to want to bypass the virtualenv construct entirely.  

Fix #5052 
Fix #5115

### The fix

I am still prototyping this and I suspect tests will need adjustment, but this allowed me to do `pipenv install requests --system`
which generated this Pipfile:
```
[[source]]
url = "https://pypi.org/simple"
verify_ssl = true
name = "pypi"

[packages]
requests = "*"

[dev-packages]

[requires]
python_version = "3.9"
```
And Pipfile.lock:
```
{
    "_meta": {
        "hash": {
            "sha256": "b8c2e1580c53e383cfe4254c1f16560b855d984fde8b2beb3bf6ee8fc2fe5a22"
        },
        "pipfile-spec": 6,
        "requires": {
            "python_version": "3.9"
        },
        "sources": [
            {
                "name": "pypi",
                "url": "https://pypi.org/simple",
                "verify_ssl": true
            }
        ]
    },
    "default": {
        "certifi": {
            "hashes": [
                "sha256:84c85a9078b11105f04f3036a9482ae10e4621616db313fe045dd24743a0820d",
                "sha256:fe86415d55e84719d75f8b69414f6438ac3547d2078ab91b67e779ef69378412"
            ],
            "markers": "python_version >= '3.6'",
            "version": "==2022.6.15"
        },
        "charset-normalizer": {
            "hashes": [
                "sha256:2857e29ff0d34db842cd7ca3230549d1a697f96ee6d3fb071cfa6c7393832597",
                "sha256:6881edbebdb17b39b4eaaa821b438bf6eddffb4468cf344f09f89def34a8b1df"
            ],
            "markers": "python_version >= '3.5'",
            "version": "==2.0.12"
        },
        "idna": {
            "hashes": [
                "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff",
                "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"
            ],
            "markers": "python_version >= '3.5'",
            "version": "==3.3"
        },
        "requests": {
            "hashes": [
                "sha256:bc7861137fbce630f17b03d3ad02ad0bf978c844f3536d0edda6499dafce2b6f",
                "sha256:d568723a7ebd25875d8d1eaf5dfa068cd2fc8194b2e483d7b1f7c81918dbec6b"
            ],
            "index": "pypi",
            "version": "==2.28.0"
        },
        "urllib3": {
            "hashes": [
                "sha256:44ece4d53fb1706f667c9bd1c648f5469a2ec925fcf3a776667042d645472c14",
                "sha256:aabaf16477806a5e1dd19aa41f8c2b7950dd3c746362d7e3223dbe6de6ac448e"
            ],
            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
            "version": "==1.26.9"
        }
    },
    "develop": {}
}
```

### The checklist
* [X] Associated issue
* [ ] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.
