### PR TITLE
fix bug when auto completing install and uninstall

### DIFF
--- a/news/5214.bugfix.rst
+++ b/news/5214.bugfix.rst
@@ -1,0 +1,2 @@
+Fix auto-complete crashing on 'install' and 'uninstall' keywords
+

--- a/news/5214.bugfix.rst
+++ b/news/5214.bugfix.rst
@@ -1,2 +1,1 @@
 Fix auto-complete crashing on 'install' and 'uninstall' keywords
-

--- a/pipenv/cli/options.py
+++ b/pipenv/cli/options.py
@@ -281,7 +281,7 @@ def package_arg(f):
         "packages",
         nargs=-1,
         callback=callback,
-        expose_value=False,
+        expose_value=True,
         type=click_types.STRING,
     )(f)
 


### PR DESCRIPTION


### The issue

https://github.com/pypa/pipenv/issues/5214

This commit fixes the auto completing crash mentioned in the above command.

### The fix

The bug is related to click and I have opened a corresponding issue in their github:
https://github.com/pallets/click/issues/2336

The main problem is that expose_value=False when used for arguments breaks the autocomplete.
The best solution is to fix click and then vendor the new version. However "expose_value=False" doesn't do anything for us as far as I can see. So removing it or setting it to true is a viable option.

### The checklist

* [X] Associated issue
* [X] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

