### PR TITLE
Fix: try python3 before python in `install --system` (#5296)

### DIFF
--- a/news/5296.bugfix.rst
+++ b/news/5296.bugfix.rst
@@ -1,0 +1,1 @@
+Fix an issue when using ``pipenv install --system`` on systems that having the ``python`` executable pointing to Python 2 and a Python 3 executable being ``python3``.

--- a/pipenv/utils/shell.py
+++ b/pipenv/utils/shell.py
@@ -445,7 +445,7 @@ def project_python(project, system=False):
     if not system:
         python = project._which("python")
     else:
-        interpreters = [system_which(p) for p in ("python", "python3")]
+        interpreters = [system_which(p) for p in ("python3", "python")]
         interpreters = [i for i in interpreters if i]  # filter out not found interpreters
         python = interpreters[0] if interpreters else None
     if not python:

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -458,3 +458,17 @@ twine = "*"
         sources = [{}]
         with pytest.raises(PipenvUsageError):
             indexes.prepare_pip_source_args(sources, pip_args=None)
+
+    @pytest.mark.utils
+    def test_project_python_tries_python3_before_python_if_system_is_true(self):
+        def mock_shutil_which(command, path=None):
+            if command != "python3":
+                return f"/usr/bin/{command}"
+            return "/usr/local/bin/python3"
+
+        with mock.patch("pipenv.utils.shell.shutil.which", wraps=mock_shutil_which):
+            # Setting project to None as system=True doesn't use it
+            project = None
+            python = shell.project_python(project, system=True)
+
+        assert python == "/usr/local/bin/python3"


### PR DESCRIPTION
Fix a regression from commit dbea3f5 where `pip install --system` tries
to install using the `python` executable first which, on some systems
may point to Python 2.  Instead try `python3` first.

Thank you for contributing to Pipenv!


### The issue

As explained in #5296 the is a regression whereby `pipenv install --system` will try `$(which python)` if it exists instead of `$(which python3)` and on some systems `python` points to Python 2, which will fail with `SyntaxError`.


### The fix

The proposed fix is to try `python3` first, then `python` if `python3` fails.


### The checklist

* [x] Associated issue
* [x] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.
