### PR TITLE
Don't count packaging as a bad package to omit.

### DIFF
--- a/news/5247.bugfix.rst
+++ b/news/5247.bugfix.rst
@@ -1,0 +1,1 @@
+Removed ``packaging`` library from ``BAD_PACKAGES`` constant to allow it to be installed, which fixes regression from ``pipenv==2022.8.13``.

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -63,7 +63,6 @@ if MYPY_RUNNING:
 # Packages that should be ignored later.
 BAD_PACKAGES = (
     "distribute",
-    "packaging",
     "pip",
     "pkg-resources",
     "setuptools",

--- a/tests/integration/test_install_basic.py
+++ b/tests/integration/test_install_basic.py
@@ -535,3 +535,16 @@ def test_install_dev_use_default_constraints(PipenvInstance):
 
         c = p.pipenv("run python -c 'import urllib3'")
         assert c.returncode != 0
+
+
+@pytest.mark.dev
+@pytest.mark.basic
+@pytest.mark.install
+@pytest.mark.needs_internet
+def test_install_does_not_exclude_packaging(PipenvInstance):
+    """Ensure that running `pipenv install` doesn't exclude packaging when its required. """
+    with PipenvInstance(chdir=True) as p:
+        c = p.pipenv("install dataclasses-json")
+        assert c.returncode == 0
+        c = p.pipenv("run python -c 'from dataclasses_json import DataClassJsonMixin'")
+        assert c.returncode == 0


### PR DESCRIPTION
Thank you for contributing to Pipenv!

Fixes: #5247

### The issue

When including the list of `BAD_PACKAGES` to be excluded from `batch_install` it caused problems for folks that depend on `packaging` to be installed by `pipenv`.  I don't see a reason to include `packaging` in the `BAD_PACKAGES` list.