### PR TITLE
Use distribution to find path of installed pipenv.

### DIFF
--- a/pipenv/utils/resolver.py
+++ b/pipenv/utils/resolver.py
@@ -7,6 +7,7 @@ import subprocess
 import sys
 import warnings
 from functools import lru_cache
+from importlib.metadata import PackageNotFoundError, distribution
 
 import crayons
 from click import echo as click_echo
@@ -37,7 +38,6 @@ if environments.MYPY_RUNNING:
     from typing import Any, Dict, List, Optional, Set, Tuple, Union  # noqa
 
     from pipenv.project import Project  # noqa
-    from pipenv.vendor.requirementslib import Pipfile, Requirement  # noqa
     from pipenv.vendor.requirementslib.models.requirements import Line  # noqa
 
 
@@ -1124,11 +1124,7 @@ def resolve_deps(
 
 @lru_cache()
 def get_pipenv_sitedir() -> Optional[str]:
-    import pkg_resources
-
-    site_dir = next(
-        iter(d for d in pkg_resources.working_set if d.key.lower() == "pipenv"), None
-    )
-    if site_dir is not None:
-        return site_dir.location
-    return None
+    try:
+        return str(distribution("pipenv")._path.cwd())
+    except PackageNotFoundError:
+        return None


### PR DESCRIPTION
### The issue

Now that we dropped support for python 3.6 we should migrate away from `pkg_resoruces` as

>Use of pkg_resources is discouraged in favor of [importlib.resources](https://docs.python.org/3/library/importlib.html#module-importlib.resources), [importlib.metadata](https://docs.python.org/3/library/importlib.metadata.html)

### The fix

Start chipping away at our direct `pkg_resoruces` usages.


### The checklist

* [ ] Associated issue
* [ ] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

<!--
### If this is a patch to the `vendor` directory...

Please try to refrain from submitting patches directly to `vendor` or `patched`, but raise your issue to the upstream project instead, and inform Pipenv to upgrade when the upstream project accepts the fix.

A pull request to upgrade vendor packages is strongly discouraged, unless there is a very good reason (e.g. you need to test Pipenv’s integration to a new vendor feature). Pipenv audits and performs vendor upgrades regularly, generally before a new release is about to drop.

If your patch is not or cannot be accepted by upstream, but is essential to Pipenv (make sure to discuss this with maintainers!), please remember to attach a patch file in `tasks/vendoring/patched`, so this divergence from upstream can be recorded and replayed afterwards.
-->
