### PR TITLE
Revise how we do the import patch to include only module pipenv.

### DIFF
--- a/news/5265.bugfix.rst
+++ b/news/5265.bugfix.rst
@@ -1,0 +1,1 @@
+Revise pip import patch to include only ``pipenv`` from site-packages and removed ``--ignore-installed`` argument from pip install in order to fix regressions with ``--use-site-packages``.

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -1529,7 +1529,6 @@ def pip_install(
         project_python(project, system=allow_global),
         _get_runnable_pip(),
         "install",
-        "--ignore-installed",
     ]
     pip_args = get_pip_args(
         project,

--- a/pipenv/patched/pip/__main__.py
+++ b/pipenv/patched/pip/__main__.py
@@ -26,7 +26,13 @@ if __name__ == "__main__":
     warnings.filterwarnings(
         "ignore", category=DeprecationWarning, module=".*packaging\\.version"
     )
-    sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(__file__)))))
+    import importlib.util
+    import sys
+    spec = importlib.util.spec_from_file_location(
+        "pipenv", location=os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(__file__))), "__init__.py"))
+    pipenv = importlib.util.module_from_spec(spec)
+    sys.modules["pipenv"] = pipenv
+    spec.loader.exec_module(pipenv)
     from pipenv.patched.pip._internal.cli.main import main as _main
 
     sys.exit(_main())

--- a/tasks/vendoring/patches/patched/_post_pip_import.patch
+++ b/tasks/vendoring/patches/patched/_post_pip_import.patch
@@ -1,12 +1,18 @@
 diff --git a/pipenv/patched/pip/__main__.py b/pipenv/patched/pip/__main__.py
-index 204a8ca2..546caab1 100644
+index 24d42002b..b424ab203 100644
 --- a/pipenv/patched/pip/__main__.py
 +++ b/pipenv/patched/pip/__main__.py
-@@ -26,6 +26,7 @@ if __name__ == "__main__":
+@@ -26,6 +26,13 @@ if __name__ == "__main__":
      warnings.filterwarnings(
          "ignore", category=DeprecationWarning, module=".*packaging\\.version"
      )
-+    sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(__file__)))))
++    import importlib.util
++    import sys
++    spec = importlib.util.spec_from_file_location(
++        "pipenv", location=os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(__file__))), "__init__.py"))
++    pipenv = importlib.util.module_from_spec(spec)
++    sys.modules["pipenv"] = pipenv
++    spec.loader.exec_module(pipenv)
      from pipenv.patched.pip._internal.cli.main import main as _main
 
      sys.exit(_main())


### PR DESCRIPTION
Fixes #5265 
Fixes #5264

This is a much cleaner approach than to avoid having all the local site-packages in the path and require `--ignore-installed` as a workaround.   For reference this particular code works on Python 3.5+

Ref:  https://docs.python.org/3/library/importlib.html#importing-a-source-file-directly