### PR TITLE
improve the case of upstream dependencies that mess up markers

### DIFF
--- a/news/5329.bugfix.rst
+++ b/news/5329.bugfix.rst
@@ -1,0 +1,1 @@
+Add error handling for when the installed package setup.py does not contain valid markers.

--- a/pipenv/utils/resolver.py
+++ b/pipenv/utils/resolver.py
@@ -704,11 +704,20 @@ class Resolver:
                 if candidate:
                     requires_python = candidate.link.requires_python
                     if requires_python:
-                        marker = marker_from_specifier(requires_python)
-                        self.markers[result.name] = marker
-                        result.markers = marker
-                        if result.req:
-                            result.req.marker = marker
+                        try:
+
+                            marker = marker_from_specifier(requires_python)
+                            self.markers[result.name] = marker
+                            result.markers = marker
+                            if result.req:
+                                result.req.marker = marker
+                        except TypeError as e:
+                            click.echo(
+                                f"Error generating python marker for {candidate}.  "
+                                f"Is the specifier {requires_python} incorrectly quoted or otherwise wrong?"
+                                f"Full error: {e}",
+                                err=True,
+                            )
             new_tree.add(result)
         self.resolved_tree = new_tree
 


### PR DESCRIPTION
Thank you for contributing to Pipenv!  Replacement of: https://github.com/pypa/pipenv/pull/4982


### The issue

Upstream setup.py can not define the setup.py markers properly, and pipenv will reveal a cryptic error.   This solves for that and allows the installation to move forward without the marker, while alerting the user of the potential problem.