### PR TITLE
Exclude from resolver constraints the editable dependencies that will be installed.

### DIFF
--- a/news/5271.bugfix.rst
+++ b/news/5271.bugfix.rst
@@ -1,0 +1,1 @@
+Fix issue where resolver is provided with ``install_requires`` constraints from ``setup.py`` that depend on editable dependencies and could not resolve them.

--- a/pipenv/project.py
+++ b/pipenv/project.py
@@ -579,7 +579,7 @@ class Project:
     def lockfile_content(self):
         return self.load_lockfile()
 
-    def _get_editable_packages(self, dev=False):
+    def get_editable_packages(self, dev=False):
         section = "dev-packages" if dev else "packages"
         packages = {
             k: v
@@ -601,11 +601,11 @@ class Project:
 
     @property
     def editable_packages(self):
-        return self._get_editable_packages(dev=False)
+        return self.get_editable_packages(dev=False)
 
     @property
     def editable_dev_packages(self):
-        return self._get_editable_packages(dev=True)
+        return self.get_editable_packages(dev=True)
 
     @property
     def vcs_packages(self):


### PR DESCRIPTION
Fixes #4323 

### The issue

Constraints for editable packages were being added to the resolver when it encountered `install_requires` lines but not filtering them out when those requirements are included as editable packages.