### PR TITLE
Fix extra indexes

### DIFF
--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -1503,7 +1503,8 @@ def pip_install(
         trusted_hosts=trusted_hosts,
         pypi_mirror=pypi_mirror,
     )
-    if not search_all_sources and requirement.index in sources:
+    source_names = {src.get("name") for src in sources}
+    if not search_all_sources and requirement.index in source_names:
         sources = list(filter(lambda d: d.get("name") == requirement.index, sources))
     if r:
         with open(r, "r") as fh:

--- a/pipenv/utils/indexes.py
+++ b/pipenv/utils/indexes.py
@@ -45,9 +45,9 @@ def prepare_pip_source_args(sources, pip_args=None):
 
 
 def get_project_index(
-    project: Optional[Union[str, TSource]],
-    index: Optional[List[str]] = None,
-    trusted_hosts: Optional[Project] = None,
+    project: Project,
+    index: Optional[Union[str, TSource]] = None,
+    trusted_hosts: Optional[List[str]] = None,
 ) -> TSource:
     from pipenv.project import SourceNotFound
 
@@ -68,7 +68,7 @@ def get_project_index(
 def get_source_list(
     project: Project,
     index: Optional[Union[str, TSource]] = None,
-    extra_indexes: Optional[List[str]] = None,
+    extra_indexes: Optional[Union[str, List[str]]] = None,
     trusted_hosts: Optional[List[str]] = None,
     pypi_mirror: Optional[str] = None,
 ) -> List[TSource]:

--- a/pipenv/utils/indexes.py
+++ b/pipenv/utils/indexes.py
@@ -78,14 +78,16 @@ def get_source_list(
     if extra_indexes:
         if isinstance(extra_indexes, str):
             extra_indexes = [extra_indexes]
+
         for source in extra_indexes:
             extra_src = get_project_index(project, source)
             if not sources or extra_src["url"] != sources[0]["url"]:
                 sources.append(extra_src)
-        else:
-            for source in project.pipfile_sources:
-                if not sources or source["url"] != sources[0]["url"]:
-                    sources.append(source)
+
+        for source in project.pipfile_sources:
+            if not sources or source["url"] != sources[0]["url"]:
+                sources.append(source)
+
     if not sources:
         sources = project.pipfile_sources[:]
     if pypi_mirror:

--- a/tests/integration/test_install_uri.py
+++ b/tests/integration/test_install_uri.py
@@ -202,6 +202,9 @@ name = "pypi"
 six = "*"
 
 [dev-packages]
+
+[pipenv]
+install_search_all_sources = true
             """.strip()
             f.write(contents)
         c = p.pipenv("install pipenv-test-private-package --index https://test.pypi.org/simple")

--- a/tests/integration/test_lock.py
+++ b/tests/integration/test_lock.py
@@ -335,6 +335,7 @@ name = "testpypi"
 
 [packages]
 pipenv-test-private-package = {version = "*", index = "testpypi"}
+pipenv-test-public-package = {version = "*", index = "pypi"}
 requests = "*"
             """.strip()
             f.write(contents)


### PR DESCRIPTION
### The issue

When installing a requirement that explicitly references an index all indexes are searched even though `install_search_all_sources = False`.

### The fix

There were two different locations where the code appears to not have the expected behavior.

### The checklist

* [ ] Associated issue
* [ ] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.
