### PR TITLE
Unravel pip shims

### DIFF
--- a/news/5204.bugfix.rst
+++ b/news/5204.bugfix.rst
@@ -1,0 +1,1 @@
+Remove usages of ``pip_shims`` from the non vendored ``pipenv`` code, but retain initialization for ``requirementslib`` still has usages.

--- a/pipenv/environment.py
+++ b/pipenv/environment.py
@@ -636,7 +636,7 @@ class Environment:
         pip_options, _ = pip_command.parser.parse_args(pip_args)
         pip_options.cache_dir = self.project.s.PIPENV_CACHE_DIR
         pip_options.pre = self.pipfile.get("pre", pre)
-        session = pip_command._build_session(self.pip_options)
+        session = pip_command._build_session(pip_options)
         finder = get_package_finder(
             install_cmd=pip_command, options=pip_options, session=session
         )

--- a/pipenv/environment.py
+++ b/pipenv/environment.py
@@ -627,18 +627,20 @@ class Environment:
 
     @contextlib.contextmanager
     def get_finder(self, pre: bool = False) -> ContextManager[PackageFinder]:
-        from .vendor.pip_shims.shims import get_package_finder
+        from .utils.resolver import get_package_finder
 
-        pip_command = InstallCommand()
+        pip_command = InstallCommand(
+            name="InstallCommand", summary="pip Install command."
+        )
         pip_args = prepare_pip_source_args(self.sources)
         pip_options, _ = pip_command.parser.parse_args(pip_args)
         pip_options.cache_dir = self.project.s.PIPENV_CACHE_DIR
         pip_options.pre = self.pipfile.get("pre", pre)
-        with pip_command._build_session(pip_options) as session:
-            finder = get_package_finder(
-                install_cmd=pip_command, options=pip_options, session=session
-            )
-            yield finder
+        session = pip_command._build_session(self.pip_options)
+        finder = get_package_finder(
+            install_cmd=pip_command, options=pip_options, session=session
+        )
+        yield finder
 
     def get_package_info(
         self, pre: bool = False

--- a/pipenv/project.py
+++ b/pipenv/project.py
@@ -643,7 +643,7 @@ class Project:
     def create_pipfile(self, python=None):
         """Creates the Pipfile, filled with juicy defaults."""
         # Inherit the pip's index configuration of install command.
-        command = InstallCommand()
+        command = InstallCommand(name="InstallCommand", summary="pip Install command.")
         indexes = command.cmd_opts.get_option("--extra-index-url").default
         sources = [self.default_source]
         for i, index in enumerate(indexes):

--- a/pipenv/project.py
+++ b/pipenv/project.py
@@ -23,15 +23,16 @@ from pipenv.cmdparse import Script
 from pipenv.core import system_which
 from pipenv.environment import Environment
 from pipenv.environments import Setting, is_in_virtualenv, normalize_pipfile_path
+from pipenv.patched.pip._internal.commands.install import InstallCommand
 from pipenv.utils.constants import is_type_checking
 from pipenv.utils.dependencies import (
     get_canonical_names,
     is_editable,
     is_star,
+    pep423_name,
     python_version,
 )
 from pipenv.utils.internet import get_url_name, is_valid_url, proper_case
-from pipenv.utils.resolver import pep423_name
 from pipenv.utils.shell import (
     find_requirements,
     find_windows_executable,
@@ -641,8 +642,6 @@ class Project:
 
     def create_pipfile(self, python=None):
         """Creates the Pipfile, filled with juicy defaults."""
-        from .vendor.pip_shims.shims import InstallCommand
-
         # Inherit the pip's index configuration of install command.
         command = InstallCommand()
         indexes = command.cmd_opts.get_option("--extra-index-url").default


### PR DESCRIPTION
`pip_shims` is slow and make the interface confusing for the internal `pip` usages.  Best part?  We no longer need to rely on pip_shims for pipenv usages, because we vendor in a specific version of pip and rely exclusively on it.

We will have to consider requirementslib separately, and then perhaps one day we can abandon pip_shims entirely.

### The checklist

* [?] Associated issue
* [X] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.
