### PR TITLE
Fix issue where a file install is included with the hashed requirements.

### DIFF
--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -1592,7 +1592,12 @@ def pip_install_deps(
     )
     for requirement in deps:
         ignore_hash = ignore_hashes
-        vcs_or_editable = requirement.is_vcs or requirement.vcs or requirement.editable
+        vcs_or_editable = (
+            requirement.is_vcs
+            or requirement.vcs
+            or requirement.editable
+            or requirement.is_file_or_url
+        )
         if vcs_or_editable:
             ignore_hash = True
         if requirement and vcs_or_editable:


### PR DESCRIPTION
Thank you for contributing to Pipenv!

Fixes #5307

### The issue

file installs can sometimes be caught into the standard requirements, which require hashes unless `--skip-lock` is passed.