### PR TITLE
Revert "Fix nondeterminism with environment markers #5239 (#5286)"

### DIFF
--- a/news/5239.bugfix.rst
+++ b/news/5239.bugfix.rst
@@ -1,1 +1,0 @@
-Fix nondeterminism with environment markers #5239


### PR DESCRIPTION
This reverts commit 4b9fc02a2561db47585e0fd822ada6dae6a49943.

@oz123 @bakhtiary -- this reverts: https://github.com/pypa/pipenv/pull/5286

because the change made here is actually fixing the issue and @dqkqd did some testing without this changeset and it was not required for fixing the issue:  https://github.com/pypa/pipenv/pull/5299#issuecomment-1228731246

I appreciate your effort to make pipenv better, please keep it up!   In this case, given some additional comments that came in on that PR and the added complexity that was not required, I think we should revert it.