### PR TITLE
Reenable these tests again on the Windows CI.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,6 +8,7 @@ concurrency:
 on:
   push:
     paths-ignore:
+      - "news/**"
       - "examples/**"
       - "peeps/**"
       - "*.ini"

--- a/news/5064.bugfix.rst
+++ b/news/5064.bugfix.rst
@@ -1,0 +1,1 @@
+Re-enabled three installs tests again on the Windows CI as recent refactor work has fixed them.

--- a/tests/integration/test_install_uri.py
+++ b/tests/integration/test_install_uri.py
@@ -126,7 +126,6 @@ def test_local_vcs_urls_work(PipenvInstance, tmpdir):
 @pytest.mark.urls
 @pytest.mark.install
 @pytest.mark.needs_internet
-@pytest.mark.skip_windows  # FIXME: https://github.com/pypa/pipenv/issues/5064
 def test_editable_vcs_install(PipenvInstance_NoPyPI):
     with PipenvInstance_NoPyPI(chdir=True) as p:
         c = p.pipenv(
@@ -147,7 +146,6 @@ def test_editable_vcs_install(PipenvInstance_NoPyPI):
 @pytest.mark.urls
 @pytest.mark.install
 @pytest.mark.needs_internet
-@pytest.mark.skip_windows  # FIXME: https://github.com/pypa/pipenv/issues/5064
 def test_install_editable_git_tag(PipenvInstance_NoPyPI):
     # This uses the real PyPI since we need Internet to access the Git
     # dependency anyway.
@@ -242,7 +240,6 @@ def test_install_local_vcs_not_in_lockfile(PipenvInstance):
 @pytest.mark.urls
 @pytest.mark.install
 @pytest.mark.needs_internet
-@pytest.mark.skip_windows  # FIXME: https://github.com/pypa/pipenv/issues/5064
 def test_get_vcs_refs(PipenvInstance_NoPyPI):
     with PipenvInstance_NoPyPI(chdir=True) as p:
         c = p.pipenv(


### PR DESCRIPTION
Thank you for contributing to Pipenv!


### The issue
Fixes #5064

Compare the successful test run of https://github.com/pypa/pipenv/pull/5162
with this branch which does nothing except try to enable those failing tests again.

Outcome:  Would appear that we fixed something in the last several months that allow those skipped Windows tests to pass in the CI again.

### The checklist

* [X] Associated issue
* [X] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

