### PR TITLE
Fix for inclusion of setuptools in the lock and install phase + other  BAD_PACKAGES.

### DIFF
--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -730,7 +730,9 @@ def batch_install(
     deps_to_install = deps_list[:]
     deps_to_install.extend(sequential_deps)
     deps_to_install = [
-        dep for dep in deps_to_install if not project.environment.is_satisfied(dep) and dep.name not in BAD_PACKAGES
+        dep
+        for dep in deps_to_install
+        if not project.environment.is_satisfied(dep) and dep.name not in BAD_PACKAGES
     ]
     sequential_dep_names = [d.name for d in sequential_deps]
 

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -730,7 +730,7 @@ def batch_install(
     deps_to_install = deps_list[:]
     deps_to_install.extend(sequential_deps)
     deps_to_install = [
-        dep for dep in deps_to_install if not project.environment.is_satisfied(dep)
+        dep for dep in deps_to_install if not project.environment.is_satisfied(dep) and dep.name not in BAD_PACKAGES
     ]
     sequential_dep_names = [d.name for d in sequential_deps]
 


### PR DESCRIPTION
After switching to use exclusively vendor'd pip for remaining commands, which includes install, two of the tests when run on python < 3.10 were failing in a weird loop where setuptools would get uninstalled and then be requested to install the newer version of setuptools and fail.   I am not sure why this passed on python 3.10 or why its so problematic for versions less than 3.10. 

The other thing this should fix is pipenv should no longer include BAD_PACKAGES in the Pipfile.lock -- these are packages that were already required be installed when installing `pipenv` so it should not be necessary to include them in the lock.  I had to manually delete setuptools from the pipenv Pipfile.lock to get the build to even run the tests for python versions < 3.10 in this PR:  https://github.com/pypa/pipenv/pull/5229 