### PR TITLE
Downgrade pyparsing -- testing for the sporadic failing deps_to_pip tests

### DIFF
--- a/pipenv/vendor/pyparsing/__init__.py
+++ b/pipenv/vendor/pyparsing/__init__.py
@@ -1,6 +1,6 @@
 # module pyparsing.py
 #
-# Copyright (c) 2003-2022  Paul T. McGuire
+# Copyright (c) 2003-2021  Paul T. McGuire
 #
 # Permission is hereby granted, free of charge, to any person obtaining
 # a copy of this software and associated documentation files (the
@@ -105,17 +105,14 @@ class version_info(NamedTuple):
 
     @property
     def __version__(self):
-        return (
-            "{}.{}.{}".format(self.major, self.minor, self.micro)
-            + (
-                "{}{}{}".format(
-                    "r" if self.releaselevel[0] == "c" else "",
-                    self.releaselevel[0],
-                    self.serial,
-                ),
-                "",
-            )[self.releaselevel == "final"]
-        )
+        return "{}.{}.{}".format(self.major, self.minor, self.micro) + (
+            "{}{}{}".format(
+                "r" if self.releaselevel[0] == "c" else "",
+                self.releaselevel[0],
+                self.serial,
+            ),
+            "",
+        )[self.releaselevel == "final"]
 
     def __str__(self):
         return "{} {} / {}".format(__name__, self.__version__, __version_time__)
@@ -128,8 +125,8 @@ class version_info(NamedTuple):
         )
 
 
-__version_info__ = version_info(3, 0, 9, "final", 0)
-__version_time__ = "05 May 2022 07:02 UTC"
+__version_info__ = version_info(3, 0, 7, "final", 0)
+__version_time__ = "15 Jan 2022 04:10 UTC"
 __version__ = __version_info__.__version__
 __versionTime__ = __version_time__
 __author__ = "Paul McGuire <ptmcg.gm+pyparsing@gmail.com>"

--- a/pipenv/vendor/pyparsing/actions.py
+++ b/pipenv/vendor/pyparsing/actions.py
@@ -55,7 +55,7 @@ def replace_with(repl_str):
         na = one_of("N/A NA").set_parse_action(replace_with(math.nan))
         term = na | num
 
-        term[1, ...].parse_string("324 234 N/A 234") # -> [324, 234, nan, 234]
+        OneOrMore(term).parse_string("324 234 N/A 234") # -> [324, 234, nan, 234]
     """
     return lambda s, l, t: [repl_str]
 

--- a/pipenv/vendor/pyparsing/diagram/template.jinja2
+++ b/pipenv/vendor/pyparsing/diagram/template.jinja2
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+    {% if not head %}
+        <style type="text/css">
+            .railroad-heading {
+                font-family: monospace;
+            }
+        </style>
+    {% else %}
+        {{ hear | safe }}
+    {% endif %}
+</head>
+<body>
+{{ body | safe }}
+{% for diagram in diagrams %}
+    <div class="railroad-group">
+        <h1 class="railroad-heading">{{ diagram.title }}</h1>
+        <div class="railroad-description">{{ diagram.text }}</div>
+        <div class="railroad-svg">
+            {{ diagram.svg }}
+        </div>
+    </div>
+{% endfor %}
+</body>
+</html>

--- a/pipenv/vendor/pyparsing/exceptions.py
+++ b/pipenv/vendor/pyparsing/exceptions.py
@@ -2,7 +2,7 @@
 
 import re
 import sys
-import typing
+from typing import Optional
 
 from .util import col, line, lineno, _collapse_string_to_ranges
 from .unicode import pyparsing_unicode as ppu
@@ -25,7 +25,7 @@ class ParseBaseException(Exception):
         self,
         pstr: str,
         loc: int = 0,
-        msg: typing.Optional[str] = None,
+        msg: Optional[str] = None,
         elem=None,
     ):
         self.loc = loc

--- a/pipenv/vendor/pyparsing/helpers.py
+++ b/pipenv/vendor/pyparsing/helpers.py
@@ -1,7 +1,6 @@
 # helpers.py
 import html.entities
 import re
-import typing
 
 from . import __diag__
 from .core import *
@@ -15,8 +14,8 @@ def delimited_list(
     expr: Union[str, ParserElement],
     delim: Union[str, ParserElement] = ",",
     combine: bool = False,
-    min: typing.Optional[int] = None,
-    max: typing.Optional[int] = None,
+    min: OptionalType[int] = None,
+    max: OptionalType[int] = None,
     *,
     allow_trailing_delim: bool = False,
 ) -> ParserElement:
@@ -70,9 +69,9 @@ def delimited_list(
 
 def counted_array(
     expr: ParserElement,
-    int_expr: typing.Optional[ParserElement] = None,
+    int_expr: OptionalType[ParserElement] = None,
     *,
-    intExpr: typing.Optional[ParserElement] = None,
+    intExpr: OptionalType[ParserElement] = None,
 ) -> ParserElement:
     """Helper to define a counted list of expressions.
 
@@ -186,9 +185,7 @@ def match_previous_expr(expr: ParserElement) -> ParserElement:
         def must_match_these_tokens(s, l, t):
             theseTokens = _flatten(t.as_list())
             if theseTokens != matchTokens:
-                raise ParseException(
-                    s, l, "Expected {}, found{}".format(matchTokens, theseTokens)
-                )
+                raise ParseException(s, l, "Expected {}, found{}".format(matchTokens, theseTokens))
 
         rep.set_parse_action(must_match_these_tokens, callDuringTry=True)
 
@@ -198,7 +195,7 @@ def match_previous_expr(expr: ParserElement) -> ParserElement:
 
 
 def one_of(
-    strs: Union[typing.Iterable[str], str],
+    strs: Union[IterableType[str], str],
     caseless: bool = False,
     use_regex: bool = True,
     as_keyword: bool = False,
@@ -313,7 +310,7 @@ def one_of(
 
             return ret
 
-        except re.error:
+        except sre_constants.error:
             warnings.warn(
                 "Exception creating Regex for one_of, building MatchFirst", stacklevel=2
             )
@@ -338,7 +335,7 @@ def dict_of(key: ParserElement, value: ParserElement) -> ParserElement:
 
         text = "shape: SQUARE posn: upper left color: light blue texture: burlap"
         attr_expr = (label + Suppress(':') + OneOrMore(data_word, stop_on=label).set_parse_action(' '.join))
-        print(attr_expr[1, ...].parse_string(text).dump())
+        print(OneOrMore(attr_expr).parse_string(text).dump())
 
         attr_label = label
         attr_value = Suppress(':') + OneOrMore(data_word, stop_on=label).set_parse_action(' '.join)
@@ -353,10 +350,10 @@ def dict_of(key: ParserElement, value: ParserElement) -> ParserElement:
     prints::
 
         [['shape', 'SQUARE'], ['posn', 'upper left'], ['color', 'light blue'], ['texture', 'burlap']]
-        - color: 'light blue'
-        - posn: 'upper left'
-        - shape: 'SQUARE'
-        - texture: 'burlap'
+        - color: light blue
+        - posn: upper left
+        - shape: SQUARE
+        - texture: burlap
         SQUARE
         SQUARE
         {'color': 'light blue', 'shape': 'SQUARE', 'posn': 'upper left', 'texture': 'burlap'}
@@ -462,7 +459,7 @@ def locatedExpr(expr: ParserElement) -> ParserElement:
 def nested_expr(
     opener: Union[str, ParserElement] = "(",
     closer: Union[str, ParserElement] = ")",
-    content: typing.Optional[ParserElement] = None,
+    content: OptionalType[ParserElement] = None,
     ignore_expr: ParserElement = quoted_string(),
     *,
     ignoreExpr: ParserElement = quoted_string(),
@@ -683,8 +680,6 @@ def make_xml_tags(
     return _makeTags(tag_str, True)
 
 
-any_open_tag: ParserElement
-any_close_tag: ParserElement
 any_open_tag, any_close_tag = make_html_tags(
     Word(alphas, alphanums + "_:").set_name("any tag")
 )
@@ -713,7 +708,7 @@ InfixNotationOperatorSpec = Union[
         InfixNotationOperatorArgType,
         int,
         OpAssoc,
-        typing.Optional[ParseAction],
+        OptionalType[ParseAction],
     ],
     Tuple[
         InfixNotationOperatorArgType,
@@ -763,14 +758,10 @@ def infix_notation(
         a tuple or list of functions, this is equivalent to calling
         ``set_parse_action(*fn)``
         (:class:`ParserElement.set_parse_action`)
-    - ``lpar`` - expression for matching left-parentheses; if passed as a
-      str, then will be parsed as Suppress(lpar). If lpar is passed as
-      an expression (such as ``Literal('(')``), then it will be kept in
-      the parsed results, and grouped with them. (default= ``Suppress('(')``)
-    - ``rpar`` - expression for matching right-parentheses; if passed as a
-      str, then will be parsed as Suppress(rpar). If rpar is passed as
-      an expression (such as ``Literal(')')``), then it will be kept in
-      the parsed results, and grouped with them. (default= ``Suppress(')')``)
+    - ``lpar`` - expression for matching left-parentheses
+      (default= ``Suppress('(')``)
+    - ``rpar`` - expression for matching right-parentheses
+      (default= ``Suppress(')')``)
 
     Example::
 
@@ -812,17 +803,9 @@ def infix_notation(
     _FB.__name__ = "FollowedBy>"
 
     ret = Forward()
-    if isinstance(lpar, str):
-        lpar = Suppress(lpar)
-    if isinstance(rpar, str):
-        rpar = Suppress(rpar)
-
-    # if lpar and rpar are not suppressed, wrap in group
-    if not (isinstance(rpar, Suppress) and isinstance(rpar, Suppress)):
-        lastExpr = base_expr | Group(lpar + ret + rpar)
-    else:
-        lastExpr = base_expr | (lpar + ret + rpar)
-
+    lpar = Suppress(lpar)
+    rpar = Suppress(rpar)
+    lastExpr = base_expr | (lpar + ret + rpar)
     for i, operDef in enumerate(op_list):
         opExpr, arity, rightLeftAssoc, pa = (operDef + (None,))[:4]
         if isinstance(opExpr, str_type):
@@ -843,7 +826,7 @@ def infix_notation(
         if rightLeftAssoc not in (OpAssoc.LEFT, OpAssoc.RIGHT):
             raise ValueError("operator must indicate right or left associativity")
 
-        thisExpr: Forward = Forward().set_name(term_name)
+        thisExpr = Forward().set_name(term_name)
         if rightLeftAssoc is OpAssoc.LEFT:
             if arity == 1:
                 matchExpr = _FB(lastExpr + opExpr) + Group(lastExpr + opExpr[1, ...])
@@ -948,7 +931,7 @@ def indentedBlock(blockStatementExpr, indentStack, indent=True, backup_stacks=[]
         assignment = Group(identifier + "=" + rvalue)
         stmt << (funcDef | assignment | identifier)
 
-        module_body = stmt[1, ...]
+        module_body = OneOrMore(stmt)
 
         parseTree = module_body.parseString(data)
         parseTree.pprint()
@@ -1058,9 +1041,7 @@ python_style_comment = Regex(r"#.*").set_name("Python style comment")
 
 # build list of built-in expressions, for future reference if a global default value
 # gets updated
-_builtin_exprs: List[ParserElement] = [
-    v for v in vars().values() if isinstance(v, ParserElement)
-]
+_builtin_exprs = [v for v in vars().values() if isinstance(v, ParserElement)]
 
 
 # pre-PEP8 compatible names

--- a/pipenv/vendor/pyparsing/results.py
+++ b/pipenv/vendor/pyparsing/results.py
@@ -65,9 +65,9 @@ class ParseResults:
         'month' in result -> True
         'minutes' in result -> False
         result.dump() -> ['1999', '/', '12', '/', '31']
-        - day: '31'
-        - month: '12'
-        - year: '1999'
+        - day: 31
+        - month: 12
+        - year: 1999
     """
 
     _null_values: Tuple[Any, ...] = (None, [], "", ())
@@ -287,7 +287,7 @@ class ParseResults:
             print(numlist.parse_string("0 123 321")) # -> ['123', '321']
 
             label = Word(alphas)
-            patt = label("LABEL") + Word(nums)[1, ...]
+            patt = label("LABEL") + OneOrMore(Word(nums))
             print(patt.parse_string("AAB 123 321").dump())
 
             # Use pop() in a parse action to remove named result (note that corresponding value is not
@@ -301,7 +301,7 @@ class ParseResults:
         prints::
 
             ['AAB', '123', '321']
-            - LABEL: 'AAB'
+            - LABEL: AAB
 
             ['AAB', '123', '321']
         """
@@ -394,7 +394,7 @@ class ParseResults:
 
         Example::
 
-            patt = Word(alphas)[1, ...]
+            patt = OneOrMore(Word(alphas))
 
             # use a parse action to append the reverse of the matched strings, to make a palindrome
             def make_palindrome(tokens):
@@ -487,7 +487,7 @@ class ParseResults:
 
         Example::
 
-            patt = Word(alphas)[1, ...]
+            patt = OneOrMore(Word(alphas))
             result = patt.parse_string("sldkj lsdkj sldkj")
             # even though the result prints in string-like form, it is actually a pyparsing ParseResults
             print(type(result), result) # -> <class 'pyparsing.ParseResults'> ['sldkj', 'lsdkj', 'sldkj']
@@ -554,7 +554,7 @@ class ParseResults:
             user_data = (Group(house_number_expr)("house_number")
                         | Group(ssn_expr)("ssn")
                         | Group(integer)("age"))
-            user_info = user_data[1, ...]
+            user_info = OneOrMore(user_data)
 
             result = user_info.parse_string("22 111-22-3333 #221B")
             for item in result:
@@ -603,15 +603,15 @@ class ParseResults:
             integer = Word(nums)
             date_str = integer("year") + '/' + integer("month") + '/' + integer("day")
 
-            result = date_str.parse_string('1999/12/31')
+            result = date_str.parse_string('12/31/1999')
             print(result.dump())
 
         prints::
 
-            ['1999', '/', '12', '/', '31']
-            - day: '31'
-            - month: '12'
-            - year: '1999'
+            ['12', '/', '31', '/', '1999']
+            - day: 1999
+            - month: 31
+            - year: 12
         """
         out = []
         NL = "\n"

--- a/pipenv/vendor/pyparsing/testing.py
+++ b/pipenv/vendor/pyparsing/testing.py
@@ -1,7 +1,7 @@
 # testing.py
 
 from contextlib import contextmanager
-import typing
+from typing import Optional
 
 from .core import (
     ParserElement,
@@ -237,12 +237,12 @@ class pyparsing_test:
     @staticmethod
     def with_line_numbers(
         s: str,
-        start_line: typing.Optional[int] = None,
-        end_line: typing.Optional[int] = None,
+        start_line: Optional[int] = None,
+        end_line: Optional[int] = None,
         expand_tabs: bool = True,
         eol_mark: str = "|",
-        mark_spaces: typing.Optional[str] = None,
-        mark_control: typing.Optional[str] = None,
+        mark_spaces: Optional[str] = None,
+        mark_control: Optional[str] = None,
     ) -> str:
         """
         Helpful method for debugging a parser - prints a string with line and column numbers.

--- a/pipenv/vendor/pyparsing/unicode.py
+++ b/pipenv/vendor/pyparsing/unicode.py
@@ -120,18 +120,7 @@ class pyparsing_unicode(unicode_set):
     A namespace class for defining common language unicode_sets.
     """
 
-    # fmt: off
-
-    # define ranges in language character sets
-    _ranges: UnicodeRangeList = [
-        (0x0020, sys.maxunicode),
-    ]
-
-    class BasicMultilingualPlane(unicode_set):
-        "Unicode set for the Basic Multilingual Plane"
-        _ranges: UnicodeRangeList = [
-            (0x0020, 0xFFFF),
-        ]
+    _ranges: UnicodeRangeList = [(32, sys.maxunicode)]
 
     class Latin1(unicode_set):
         "Unicode set for Latin-1 Unicode Character Range"
@@ -289,13 +278,11 @@ class pyparsing_unicode(unicode_set):
 
     class CJK(Chinese, Japanese, Hangul):
         "Unicode set for combined Chinese, Japanese, and Korean (CJK) Unicode Character Range"
+        pass
 
     class Thai(unicode_set):
         "Unicode set for Thai Unicode Character Range"
-        _ranges: UnicodeRangeList = [
-            (0x0E01, 0x0E3A),
-            (0x0E3F, 0x0E5B)
-        ]
+        _ranges: UnicodeRangeList = [(0x0E01, 0x0E3A), (0x0E3F, 0x0E5B)]
 
     class Arabic(unicode_set):
         "Unicode set for Arabic Unicode Character Range"
@@ -321,12 +308,7 @@ class pyparsing_unicode(unicode_set):
 
     class Devanagari(unicode_set):
         "Unicode set for Devanagari Unicode Character Range"
-        _ranges: UnicodeRangeList = [
-            (0x0900, 0x097F),
-            (0xA8E0, 0xA8FF)
-        ]
-
-    # fmt: on
+        _ranges: UnicodeRangeList = [(0x0900, 0x097F), (0xA8E0, 0xA8FF)]
 
 
 pyparsing_unicode.Japanese._ranges = (
@@ -335,9 +317,7 @@ pyparsing_unicode.Japanese._ranges = (
     + pyparsing_unicode.Japanese.Katakana._ranges
 )
 
-pyparsing_unicode.BMP = pyparsing_unicode.BasicMultilingualPlane
-
-# add language identifiers using language Unicode
+# define ranges in language character sets
 pyparsing_unicode.العربية = pyparsing_unicode.Arabic
 pyparsing_unicode.中文 = pyparsing_unicode.Chinese
 pyparsing_unicode.кириллица = pyparsing_unicode.Cyrillic

--- a/pipenv/vendor/pythonfinder/models/path.py
+++ b/pipenv/vendor/pythonfinder/models/path.py
@@ -11,7 +11,7 @@ from itertools import chain
 
 import pipenv.vendor.attr as attr
 import pipenv.vendor.six as six
-from pipenv.vendor.pyparsing.core import cached_property
+from pipenv.patched.pip._vendor.distlib.util import cached_property
 
 from ..compat import Path, fs_str
 from ..environment import (

--- a/pipenv/vendor/requirementslib/models/requirements.py
+++ b/pipenv/vendor/requirementslib/models/requirements.py
@@ -15,7 +15,7 @@ from urllib.parse import unquote
 
 import pipenv.vendor.attr as attr
 import pipenv.vendor.pip_shims as pip_shims
-from pipenv.vendor.pyparsing.core import cached_property
+from pipenv.patched.pip._vendor.distlib.util import cached_property
 from pipenv.patched.pip._vendor.packaging.markers import Marker
 from pipenv.patched.pip._vendor.packaging.requirements import Requirement as PackagingRequirement
 from pipenv.patched.pip._vendor.packaging.specifiers import (

--- a/pipenv/vendor/vendor.txt
+++ b/pipenv/vendor/vendor.txt
@@ -17,7 +17,7 @@ pipdeptree==2.2.1
 platformdirs==2.4.0
 plette[validation]==0.2.3
 ptyprocess==0.7.0
-pyparsing==3.0.9
+pyparsing==3.0.7
 python-dateutil==2.8.2
 python-dotenv==0.19.0
 pythonfinder==1.2.10

--- a/tasks/vendoring/__init__.py
+++ b/tasks/vendoring/__init__.py
@@ -62,6 +62,7 @@ LIBRARY_RENAMES = {
     "requests": "pipenv.patched.pip._vendor.requests",
     "packaging": "pipenv.patched.pip._vendor.packaging",
     "urllib3": "pipenv.patched.pip._vendor.urllib3",
+    "zipp": "pipenv.vendor.zipp",
 }
 
 GLOBAL_REPLACEMENT = [
@@ -78,7 +79,7 @@ GLOBAL_REPLACEMENT = [
     ),
     (
         r"from cached_property import cached_property",
-        r"from pipenv.vendor.pyparsing.core import cached_property",
+        r"from pipenv.patched.pip._vendor.distlib.util import cached_property",
     ),
     (r"(?<!\.)pep517\.envbuild", r"envbuild"),
     (r"(?<!\.)pep517\.wrappers", r"wrappers"),


### PR DESCRIPTION
I began to wonder if upgrading `pyparsing` isn't what set off the sporadic test failure on those two deps_to_pip tests.  The reason I wonder about this is the `requirementslib` build never did pass when I unpinned `pyparsing`:  https://github.com/sarugaku/requirementslib/pull/327

Also, when I re-ran vendoring the first time it reverted the `zipp` import and so I fixed that in the vendoring script + the old version of pyparsing we used doesn't have cached_property so I adjusted that part of vendoring too.


