### PR TITLE
Issue 5273 constraints are not recognized

### DIFF
--- a/pipenv/utils/dependencies.py
+++ b/pipenv/utils/dependencies.py
@@ -282,13 +282,14 @@ def convert_deps_to_pip(
 
 def get_constraints_from_deps(deps):
     """Get contraints from Pipfile-formatted dependency"""
+    from pipenv.patched.pip._internal.req.req_install import (
+        check_invalid_constraint_type,
+    )
     from pipenv.vendor.requirementslib.models.requirements import Requirement
 
     def is_constraint(dep):
-        # https://pip.pypa.io/en/stable/user_guide/#constraints-files
-        # constraints must have a name, they cannot be editable, and they cannot specify extras.
-        ireq = dep.as_ireq()
-        return ireq.name and not ireq.editable and not ireq.extras
+        problem = check_invalid_constraint_type(dep.as_ireq())
+        return not problem
 
     constraints = []
     for dep_name, dep in deps.items():

--- a/pipenv/utils/dependencies.py
+++ b/pipenv/utils/dependencies.py
@@ -287,7 +287,8 @@ def get_constraints_from_deps(deps):
     def is_constraint(dep):
         # https://pip.pypa.io/en/stable/user_guide/#constraints-files
         # constraints must have a name, they cannot be editable, and they cannot specify extras.
-        return dep.name and not dep.editable and not dep.extras
+        ireq = dep.as_ireq()
+        return ireq.name and not ireq.editable and not ireq.extras
 
     constraints = []
     for dep_name, dep in deps.items():

--- a/pipenv/utils/dependencies.py
+++ b/pipenv/utils/dependencies.py
@@ -287,14 +287,11 @@ def get_constraints_from_deps(deps):
     )
     from pipenv.vendor.requirementslib.models.requirements import Requirement
 
-    def is_constraint(dep):
-        problem = check_invalid_constraint_type(dep.as_ireq())
-        return not problem
-
     constraints = []
     for dep_name, dep in deps.items():
         new_dep = Requirement.from_pipfile(dep_name, dep)
-        if is_constraint(new_dep):
+        problem = check_invalid_constraint_type(new_dep.as_ireq())
+        if not problem:
             c = new_dep.as_line().strip()
             constraints.append(c)
     return constraints

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -144,6 +144,7 @@ def test_convert_deps_to_pip_one_way(deps, expected):
         ({"requests": {"extras": ["security"]}}, []),
         ({"requests": {"extras": []}}, ["requests"]),
         ({"extras" : {}}, ["extras"]),
+        ({"uvicorn[standard]" : {}}, [])
     ],
 )
 def test_get_constraints_from_deps(deps, expected):


### PR DESCRIPTION
### The issue
This fixes https://github.com/pypa/pipenv/issues/5273

### The fix

Convert ``Requirement`` into ``InstallRequirement`` before checking constraint.

### The checklist

* [ ] Associated issue
* [ ] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.