### PR TITLE
Issue 4371 incorrect dependencies when install dev packages

### DIFF
--- a/news/5234.bugfix.rst
+++ b/news/5234.bugfix.rst
@@ -1,0 +1,2 @@
+Use ``packages`` as contraints when locking ``dev-packages`` in Pipfile.
+Use ``packages`` as contraints when installing new ``dev-packages``.

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -43,6 +43,7 @@ from pipenv.utils.shell import (
     cmd_list_to_shell,
     find_python,
     is_python_command,
+    normalize_path,
     project_python,
     subprocess_run,
     system_which,
@@ -1578,7 +1579,7 @@ def pip_install(
     )
     pip_command.extend(pip_args)
     if r:
-        pip_command.extend(["-r", vistir.path.normalize_path(r)])
+        pip_command.extend(["-r", normalize_path(r)])
     elif line:
         pip_command.extend(line)
     if dev and use_constraint:
@@ -1586,7 +1587,7 @@ def pip_install(
             project,
             requirements_dir=requirements_dir,
         )
-        pip_command.extend(["-c", vistir.path.normalize_path(constraint_filename)])
+        pip_command.extend(["-c", normalize_path(constraint_filename)])
     pip_command.extend(prepare_pip_source_args(sources))
     if project.s.is_verbose():
         click.echo(f"$ {cmd_list_to_shell(pip_command)}", err=True)

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -1550,7 +1550,7 @@ def pip_install(
     if dev and use_constraint:
         constraint_filename = prepare_default_constraint_file(
             project,
-            dir=requirements_dir,
+            directory=requirements_dir,
         )
         pip_command.extend(["-c", normalize_path(constraint_filename)])
     pip_command.extend(prepare_pip_source_args(sources))

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -28,11 +28,12 @@ from pipenv.utils.constants import MYPY_RUNNING
 from pipenv.utils.dependencies import (
     convert_deps_to_pip,
     get_canonical_names,
+    get_constraints_from_deps,
     is_pinned,
     is_required_version,
     is_star,
     pep423_name,
-    prepare_default_constraint_file,
+    prepare_constraint_file,
     python_version,
 )
 from pipenv.utils.indexes import get_source_list, parse_indexes, prepare_pip_source_args
@@ -1548,9 +1549,12 @@ def pip_install(
     elif line:
         pip_command.extend(line)
     if dev and use_constraint:
-        constraint_filename = prepare_default_constraint_file(
-            project,
+        default_constraints = get_constraints_from_deps(project.packages)
+        constraint_filename = prepare_constraint_file(
+            default_constraints,
             directory=requirements_dir,
+            sources=None,
+            pip_args=None,
         )
         pip_command.extend(["-c", normalize_path(constraint_filename)])
     pip_command.extend(prepare_pip_source_args(sources))

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -28,8 +28,7 @@ from pipenv.utils.constants import MYPY_RUNNING
 from pipenv.utils.dependencies import (
     convert_deps_to_pip,
     get_canonical_names,
-    has_extras,
-    is_editable,
+    get_constraints_from_deps,
     is_pinned,
     is_required_version,
     is_star,
@@ -1460,16 +1459,7 @@ def write_constraint_to_file(
         prefix="pipenv-", suffix="-constraint.txt", dir=requirements_dir, delete=False
     )
 
-    # duplicated in pipenv.utils.resolver
-    # https://pip.pypa.io/en/stable/user_guide/#constraints-files
-    # constraints must have a name, they cannot be editable, and they cannot specify extras.
-    constraints = {
-        k: v
-        for k, v in project.packages.items()
-        if not is_editable(k) and not is_editable(v) and not has_extras(v)
-    }
-    constraints = convert_deps_to_pip(constraints, project=project, r=False)
-
+    constraints = get_constraints_from_deps(project.packages)
     for line in constraints:
         if project.s.is_verbose():
             click.echo(

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -1095,8 +1095,9 @@ def do_lock(
         for k, v in lockfile[section].copy().items():
             if not hasattr(v, "keys"):
                 del lockfile[section][k]
-    # Resolve dev-package dependencies followed by packages dependencies.
-    for is_dev in [True, False]:
+
+    # Resolve package to generate constraints before resolving dev-packages
+    for is_dev in [False, True]:
         pipfile_section = "dev-packages" if is_dev else "packages"
         if project.pipfile_exists:
             packages = project.parsed_pipfile.get(pipfile_section, {})

--- a/pipenv/resolver.py
+++ b/pipenv/resolver.py
@@ -745,12 +745,15 @@ def resolve_packages(pre, clear, verbose, system, write, requirements_dir, packa
         else None
     )
 
-    def resolve(packages, pre, project, sources, clear, system, requirements_dir=None):
+    def resolve(
+        packages, pre, project, sources, clear, system, dev, requirements_dir=None
+    ):
         return resolve_deps(
             packages,
             which,
             project=project,
             pre=pre,
+            dev=dev,
             sources=sources,
             clear=clear,
             allow_global=system,
@@ -769,6 +772,7 @@ def resolve_packages(pre, clear, verbose, system, write, requirements_dir, packa
     results, resolver = resolve(
         packages,
         pre=pre,
+        dev=dev,
         project=project,
         sources=sources,
         clear=clear,

--- a/pipenv/utils/dependencies.py
+++ b/pipenv/utils/dependencies.py
@@ -299,7 +299,7 @@ def get_constraints_from_deps(deps):
 
 
 def prepare_constraint_file(
-    constraints=None,
+    constraints,
     directory=None,
     sources=None,
     pip_args=None,
@@ -320,7 +320,7 @@ def prepare_constraint_file(
         delete=False,
     )
 
-    if sources:
+    if sources and pip_args:
         skip_args = ("build-isolation", "use-pep517", "cache-dir")
         args_to_add = [
             arg for arg in pip_args if not any(bad_arg in arg for bad_arg in skip_args)

--- a/pipenv/utils/dependencies.py
+++ b/pipenv/utils/dependencies.py
@@ -300,21 +300,21 @@ def get_constraints_from_deps(deps):
 
 def prepare_default_constraint_file(
     project,
-    dir=None,
+    directory=None,
 ):
     from pipenv.vendor.vistir.path import (
         create_tracked_tempdir,
         create_tracked_tempfile,
     )
 
-    if not dir:
-        dir = create_tracked_tempdir(suffix="-requirements", prefix="pipenv-")
+    if not directory:
+        directory = create_tracked_tempdir(suffix="-requirements", prefix="pipenv-")
 
     default_constraints_file = create_tracked_tempfile(
         mode="w",
         prefix="pipenv-",
         suffix="-default-constraints.txt",
-        dir=dir,
+        dir=directory,
         delete=False,
     )
     default_constraints = get_constraints_from_deps(project.packages)

--- a/pipenv/utils/dependencies.py
+++ b/pipenv/utils/dependencies.py
@@ -284,9 +284,9 @@ def get_constraints_from_deps(deps):
     """Get contraints from Pipfile-formatted dependency"""
     from pipenv.vendor.requirementslib.models.requirements import Requirement
 
-    # https://pip.pypa.io/en/stable/user_guide/#constraints-files
-    # constraints must have a name, they cannot be editable, and they cannot specify extras.
     def is_constraint(dep):
+        # https://pip.pypa.io/en/stable/user_guide/#constraints-files
+        # constraints must have a name, they cannot be editable, and they cannot specify extras.
         return dep.name and not dep.editable and not dep.extras
 
     constraints = []
@@ -296,6 +296,31 @@ def get_constraints_from_deps(deps):
             c = new_dep.as_line().strip()
             constraints.append(c)
     return constraints
+
+
+def prepare_default_constraint_file(
+    project,
+    dir=None,
+):
+    from pipenv.vendor.vistir.path import (
+        create_tracked_tempdir,
+        create_tracked_tempfile,
+    )
+
+    if not dir:
+        dir = create_tracked_tempdir(suffix="-requirements", prefix="pipenv-")
+
+    default_constraints_file = create_tracked_tempfile(
+        mode="w",
+        prefix="pipenv-",
+        suffix="-default-constraints.txt",
+        dir=dir,
+        delete=False,
+    )
+    default_constraints = get_constraints_from_deps(project.packages)
+    default_constraints_file.write("\n".join([c for c in default_constraints]))
+    default_constraints_file.close()
+    return default_constraints_file.name
 
 
 def is_required_version(version, specified_version):

--- a/pipenv/utils/dependencies.py
+++ b/pipenv/utils/dependencies.py
@@ -301,6 +301,12 @@ def is_editable(pipfile_entry):
     return False
 
 
+def has_extras(pipfile_entry):
+    if hasattr(pipfile_entry, "get"):
+        return pipfile_entry.get("extras")
+    return False
+
+
 @contextmanager
 def locked_repository(requirement):
     from pipenv.vendor.vistir.path import create_tracked_tempdir

--- a/pipenv/utils/resolver.py
+++ b/pipenv/utils/resolver.py
@@ -4,7 +4,7 @@ import os
 import subprocess
 import sys
 import warnings
-from functools import lru_cache
+from functools import cached_property, lru_cache
 from typing import Dict, List, Optional, Set, Tuple, Union
 
 from pipenv import environments
@@ -16,6 +16,9 @@ from pipenv.patched.pip._internal.models.target_python import TargetPython
 from pipenv.patched.pip._internal.network.cache import SafeFileCache
 from pipenv.patched.pip._internal.operations.build.build_tracker import (
     get_build_tracker,
+)
+from pipenv.patched.pip._internal.req.constructors import (
+    install_req_from_parsed_requirement,
 )
 from pipenv.patched.pip._internal.req.req_file import parse_requirements
 from pipenv.patched.pip._internal.utils.hashes import FAVORITE_HASH
@@ -137,15 +140,12 @@ class Resolver:
         self.requires_python_markers = {}
         self._pip_args = None
         self._constraints = None
-        self._default_constraints = None
         self._parsed_constraints = None
-        self._parsed_default_constraints = None
         self._resolver = None
         self._finder = None
         self._ignore_compatibility_finder = None
         self._session = None
         self._constraint_file = None
-        self._default_constraint_file = None
         self._pip_options = None
         self._pip_command = None
         self._retry_attempts = 0
@@ -576,11 +576,9 @@ class Resolver:
         default_constraints_file.close()
         return default_constraints_file.name
 
-    @property
+    @cached_property
     def default_constraint_file(self):
-        if self._default_constraint_file is None:
-            self._default_constraint_file = self.prepare_default_constraint_file()
-        return self._default_constraint_file
+        return self.prepare_default_constraint_file()
 
     @property
     def pip_options(self):
@@ -660,36 +658,30 @@ class Resolver:
             )
         return self._parsed_constraints
 
-    @property
+    @cached_property
     def parsed_default_constraints(self):
         pip_options = self.pip_options
         pip_options.extra_index_urls = []
-        if self._parsed_default_constraints is None:
-            self._parsed_default_constraints = parse_requirements(
-                self.default_constraint_file,
-                constraint=True,
-                finder=self.finder,
-                session=self.session,
-                options=pip_options,
-            )
-        return self._parsed_default_constraints
-
-    @property
-    def default_constraints(self):
-        from pipenv.patched.pip._internal.req.constructors import (
-            install_req_from_parsed_requirement,
+        parsed_default_constraints = parse_requirements(
+            self.default_constraint_file,
+            constraint=True,
+            finder=self.finder,
+            session=self.session,
+            options=pip_options,
         )
+        return parsed_default_constraints
 
-        if self._default_constraints is None:
-            self._default_constraints = [
-                install_req_from_parsed_requirement(
-                    c,
-                    isolated=self.pip_options.build_isolation,
-                    user_supplied=False,
-                )
-                for c in self.parsed_default_constraints
-            ]
-        return self._default_constraints
+    @cached_property
+    def default_constraints(self):
+        default_constraints = [
+            install_req_from_parsed_requirement(
+                c,
+                isolated=self.pip_options.build_isolation,
+                user_supplied=False,
+            )
+            for c in self.parsed_default_constraints
+        ]
+        return default_constraints
 
     @property
     def constraints(self):

--- a/pipenv/utils/resolver.py
+++ b/pipenv/utils/resolver.py
@@ -4,7 +4,7 @@ import os
 import subprocess
 import sys
 import warnings
-from functools import cached_property, lru_cache
+from functools import lru_cache
 from typing import Dict, List, Optional, Set, Tuple, Union
 
 from pipenv import environments
@@ -576,7 +576,8 @@ class Resolver:
         default_constraints_file.close()
         return default_constraints_file.name
 
-    @cached_property
+    @property
+    @lru_cache()
     def default_constraint_file(self):
         return self.prepare_default_constraint_file()
 
@@ -658,7 +659,8 @@ class Resolver:
             )
         return self._parsed_constraints
 
-    @cached_property
+    @property
+    @lru_cache()
     def parsed_default_constraints(self):
         pip_options = self.pip_options
         pip_options.extra_index_urls = []
@@ -671,7 +673,8 @@ class Resolver:
         )
         return parsed_default_constraints
 
-    @cached_property
+    @property
+    @lru_cache()
     def default_constraints(self):
         default_constraints = [
             install_req_from_parsed_requirement(

--- a/pipenv/utils/resolver.py
+++ b/pipenv/utils/resolver.py
@@ -32,9 +32,8 @@ from .dependencies import (
     HackedPythonVersion,
     clean_pkg_version,
     convert_deps_to_pip,
+    get_constraints_from_deps,
     get_vcs_deps,
-    has_extras,
-    is_editable,
     is_pinned_requirement,
     pep423_name,
     translate_markers,
@@ -562,16 +561,6 @@ class Resolver:
         return self._constraint_file
 
     def prepare_default_constraint_file(self):
-        def get_default_constraints_from_packages():
-            # https://pip.pypa.io/en/stable/user_guide/#constraints-files
-            # constraints must have a name, they cannot be editable, and they cannot specify extras.
-            constraints = {
-                k: v
-                for k, v in self.project.packages.items()
-                if not is_editable(k) and not is_editable(v) and not has_extras(v)
-            }
-            constraints = convert_deps_to_pip(constraints, project=self.project, r=False)
-            return constraints
 
         from pipenv.vendor.vistir.path import create_tracked_tempfile
 
@@ -582,8 +571,7 @@ class Resolver:
             dir=self.req_dir,
             delete=False,
         )
-
-        default_constraints = get_default_constraints_from_packages()
+        default_constraints = get_constraints_from_deps(self.project.packages)
         default_constraints_file.write("\n".join([c for c in default_constraints]))
         default_constraints_file.close()
         return default_constraints_file.name

--- a/tests/integration/test_install_basic.py
+++ b/tests/integration/test_install_basic.py
@@ -510,7 +510,6 @@ requests = {version="*", index="pypi"}
         c = p.pipenv("install")
         assert c.returncode == 0
 
-@flaky
 @pytest.mark.dev
 @pytest.mark.install
 def test_install_dev_use_default_constraints(PipenvInstance):

--- a/tests/integration/test_lock.py
+++ b/tests/integration/test_lock.py
@@ -793,7 +793,6 @@ requests = {requirement}
         assert p.lockfile['default']['requests'] == expected_result
 
 
-@flaky
 @pytest.mark.dev
 @pytest.mark.lock
 @pytest.mark.install

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -131,6 +131,20 @@ def test_convert_deps_to_pip(deps, expected):
 def test_convert_deps_to_pip_one_way(deps, expected):
     assert dependencies.convert_deps_to_pip(deps, r=False) == [expected.lower()]
 
+@pytest.mark.utils
+@pytest.mark.parametrize(
+    "deps, expected",
+    [
+        ({"requests": {}}, ["requests"]),
+        ({"FooProject": {"path": ".", "editable" : "true"}}, []),
+        ({"FooProject": {"version": "==1.2"}}, ["fooproject==1.2"]),
+        ({"requests": {"extras": ["security"]}}, []),
+        ({"requests": {"extras": []}}, ["requests"]),
+        ({"extras" : {}}, ["extras"]),
+    ],
+)
+def test_get_constraints_from_deps(deps, expected):
+    assert dependencies.get_constraints_from_deps(deps) == expected
 
 @pytest.mark.parametrize("line,result", [
     ("-i https://example.com/simple/", ("https://example.com/simple/", None, None, [])),


### PR DESCRIPTION
### The issue

I'm trying to fix https://github.com/pypa/pipenv/issues/4371. I think it's better to consider 2 cases below:
- Installing from Pipfile.
- Installing from provided packages (the issue itself).

### The fix

#### Installing from Pipfile

I read through the code, and here is what it does when installing packages from Pipfile:
1. Resolve `dev-packages` dependencies. Write to lockfile as default.
2. Resolve `packages` dependencies. Write to lockfile as develop.
3. Overwrite duplicated develop packages by default packages.
4. Install default and develop packages in the lockfile.

Because, `dev-packages` is resolved separately, there might be a chance where `dev-packages` is overwritten but its dependencies are not (they aren't duplicated with `packages`). So I think the result dependency graph would be more accurate if `packages` is considered as constraint while resolving `dev-packages` dependencies. Luckily pip provided [constraints files](https://pip.pypa.io/en/stable/user_guide/#constraints-files).

I modified the code to do the followings:
1. Resolve `packages` dependencies. Write to lockfile.
2. Create constraints file from `packages`. Skip editable and extras packages as describe in [pip constraints files](https://pip.pypa.io/en/stable/user_guide/#constraints-files).
3. Resolve `dev-packages` dependencies using constraints file above. Write to lockfile as default.
4. Overwrite duplicated packages. Although `dev-packages` was resolved with constraints, this step is also important because there some cases constraints might be skipped (editable and extras packages).
5. Install resolved packages.


#### Installing from provided packages

When packages are passed as arguments, pipenv does the followings:
1. Install passed packages without resolving dependencies. Write to Pipfile and lockfile.
2. Resolving `dev-packages` and `packages` independently. Modify the lockfile.
3. Overwrite duplicated packages.
4. Install all the packages in the lockfile again. There might be a case it will uninstall the packages from step 1 before installing.

Similar to the first problem, I tried to use default packages as constraints to resolve packages dependencies. I think it is enough to just resolve `dev-packages` at step 1. Because default packages should be installed directly, and resolved packages at step 2 don't need to be resolved again.

### The checklist

* [ ] Associated issue
* [ ] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.