### PR TITLE
Actually filter out missing interpreters

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,7 +19,7 @@ How does this pull request fix your problem? Did you consider any alternatives? 
 ### The checklist
 
 * [ ] Associated issue
-* [ ] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.
+* [ ] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.
 
 <!--
 ### If this is a patch to the `vendor` directory...

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Or, if you\'re using FreeBSD:
 Or, if you\'re using Gentoo:
 
     sudo emerge pipenv
-    
+
 Or, if you\'re using Void Linux:
 
     sudo xbps-install -S python3-pipenv

--- a/news/5261.bugfix
+++ b/news/5261.bugfix
@@ -1,0 +1,1 @@
+Fix "The Python interpreter can't be found" error when running `pipenv install --system` with a python3 but no python.

--- a/news/5261.bugfix
+++ b/news/5261.bugfix
@@ -1,1 +1,0 @@
-Fix "The Python interpreter can't be found" error when running `pipenv install --system` with a python3 but no python.

--- a/news/5261.bugfix.rst
+++ b/news/5261.bugfix.rst
@@ -1,0 +1,1 @@
+Fix "The Python interpreter can't be found" error when running ``pipenv install --system`` with a python3 but no python.

--- a/pipenv/utils/shell.py
+++ b/pipenv/utils/shell.py
@@ -446,6 +446,7 @@ def project_python(project, system=False):
         python = project._which("python")
     else:
         interpreters = [system_which(p) for p in ("python", "python3")]
+        interpreters = [i for i in interpreters if i]  # filter out not found interpreters
         python = interpreters[0] if interpreters else None
     if not python:
         click.secho("The Python interpreter can't be found.", fg="red", err=True)


### PR DESCRIPTION
This fixes https://github.com/pypa/pipenv/issues/5261.

Before this change, I would get a "The Python interpreter can't be
found" error when running `pipenv install --system` with a python3 but
no python.

Demo:

```
$ docker run $(docker build -q -f Dockerfile.pipenv-2022.8.15 https://github.com/jfly/2022-08-16-pipenv-system-which-issue.git#main)
Installing dependencies from Pipfile.lock (63bec0)...
The Python interpreter can't be found.▉ 0/4 — 00:00:00
  🐍   ▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉ 0/4 — 00:00:00
```

I'm confident this bug was introduced in
https://github.com/pypa/pipenv/commit/f276360dfcef3200908e2c6569567d617919c63d,
which removed a usage of `first()`, but broke the "filter None values"
behavior that `first()` gave us.

### The checklist

* [x] Associated issue
* [x] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix`, `.feature`, `.behavior`, `.doc`. `.vendor`. or `.trivial` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.
