### PR TITLE
Use a context manager to handle the temporary constraints file

### DIFF
--- a/news/5316.trivial.rst
+++ b/news/5316.trivial.rst
@@ -1,0 +1,1 @@
+Use context managers when working with the temporary constraints file.

--- a/pipenv/resolver.py
+++ b/pipenv/resolver.py
@@ -127,9 +127,8 @@ def handle_parsed_args(parsed):
         os.environ["PIP_RESOLVER_DEBUG"] = ""
     os.environ["PIPENV_VERBOSITY"] = str(parsed.verbose)
     if parsed.constraints_file:
-        constraints = open(parsed.constraints_file)
-        file_constraints = constraints.read().strip().split("\n")
-        constraints.close()
+        with open(parsed.constraints_file) as constraints:
+            file_constraints = constraints.read().strip().split("\n")
         os.unlink(parsed.constraints_file)
         parsed.packages += sorted(file_constraints)
     return parsed

--- a/pipenv/utils/resolver.py
+++ b/pipenv/utils/resolver.py
@@ -1026,11 +1026,10 @@ def venv_resolve_deps(
             sp.write(decode_for_output("Building requirements..."))
             deps = convert_deps_to_pip(deps, project, include_index=True)
             constraints = set(deps)
-            constraints_file = tempfile.NamedTemporaryFile(
+            with tempfile.NamedTemporaryFile(
                 mode="w+", prefix="pipenv", suffix="constraints.txt", delete=False
-            )
-            constraints_file.write(str("\n".join(constraints)))
-            constraints_file.close()
+            ) as constraints_file:
+                constraints_file.write(str("\n".join(constraints)))
             cmd.append("--constraints-file")
             cmd.append(constraints_file.name)
             sp.write(decode_for_output("Resolving dependencies..."))


### PR DESCRIPTION
Change #5313 to use a context manager as best practices suggest.