### PR TITLE
Document all environment variables

### DIFF
--- a/news/5235.doc.rst
+++ b/news/5235.doc.rst
@@ -1,0 +1,1 @@
+Add documentation for environment variables the configure pipenv.

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -146,7 +146,8 @@ def load_dot_env(project, as_dict=False, quiet=False):
                     err=True,
                 )
             dotenv.load_dotenv(dotenv_file, override=True)
-        project.s.initialize()
+
+            project.s = environments.Setting()
 
 
 def cleanup_virtualenv(project, bare=True):

--- a/pipenv/environments.py
+++ b/pipenv/environments.py
@@ -107,19 +107,20 @@ Default is to show emojis. This is automatically set on Windows.
 
 
 class Setting:
+    """
+    Control various settings of pipenv via environment variables.
+    """
+
     def __init__(self) -> None:
+
         self.USING_DEFAULT_PYTHON = True
-        self.initialize()
+        """Use the default Python"""
 
-    def initialize(self):
-
+        #: Location for Pipenv to store it's package cache.
+        #: Default is to use appdir's user cache directory.
         self.PIPENV_CACHE_DIR = os.environ.get(
             "PIPENV_CACHE_DIR", user_cache_dir("pipenv")
         )
-        """Location for Pipenv to store it's package cache.
-
-        Default is to use appdir's user cache directory.
-        """
 
         # Tells Pipenv which Python to default to, when none is provided.
         self.PIPENV_DEFAULT_PYTHON_VERSION = os.environ.get(


### PR DESCRIPTION
 Removed the initialize method. This was masking sphinx autodoc.
 Also, it was directly used inside the __init__ method.

 Fix #5201

