### PR TITLE
Fix typo in Basic Usage of Pipenv doc

### DIFF
--- a/docs/basics.rst
+++ b/docs/basics.rst
@@ -468,7 +468,7 @@ doing a multi stage build for your application::
    it is done never the less. A calculated risk, since the intermediatiary image
    is discarded.
    The runtime image later shows that you should create a user and user it to
-   run your applicaion.
+   run your application.
    **Once again, you should not run pipenv as root (or Admin on Windows) normally.
    This could lead to breakage of your Python installation, or even your complete
    OS.**


### PR DESCRIPTION
### The issue

There is a typo in [Basic Usage of Pipenv](https://pipenv.pypa.io/en/latest/basics/) doc.

### The fix

...


### The checklist

...