### PR TITLE
Fixes checking constraint throws deprecation messages.

### DIFF
--- a/news/5309.bugfix.rst
+++ b/news/5309.bugfix.rst
@@ -1,1 +1,1 @@
-Fix 5273, use our own method for checking if a package is a valid constraint.
+Fix #5273, use our own method for checking if a package is a valid constraint.

--- a/news/5309.bugfix.rst
+++ b/news/5309.bugfix.rst
@@ -1,0 +1,1 @@
+Fix 5273, use our own method for checking if a package is a valid constraint.

--- a/pipenv/utils/dependencies.py
+++ b/pipenv/utils/dependencies.py
@@ -4,7 +4,10 @@ from typing import Mapping, Sequence
 
 from pipenv.patched.pip._vendor.packaging.markers import Marker
 from pipenv.patched.pip._vendor.packaging.version import parse
-from pipenv.vendor.requirementslib.models.requirements import Requirement
+from pipenv.vendor.requirementslib.models.requirements import (
+    InstallRequirement,
+    Requirement,
+)
 
 from .constants import SCHEME_LIST, VCS_LIST
 from .shell import temp_path
@@ -270,16 +273,14 @@ def convert_deps_to_pip(
 
 def get_constraints_from_deps(deps):
     """Get contraints from Pipfile-formatted dependency"""
-    from pipenv.patched.pip._internal.req.req_install import (
-        check_invalid_constraint_type,
-    )
-    from pipenv.vendor.requirementslib.models.requirements import Requirement
+
+    def is_constraints(dep: InstallRequirement) -> bool:
+        return dep.name and not dep.editable and not dep.extras
 
     constraints = []
     for dep_name, dep in deps.items():
         new_dep = Requirement.from_pipfile(dep_name, dep)
-        problem = check_invalid_constraint_type(new_dep.as_ireq())
-        if not problem:
+        if is_constraints(new_dep.as_ireq()):
             c = new_dep.as_line().strip()
             constraints.append(c)
     return constraints


### PR DESCRIPTION
Thank you for contributing to Pipenv!


### The issue
Fix https://github.com/pypa/pipenv/issues/5273. 
This is a bug from commit https://github.com/pypa/pipenv/commit/640612d0d76a57e597517a1811c400e231f4cf1b. Because `check_invalid_constraint_type` from `pip` throws `PipDeprecationWarning`.

### The fix
Create our own method for checking if package is constraint or not.

### The checklist

* [x] Associated issue
* [x] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.