### PR TITLE
We need to be able to modify vistir to fix this bug, and we should work towards its complete removal.

### DIFF
--- a/news/5197.vendor.rst
+++ b/news/5197.vendor.rst
@@ -1,0 +1,1 @@
+Fix ``distutils`` usage in our copy of ``vistir`` and note the library is deprecated and marked for removal.

--- a/pipenv/vendor/vendor.txt
+++ b/pipenv/vendor/vendor.txt
@@ -31,7 +31,7 @@ toml==0.10.2
 tomli==1.1.0
 tomlkit==0.9.2
 urllib3==1.26.6
-vistir==0.5.2
+vistir==0.5.2  # Deprecated: our copy is modified to fix bugs
 wheel==0.36.2
 yaspin==2.0.0
 zipp==3.5.0

--- a/pipenv/vendor/vistir/misc.py
+++ b/pipenv/vendor/vistir/misc.py
@@ -157,11 +157,11 @@ def _spawn_subprocess(
     combine_stderr=True,  # type: bool
 ):
     # type: (...) -> subprocess.Popen
-    from distutils.spawn import find_executable
+    from shutil import which
 
     if not env:
         env = os.environ.copy()
-    command = find_executable(script.command)
+    command = which(script.command)
     options = {
         "env": env,
         "universal_newlines": True,


### PR DESCRIPTION
### The issue

Vistir has broken distutil code and probably other bugs.  Fix the known bug here, and note in the vendoring that its deprecated and our copy has diverged from the parent pypi `vistir` -- our goal is complete removal of this library.   An effort will be made to begin converting usages in `requirementslib` since that will be the biggest blocker to completely removing it from `pipenv`.

