### PR TITLE
Fix nondeterminism with environment markers #5239

### DIFF
--- a/news/5239.bugfix.rst
+++ b/news/5239.bugfix.rst
@@ -1,0 +1,1 @@
+Fix nondeterminism with environment markers #5239

--- a/pipenv/utils/resolver.py
+++ b/pipenv/utils/resolver.py
@@ -5,7 +5,7 @@ import subprocess
 import sys
 import warnings
 from functools import lru_cache
-from typing import Dict, List, Optional, Set, Tuple, Union
+from typing import Dict, List, Optional, Tuple, Union
 
 from pipenv import environments
 from pipenv.exceptions import RequirementError, ResolutionFailure
@@ -86,7 +86,6 @@ def get_package_finder(
 
 
 class HashCacheMixin:
-
     """Caches hashes of PyPI artifacts so we do not need to re-download them.
 
     Hashes are only cached when the URL appears to contain a hash in it and the
@@ -189,12 +188,14 @@ class Resolver:
         pre: bool = False,
         clear: bool = False,
     ) -> Tuple[
-        Set[str],
+        List[str],
         Dict[str, Dict[str, Union[str, bool, List[str]]]],
         Dict[str, str],
         Dict[str, str],
     ]:
-        constraints: Set[str] = set()
+        constraints: Dict[
+            str, None
+        ] = {}  # Used Dict instead of Set because Dict is ordered and is hence stable
         skipped: Dict[str, Dict[str, Union[str, bool, List[str]]]] = {}
         if index_lookup is None:
             index_lookup = {}
@@ -247,9 +248,9 @@ class Resolver:
             constraint_update, lockfile_update = self.get_deps_from_req(
                 req, resolver=transient_resolver, resolve_vcs=project.s.PIPENV_RESOLVE_VCS
             )
-            constraints |= constraint_update
+            constraints.update(constraint_update)
             skipped.update(lockfile_update)
-        return constraints, skipped, index_lookup, markers_lookup
+        return list(constraints.keys()), skipped, index_lookup, markers_lookup
 
     def parse_line(
         self,
@@ -309,7 +310,7 @@ class Resolver:
         req: Requirement,
         resolver: Optional["Resolver"] = None,
         resolve_vcs: bool = True,
-    ) -> Tuple[Set[str], Dict[str, Dict[str, Union[str, bool, List[str]]]]]:
+    ) -> Tuple[Dict[str, None], Dict[str, Dict[str, Union[str, bool, List[str]]]]]:
         from pipenv.vendor.requirementslib.models.requirements import Requirement
         from pipenv.vendor.requirementslib.models.utils import (
             _requirement_to_str_lowercase_name,
@@ -317,7 +318,9 @@ class Resolver:
         from pipenv.vendor.requirementslib.utils import is_installable_dir
 
         # TODO: this is way too complex, refactor this
-        constraints: Set[str] = set()
+        constraints: Dict[
+            str, None
+        ] = {}  # Used Dict instead of Set because Dict is ordered and is hence stable
         locked_deps: Dict[str, Dict[str, Union[str, bool, List[str]]]] = {}
         editable_packages = self.project.get_editable_packages(dev=self.dev)
         if (req.is_file_or_url or req.is_vcs) and not req.is_wheel:
@@ -365,12 +368,12 @@ class Resolver:
                                 new_req, resolver
                             )
                         locked_deps.update(new_lock)
-                        constraints |= new_constraints
+                        constraints.update(new_constraints)
                 # if there is no marker or there is a valid marker, add the constraint line
                 elif r and (not r.marker or (r.marker and r.marker.evaluate())):
                     if r.name not in editable_packages:
                         line = _requirement_to_str_lowercase_name(r)
-                        constraints.add(line)
+                        constraints[line] = None
             # ensure the top level entry remains as provided
             # note that we shouldn't pin versions for editable vcs deps
             if not req.is_vcs:
@@ -418,7 +421,7 @@ class Resolver:
                         err=True,
                     )
                 return constraints, locked_deps
-            constraints.add(req.constraint_line)
+            constraints[req.constraint_line] = None
             return constraints, locked_deps
         return constraints, locked_deps
 


### PR DESCRIPTION
this is a continuation of the following PR:
https://github.com/pypa/pipenv/pull/5279

### The issue

What is the thing you want to fix? Is it associated with an issue on GitHub? Please mention it.

Always consider opening an issue first to describe your problem, so we can discuss what is the best way to amend it.  Note that if you do not describe the goal of this change or link to a related issue, the maintainers may close the PR without further review.

If your pull request makes a non-insignificant change to Pipenv, such as the user interface or intended functionality, please file a PEEP.

    https://github.com/pypa/pipenv/blob/master/peeps/PEEP-000.md

### The fix

How does this pull request fix your problem? Did you consider any alternatives? Why is this the *best* solution, in your opinion?


### The checklist

* [x] Associated issue
* [x] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

<!--
### If this is a patch to the `vendor` directory...

Please try to refrain from submitting patches directly to `vendor` or `patched`, but raise your issue to the upstream project instead, and inform Pipenv to upgrade when the upstream project accepts the fix.

A pull request to upgrade vendor packages is strongly discouraged, unless there is a very good reason (e.g. you need to test Pipenv’s integration to a new vendor feature). Pipenv audits and performs vendor upgrades regularly, generally before a new release is about to drop.

If your patch is not or cannot be accepted by upstream, but is essential to Pipenv (make sure to discuss this with maintainers!), please remember to attach a patch file in `tasks/vendoring/patched`, so this divergence from upstream can be recorded and replayed afterwards.
-->
