### PR TITLE
Remove old way of generting requirements.

### DIFF
--- a/news/5200.removal.rst
+++ b/news/5200.removal.rst
@@ -1,0 +1,1 @@
+The deprecated way of generating requriements ``install -r`` or ``lock -r`` has been removed in favor of the ``pipenv requirements`` command.

--- a/pipenv/cli/command.py
+++ b/pipenv/cli/command.py
@@ -23,7 +23,6 @@ from pipenv.cli.options import (
     uninstall_options,
     verbose_option,
 )
-from pipenv.exceptions import PipenvOptionsError
 from pipenv.utils.processes import subprocess_run
 from pipenv.vendor.click import (
     Choice,
@@ -330,47 +329,16 @@ def lock(ctx, state, **kwargs):
         warn=(not state.quiet),
         site_packages=state.site_packages,
     )
-    emit_requirements = state.lockoptions.emit_requirements
     dev = state.installstate.dev
     dev_only = state.lockoptions.dev_only
     pre = state.installstate.pre
-    if emit_requirements:
-        secho(
-            "Warning: The lock flag -r/--requirements will be deprecated in a future version\n"
-            "of pipenv in favor of the new requirements command. For more info see\n"
-            "https://pipenv.pypa.io/en/latest/advanced/#generating-a-requirements-txt\n"
-            "NOTE: the requirements command parses Pipfile.lock directly without performing any\n"
-            "locking operations. Updating packages should be done by running pipenv lock.",
-            fg="yellow",
-            err=True,
-        )
-        # Emit requirements file header (unless turned off with --no-header)
-        if state.lockoptions.emit_requirements_header:
-            header_options = ["--requirements"]
-            if dev_only:
-                header_options.append("--dev-only")
-            elif dev:
-                header_options.append("--dev")
-            echo(LOCK_HEADER.format(options=" ".join(header_options)))
-            # TODO: Emit pip-compile style header
-            if dev and not dev_only:
-                echo(LOCK_DEV_NOTE)
-        # Setting "emit_requirements=True" means do_init() just emits the
-        # install requirements file to stdout, it doesn't install anything
-        do_init(
-            state.project,
-            dev=dev,
-            dev_only=dev_only,
-            emit_requirements=emit_requirements,
-            pypi_mirror=state.pypi_mirror,
-            pre=pre,
-        )
-    elif state.lockoptions.dev_only:
-        raise PipenvOptionsError(
-            "--dev-only",
-            "--dev-only is only permitted in combination with --requirements. "
-            "Aborting.",
-        )
+    do_init(
+        state.project,
+        dev=dev,
+        dev_only=dev_only,
+        pypi_mirror=state.pypi_mirror,
+        pre=pre,
+    )
     do_lock(
         state.project,
         ctx=ctx,

--- a/pipenv/cli/command.py
+++ b/pipenv/cli/command.py
@@ -316,7 +316,7 @@ LOCK_DEV_NOTE = """\
 @pass_context
 def lock(ctx, state, **kwargs):
     """Generates Pipfile.lock."""
-    from ..core import do_init, do_lock, ensure_project
+    from ..core import do_lock, ensure_project
 
     # Ensure that virtualenv is available.
     # Note that we don't pass clear on to ensure_project as it is also
@@ -329,16 +329,7 @@ def lock(ctx, state, **kwargs):
         warn=(not state.quiet),
         site_packages=state.site_packages,
     )
-    dev = state.installstate.dev
-    dev_only = state.lockoptions.dev_only
     pre = state.installstate.pre
-    do_init(
-        state.project,
-        dev=dev,
-        dev_only=dev_only,
-        pypi_mirror=state.pypi_mirror,
-        pre=pre,
-    )
     do_lock(
         state.project,
         ctx=ctx,

--- a/pipenv/cli/options.py
+++ b/pipenv/cli/options.py
@@ -92,8 +92,6 @@ class InstallState:
 class LockOptions:
     def __init__(self):
         self.dev_only = False
-        self.emit_requirements = False
-        self.emit_requirements_header = False
 
 
 pass_state = make_pass_decorator(State, ensure=True)
@@ -460,41 +458,6 @@ def requirementstxt_option(f):
     )(f)
 
 
-def emit_requirements_flag(f):
-    def callback(ctx, param, value):
-        state = ctx.ensure_object(State)
-        if value:
-            state.lockoptions.emit_requirements = value
-        return value
-
-    return option(
-        "--requirements",
-        "-r",
-        default=False,
-        is_flag=True,
-        expose_value=False,
-        help="Generate output in requirements.txt format.",
-        callback=callback,
-    )(f)
-
-
-def emit_requirements_header_flag(f):
-    def callback(ctx, param, value):
-        state = ctx.ensure_object(State)
-        if value:
-            state.lockoptions.emit_requirements_header = value
-        return value
-
-    return option(
-        "--header/--no-header",
-        default=True,
-        is_flag=True,
-        expose_value=False,
-        help="Add header to generated requirements",
-        callback=callback,
-    )(f)
-
-
 def dev_only_flag(f):
     def callback(ctx, param, value):
         state = ctx.ensure_object(State)
@@ -597,8 +560,6 @@ def uninstall_options(f):
 def lock_options(f):
     f = install_base_options(f)
     f = lock_dev_option(f)
-    f = emit_requirements_flag(f)
-    f = emit_requirements_header_flag(f)
     f = dev_only_flag(f)
     return f
 

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -797,7 +797,6 @@ def do_install_dependencies(
     dev=False,
     dev_only=False,
     bare=False,
-    emit_requirements=False,
     allow_global=False,
     ignore_hashes=False,
     skip_lock=False,
@@ -805,16 +804,13 @@ def do_install_dependencies(
     requirements_dir=None,
     pypi_mirror=None,
 ):
-    """ "
-    Executes the install functionality.
+    """
+    Executes the installation functionality.
 
-    If emit_requirements is True, simply spits out a requirements format to stdout.
     """
 
     import queue
 
-    if emit_requirements:
-        bare = True
     # Load the lockfile if it exists, or if dev_only is being used.
     if skip_lock or not project.lockfile_exists:
         if not bare:
@@ -840,15 +836,6 @@ def do_install_dependencies(
             )
     dev = dev or dev_only
     deps_list = list(lockfile.get_requirements(dev=dev, only=dev_only))
-    if emit_requirements:
-        index_args = prepare_pip_source_args(
-            get_source_list(project, pypi_mirror=pypi_mirror)
-        )
-        index_args = " ".join(index_args).replace(" -", "\n-")
-        deps = [req.as_line(sources=False, include_hashes=False) for req in deps_list]
-        click.echo(index_args)
-        click.echo("\n".join(sorted(deps)))
-        sys.exit(0)
     if concurrent:
         nprocs = project.s.PIPENV_MAX_SUBPROCESS
     else:
@@ -1233,7 +1220,6 @@ def do_init(
     project,
     dev=False,
     dev_only=False,
-    emit_requirements=False,
     allow_global=False,
     ignore_pipfile=False,
     skip_lock=False,
@@ -1340,7 +1326,6 @@ def do_init(
         project,
         dev=dev,
         dev_only=dev_only,
-        emit_requirements=emit_requirements,
         allow_global=allow_global,
         skip_lock=skip_lock,
         concurrent=concurrent,

--- a/tests/integration/test_lock.py
+++ b/tests/integration/test_lock.py
@@ -104,7 +104,7 @@ def test_lock_keep_outdated(PipenvInstance):
             contents = """
 [packages]
 requests = {version = "==2.14.0"}
-PyTest = "==3.1.0"
+pytest = "==3.1.0"
             """.strip()
             f.write(contents)
 
@@ -120,7 +120,7 @@ PyTest = "==3.1.0"
             updated_contents = """
 [packages]
 requests = {version = "==2.18.4"}
-PyTest = "*"
+pytest = "*"
             """.strip()
             f.write(updated_contents)
 
@@ -427,10 +427,6 @@ fake-package = "*"
             f.write(contents)
         c = p.pipenv(f'install -v --pypi-mirror {mirror_url}')
         assert c.returncode == 0
-        assert f'-i {mirror_url}' in c.stdout.strip()
-        assert '--extra-index-url https://test.pypi.org/simple' in c.stdout.strip()
-        assert f'--extra-index-url {mirror_url}' not in c.stdout.strip()
-
 
 @pytest.mark.lock
 @pytest.mark.install

--- a/tests/integration/test_lock.py
+++ b/tests/integration/test_lock.py
@@ -46,16 +46,18 @@ flask = "==0.12.2"
 
         dev_req_list = ("flask==0.12.2",)
 
-        c = p.pipenv('lock -r')
-        d = p.pipenv('lock -r -d')
+        c = p.pipenv('lock')
         assert c.returncode == 0
-        assert d.returncode == 0
+
+        default = p.pipenv('requirements')
+        assert default.returncode == 0
+        dev = p.pipenv('requirements --dev-only')
 
         for req in req_list:
-            assert req in c.stdout
+            assert req in default.stdout
 
         for req in dev_req_list:
-            assert req in d.stdout
+            assert req in dev.stdout
 
 
 @pytest.mark.lock
@@ -306,7 +308,9 @@ requests = {version = "*", extras = ["socks"]}
         assert "pysocks" in p.lockfile["default"]
         assert "markers" not in p.lockfile["default"]['pysocks']
 
-        c = p.pipenv('lock -r')
+        c = p.pipenv('lock')
+        assert c.returncode == 0
+        c = p.pipenv('requirements')
         assert c.returncode == 0
         assert "extra == 'socks'" not in c.stdout.strip()
 
@@ -388,12 +392,8 @@ pipenv-test-private-package = {version = "*", index = "testpypi"}
 requests = "*"
             """.strip()
             f.write(contents)
-        c = p.pipenv('install')
+        c = p.pipenv('lock')
         assert c.returncode == 0
-        c = p.pipenv('lock -r')
-        assert c.returncode == 0
-        assert '-i https://pypi.org/simple' in c.stdout.strip()
-        assert '--extra-index-url https://test.pypi.org/simple' in c.stdout.strip()
 
 
 @pytest.mark.lock
@@ -425,9 +425,7 @@ six = {version = "*", index = "testpypi"}
 fake-package = "*"
             """.strip()
             f.write(contents)
-        c = p.pipenv(f'install --pypi-mirror {mirror_url}')
-        assert c.returncode == 0
-        c = p.pipenv(f'lock -r --pypi-mirror {mirror_url}')
+        c = p.pipenv(f'install -v --pypi-mirror {mirror_url}')
         assert c.returncode == 0
         assert f'-i {mirror_url}' in c.stdout.strip()
         assert '--extra-index-url https://test.pypi.org/simple' in c.stdout.strip()


### PR DESCRIPTION
Thank you for contributing to Pipenv!


### The issue

Remove the deprecated `install -r` command and simplify the CLI interface + logic.

Fixes: #5198

### The fix

We have the `pipenv requirements` command now.


### The checklist

* [X] Associated issue
* [X] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.
