### PR TITLE
Documentation: Fix Docker example in Basic Usage

### DIFF
--- a/docs/basics.rst
+++ b/docs/basics.rst
@@ -427,7 +427,7 @@ doing a multi stage build for your application::
   # Tell pipenv to create venv in the current directory
   ENV PIPENV_VENV_IN_PROJECT=1
 
-  # Pipefile contains requests
+  # Pipfile contains requests
   ADD Pipfile.lock Pipfile /usr/src/
 
   WORKDIR /usr/src
@@ -445,22 +445,23 @@ doing a multi stage build for your application::
 
   FROM docker.io/python:3.9 AS runtime
 
-  RUN mkdir -v /usr/src/venv
+  RUN mkdir -v /usr/src/.venv
 
-  COPY --from=builder /usr/src/.venv/ /usr/src/venv/
+  COPY --from=builder /usr/src/.venv/ /usr/src/.venv/
 
-  RUN /usr/src/venv/bin/python -c "import requests; print(requests.__version__)"
+  RUN /usr/src/.venv/bin/python -c "import requests; print(requests.__version__)"
 
   # HERE GOES ANY CODE YOU NEED TO ADD TO CREATE YOUR APPLICATION'S IMAGE
   # For example
   # RUN apt install -y libcurl3-gnutls
   # RUN adduser --uid 123123 coolio
+  # ADD run.py /usr/src/
 
   WORKDIR /usr/src/
 
   USER coolio
 
-  CMD ["./venv/bin/python", "-m", "run.py"]
+  CMD ["./.venv/bin/python", "-m", "run.py"]
 
 .. Note::
 


### PR DESCRIPTION
### The issue

The Docker example in the Basic Usage document needed a bit of TLC. Because the name of the virtualenv changed between the builder and the runtime container, Python was unable to find itself or its site-packages directory:

```
coolio@674956d0c53e:/usr/src$ ./venv/bin/pip
bash: ./venv/bin/pip: /usr/src/.venv/bin/python: bad interpreter: No such file or directory
```

### The fix

To fix this, I changed the directory of the virtualenv in the runtime container to .venv which matches the builder.

I also added an example of how to get run.py into the container in the first place, since we run it later.