### PR TITLE
5192 correct spacing for PIPENV_COLORBLIND warning

### DIFF
--- a/pipenv/cli/command.py
+++ b/pipenv/cli/command.py
@@ -95,8 +95,8 @@ def cli(
 
     if "PIPENV_COLORBLIND" in os.environ:
         echo(
-            "PIPENV_COLORBLIND is deprecated, use NO_COLOR instead"
-            "Per https://no-color.org/",
+            "PIPENV_COLORBLIND is deprecated, use NO_COLOR"
+            " per https://no-color.org/ instead",
             err=True,
         )
 


### PR DESCRIPTION
### The issue
https://github.com/pypa/pipenv/issues/5192
### The fix
I added a space.  I also changed the order of words a bit to make it feel smoother.
