### PR TITLE
Apply fix to constraints generation based on fact that pip resolver does not allowe unnamed constraints.

### DIFF
--- a/news/5273.bugfix.rst
+++ b/news/5273.bugfix.rst
@@ -1,0 +1,1 @@
+Fix issue where unnamed constraints were provided but which are not allowed by ``pip`` resolver.

--- a/pipenv/utils/dependencies.py
+++ b/pipenv/utils/dependencies.py
@@ -280,7 +280,7 @@ def get_constraints_from_deps(deps):
     constraints = []
     for dep_name, dep in deps.items():
         new_dep = Requirement.from_pipfile(dep_name, dep)
-        if is_constraints(new_dep.as_ireq()):
+        if new_dep.is_named and is_constraints(new_dep.as_ireq()):
             c = new_dep.as_line().strip()
             constraints.append(c)
     return constraints


### PR DESCRIPTION
Apply fix to constraints generation based on fact that pip resolver does not allowe unnamed constraints.

Fixes #5273