### PR TITLE
minimum set of changes for using internal vendor pip.

### DIFF
--- a/pipenv/patched/notpip/_internal/build_env.py
+++ b/pipenv/patched/notpip/_internal/build_env.py
@@ -17,7 +17,7 @@ from pipenv.patched.notpip._vendor.certifi import where
 from pipenv.patched.notpip._vendor.packaging.requirements import Requirement
 from pipenv.patched.notpip._vendor.packaging.version import Version
 
-from pip import __file__ as pip_location
+from pipenv.patched.notpip import __file__ as pip_location
 from pipenv.patched.notpip._internal.cli.spinners import open_spinner
 from pipenv.patched.notpip._internal.locations import get_platlib, get_prefixed_libs, get_purelib
 from pipenv.patched.notpip._internal.metadata import get_default_environment, get_environment

--- a/pipenv/vendor/vistir/misc.py
+++ b/pipenv/vendor/vistir/misc.py
@@ -157,11 +157,11 @@ def _spawn_subprocess(
     combine_stderr=True,  # type: bool
 ):
     # type: (...) -> subprocess.Popen
-    from distutils.spawn import find_executable
+    from shutil import which
 
     if not env:
         env = os.environ.copy()
-    command = find_executable(script.command)
+    command = which(script.command)
     options = {
         "env": env,
         "universal_newlines": True,

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,6 @@ if sys.argv[-1] == "publish":
     sys.exit()
 
 required = [
-    "pip>=22.0.4",
     "certifi",
     "setuptools>=36.2.1",
     "virtualenv-clone>=0.2.5",

--- a/tests/integration/test_lock.py
+++ b/tests/integration/test_lock.py
@@ -282,11 +282,11 @@ maya = "*"
             """.strip()
             f.write(contents)
 
-        c = p.pipenv('lock --verbose')
-        assert c.returncode == 0
+            c = p.pipenv('lock --verbose')
+            assert c.returncode == 0
 
-        c = p.pipenv('install')
-        assert c.returncode == 0
+            c = p.pipenv('install')
+            assert c.returncode == 0
 
 
 @pytest.mark.lock


### PR DESCRIPTION
Thank you for contributing to Pipenv!


### The issue

I noticed this through a number of issue reports that sometimes a user's local pip conflicts with pipenv's expected behavior.   To me, it does not make sense that we do not always use our patched vendored pip to install certain types of packages.   With this change it should be possible for a user to only install `pipenv` and not have pip installed at all.   There is nothing wrong with having both installed, but why have `pipenv` require it and rely on it when we go to the work to patch an vendor in the latest and greatest `pip`?

I will rename `notpip` to `pip` in a follow-up PR.