### PR TITLE
Remove tests that are old and permanently skipped

### DIFF
--- a/news/5165.removal.rst
+++ b/news/5165.removal.rst
@@ -1,0 +1,1 @@
+Remove tests that have been for a while been marked skipped and are no longer relevant.

--- a/tests/integration/test_install_basic.py
+++ b/tests/integration/test_install_basic.py
@@ -31,7 +31,6 @@ def test_basic_setup(PipenvInstance):
 @flaky
 @pytest.mark.basic
 @pytest.mark.install
-@pytest.mark.skip_osx
 def test_basic_install(PipenvInstance):
     with PipenvInstance() as p:
         c = p.pipenv("install requests")
@@ -81,18 +80,6 @@ def test_bad_mirror_install(PipenvInstance):
         os.environ.pop("PIPENV_TEST_INDEX", None)
         c = p.pipenv("install requests --pypi-mirror https://pypi.example.org")
         assert c.returncode != 0
-
-
-@pytest.mark.lock
-@pytest.mark.complex
-@pytest.mark.skip(reason="Does not work unless you can explicitly install into py2")
-def test_complex_lock(PipenvInstance):
-    with PipenvInstance() as p:
-        c = p.pipenv("install apscheduler")
-        assert c.returncode == 0
-        assert "apscheduler" in p.pipfile["packages"]
-        assert "funcsigs" in p.lockfile["default"]
-        assert "futures" in p.lockfile["default"]
 
 
 @flaky
@@ -313,7 +300,6 @@ def test_requirements_to_pipfile(PipenvInstance, pypi):
 
 @pytest.mark.basic
 @pytest.mark.install
-@pytest.mark.skip_osx
 @pytest.mark.requirements
 def test_skip_requirements_when_pipfile(PipenvInstance):
     """Ensure requirements.txt is NOT imported when

--- a/tests/integration/test_install_twists.py
+++ b/tests/integration/test_install_twists.py
@@ -115,21 +115,6 @@ setup(
             )
 
 
-@pytest.mark.e
-@pytest.mark.local
-@pytest.mark.install
-def test_e_dot(PipenvInstance, pip_src_dir):
-    with PipenvInstance() as p:
-        path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        c = p.pipenv(f"install -e '{path}' --dev")
-
-        assert c.returncode == 0
-
-        key = [k for k in p.pipfile["dev-packages"].keys()][0]
-        assert "path" in p.pipfile["dev-packages"][key]
-        assert "requests" in p.lockfile["develop"]
-
-
 @pytest.mark.install
 @pytest.mark.multiprocessing
 @flaky

--- a/tests/integration/test_install_twists.py
+++ b/tests/integration/test_install_twists.py
@@ -118,7 +118,6 @@ setup(
 @pytest.mark.e
 @pytest.mark.local
 @pytest.mark.install
-@pytest.mark.skip(reason="this doesn't work on windows")
 def test_e_dot(PipenvInstance, pip_src_dir):
     with PipenvInstance() as p:
         path = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -129,6 +128,7 @@ def test_e_dot(PipenvInstance, pip_src_dir):
         key = [k for k in p.pipfile["dev-packages"].keys()][0]
         assert "path" in p.pipfile["dev-packages"][key]
         assert "requests" in p.lockfile["develop"]
+
 
 @pytest.mark.install
 @pytest.mark.multiprocessing

--- a/tests/integration/test_lock.py
+++ b/tests/integration/test_lock.py
@@ -311,31 +311,6 @@ requests = {version = "*", extras = ["socks"]}
         assert "extra == 'socks'" not in c.stdout.strip()
 
 
-@pytest.mark.lock
-@pytest.mark.extras
-@pytest.mark.complex
-@pytest.mark.needs_internet
-@pytest.mark.skip(reason='Needs numpy to be mocked')
-def test_complex_lock_deep_extras(PipenvInstance):
-    # records[pandas] requires tablib[pandas] which requires pandas.
-    # This uses the real PyPI; Pandas has too many requirements to mock.
-
-    with PipenvInstance() as p:
-        with open(p.pipfile_path, 'w') as f:
-            contents = """
-[packages]
-records = {extras = ["pandas"], version = "==0.5.2"}
-            """.strip()
-            f.write(contents)
-
-        c = p.pipenv('install')
-        assert c.returncode == 0
-        c = p.pipenv('lock')
-        assert c.returncode == 0
-        assert 'tablib' in p.lockfile['default']
-        assert 'pandas' in p.lockfile['default']
-
-
 @pytest.mark.index
 @pytest.mark.install  # private indexes need to be uncached for resolution
 @pytest.mark.skip_lock
@@ -605,25 +580,6 @@ requests = {git = "%s", editable = true, markers = "python_version >= '2.6'"}
         assert 'certifi' in p.lockfile['default']
         c = p.pipenv('install')
         assert c.returncode == 0
-
-
-@pytest.mark.lock
-@pytest.mark.skip(reason="This doesn't work for some reason.")
-def test_lock_respecting_python_version(PipenvInstance):
-    with PipenvInstance(chdir=True) as p:
-        with open(p.pipfile_path, 'w') as f:
-            f.write("""
-[packages]
-django = "*"
-            """.strip())
-        c = p.pipenv('install ')
-        assert c.returncode == 0
-        c = p.pipenv('run python --version')
-        assert c.returncode == 0
-        py_version = c.stderr.splitlines()[-1].strip().split()[-1]
-        django_version = '==2.0.6' if py_version.startswith('3') else '==1.11.13'
-        assert py_version == '2.7.14'
-        assert p.lockfile['default']['django']['version'] == django_version
 
 
 @pytest.mark.lock

--- a/tests/integration/test_pipenv.py
+++ b/tests/integration/test_pipenv.py
@@ -12,17 +12,6 @@ from pipenv.utils.processes import subprocess_run
 from pipenv.utils.shell import temp_environ
 
 
-@pytest.mark.code
-@pytest.mark.install
-@pytest.mark.skip(reason='non deterministic')
-def test_code_import_manual(PipenvInstance):
-    with PipenvInstance(chdir=True) as p:
-        with open('t.py', 'w') as f:
-            f.write('import requests')
-        p.pipenv('install -c .')
-        assert 'requests' in p.pipfile['packages']
-
-
 @pytest.mark.lock
 @pytest.mark.deploy
 def test_deploy_works(PipenvInstance):


### PR DESCRIPTION
### The issue

Remove tests that are old and permanently skipped, remove OS skips that seem to not make sense.


### The checklist

* [ ] Associated issue
* [X] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.
