### PR TITLE
Remove `get_pipenv_dist` function that is no longer used.

### DIFF
--- a/pipenv/utils/shell.py
+++ b/pipenv/utils/shell.py
@@ -48,16 +48,6 @@ def make_posix(path: str) -> str:
     return path
 
 
-def get_pipenv_dist(pkg="pipenv", pipenv_site=None):
-    from pipenv.resolver import find_site_path
-
-    pipenv_libdir = os.path.dirname(os.path.abspath(__file__))
-    if pipenv_site is None:
-        pipenv_site = os.path.dirname(pipenv_libdir)
-    pipenv_dist, _ = find_site_path(pkg, site_dir=pipenv_site)
-    return pipenv_dist
-
-
 @contextmanager
 def chdir(path):
     """Context manager to change working directories."""


### PR DESCRIPTION
Remove `get_pipenv_dist` function that is no longer used.  We dropped using it in a prior PR.