### PR TITLE
Revert "Fixes pipenv lock nondeterminism with environment markers (#5299)"

### DIFF
--- a/pipenv/utils/resolver.py
+++ b/pipenv/utils/resolver.py
@@ -644,7 +644,6 @@ class Resolver:
             # Only use default_constraints when installing dev-packages
             if self.dev:
                 self._constraints += self.default_constraints
-            self._constraints.sort(key=lambda ireq: ireq.name)
         return self._constraints
 
     @contextlib.contextmanager


### PR DESCRIPTION
This reverts commit d33f4ec541bfb814be38539984ebcd6ca6035ad5.

Sometimes ireq.name is None.  Also noting that I added sorting in a different spot in this PR yesterday:  https://github.com/pypa/pipenv/pull/5313/files#diff-3542045ed7f41738cd4519e02753c9e83af5654c56c124598f0fbbd82405ec49R134
