### PR TITLE
Respect `disable_pip_input` setting from Pipfile

### DIFF
--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -844,7 +844,12 @@ def do_install_dependencies(
     }
 
     batch_install(
-        project, normal_deps, procs, failed_deps_queue, requirements_dir, **install_kwargs
+        project,
+        normal_deps,
+        procs,
+        failed_deps_queue,
+        requirements_dir,
+        **install_kwargs,
     )
 
     if not procs.empty():
@@ -1362,7 +1367,7 @@ def get_pip_args(
         ],
         "src_dir": src_dir,
     }
-    arg_set = ["--no-input"]
+    arg_set = ["--no-input"] if project.settings.get("disable_pip_input", True) else []
     for key in arg_map.keys():
         if key in locals() and locals().get(key):
             arg_set.extend(arg_map.get(key))
@@ -1611,7 +1616,8 @@ def pip_install_deps(
         )
         if project.s.is_verbose():
             click.echo(
-                f"Writing supplied requirement line to temporary file: {line!r}", err=True
+                f"Writing supplied requirement line to temporary file: {line!r}",
+                err=True,
             )
         target = editable_requirements if vcs_or_editable else standard_requirements
         target.write(vistir.misc.to_bytes(line))


### PR DESCRIPTION
### The issue

https://github.com/pypa/pipenv/pull/5301 broke keyring support again until https://github.com/pypa/pip/pull/11029 gets merged into Pip and then vendored into Pipenv.

### The fix

This makes `get_pip_args()` respect `disable_pip_input` that was introduced in https://github.com/pypa/pipenv/pull/5036.


### The checklist

* [ ] Associated issue
* [ ] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.
