### PR TITLE
fix for issue where requirement is a file or URL but does conntain hashes.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
   hooks:
   - id: black
 
-- repo: https://gitlab.com/pycqa/flake8
+- repo: https://github.com/PyCQA/flake8
   rev: 4.0.1
   hooks:
   - id: flake8

--- a/news/5306.bugfix.rst
+++ b/news/5306.bugfix.rst
@@ -1,0 +1,1 @@
+Fix the issue from ``2022.9.2`` where tarball URL packages were being skipped on batch_install.

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -1601,7 +1601,7 @@ def pip_install_deps(
             requirement.is_vcs
             or requirement.vcs
             or requirement.editable
-            or requirement.is_file_or_url
+            or (requirement.is_file_or_url and not requirement.hashes)
         )
         if vcs_or_editable:
             ignore_hash = True
@@ -1627,10 +1627,25 @@ def pip_install_deps(
 
     cmds = []
     files = []
-    standard_deps = list(filter(lambda d: not (d.is_vcs or d.vcs or d.editable), deps))
+    standard_deps = list(
+        filter(
+            lambda d: not (
+                d.is_vcs or d.vcs or d.editable or (d.is_file_or_url and not d.hashes)
+            ),
+            deps,
+        )
+    )
     if standard_deps:
         files.append(standard_requirements)
-    editable_deps = list(filter(lambda d: d.is_vcs or d.vcs or d.editable, deps))
+    editable_deps = list(
+        filter(
+            lambda d: d.is_vcs
+            or d.vcs
+            or d.editable
+            or (d.is_file_or_url and not d.hashes),
+            deps,
+        )
+    )
     if editable_deps:
         files.append(editable_requirements)
     for file in files:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -349,6 +349,8 @@ class _PipenvInstance:
             self.chdir = False or chdir
             self.pipfile_path = p_path
             self._pipfile = _Pipfile(Path(p_path))
+        else:
+            self._pipfile = None
 
     def __enter__(self):
         if self.chdir:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -357,6 +357,8 @@ class _PipenvInstance:
 
     def __exit__(self, *args):
         warn_msg = 'Failed to remove resource: {!r}'
+        if self.pipfile_path:
+            os.remove(self.pipfile_path)
         if self.chdir:
             os.chdir(self.original_dir)
         self.path = None

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -343,6 +343,10 @@ class _PipenvInstance:
 
         if pipfile:
             p_path = os.sep.join([self.path, 'Pipfile'])
+            try:
+                os.remove(p_path)
+            except FileNotFoundError:
+                pass
             with open(p_path, 'a'):
                 os.utime(p_path, None)
 

--- a/tests/integration/test_install_basic.py
+++ b/tests/integration/test_install_basic.py
@@ -558,12 +558,12 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-six = {file = "https://files.pythonhosted.org/packages/71/39/171f1c67cd00715f190ba0b100d606d440a28c93c7714febeca8b79af85e/six-1.16.0.tar.gz"}
+dataclasses-json = {file = "https://files.pythonhosted.org/packages/85/94/1b30216f84c48b9e0646833f6f2dd75f1169cc04dc45c48fe39e644c89d5/dataclasses-json-0.5.7.tar.gz"}
                     """.strip()
             f.write(contents)
         c = p.pipenv("lock")
         assert c.returncode == 0
         c = p.pipenv("sync")
         assert c.returncode == 0
-        c = p.pipenv("run python -c 'import six'")
+        c = p.pipenv("run python -c 'from dataclasses_json import dataclass_json'")
         assert c.returncode == 0

--- a/tests/integration/test_install_basic.py
+++ b/tests/integration/test_install_basic.py
@@ -545,3 +545,25 @@ def test_install_does_not_exclude_packaging(PipenvInstance):
         assert c.returncode == 0
         c = p.pipenv("run python -c 'from dataclasses_json import DataClassJsonMixin'")
         assert c.returncode == 0
+
+
+def test_install_tarball_is_actually_installed(PipenvInstance):
+    """ Test case for Issue 5326"""
+    with PipenvInstance(chdir=True) as p:
+        with open(p.pipfile_path, "w") as f:
+            contents = """
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+six = {file = "https://files.pythonhosted.org/packages/71/39/171f1c67cd00715f190ba0b100d606d440a28c93c7714febeca8b79af85e/six-1.16.0.tar.gz"}
+                    """.strip()
+            f.write(contents)
+        c = p.pipenv("lock")
+        assert c.returncode == 0
+        c = p.pipenv("sync")
+        assert c.returncode == 0
+        c = p.pipenv("run python -c 'import six'")
+        assert c.returncode == 0


### PR DESCRIPTION
there are actually a couple of fixes here, one is that sometimes the file URL contains hashes so we should include that with the group with hashes like we did in `2022.8.31` by accident.  Also the filters after need to detect this additional part of the conditional and that change was missing in #5326.


### The issue

#5306 