### PR TITLE
Examine the 20 slowest tests and make improvements.

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -264,8 +264,8 @@ class _Pipfile:
         self.path.write_text(self.dumps())
 
     @classmethod
-    def get_fixture_path(cls, path):
-        return Path(__file__).absolute().parent.parent / "test_artifacts" / path
+    def get_fixture_path(cls, path, fixtures="test_artifacts"):
+        return Path(__file__).absolute().parent.parent / fixtures / path
 
     @classmethod
     def get_url(cls, pkg=None, filename=None):

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -158,31 +158,17 @@ def test_pipenv_check(pipenv_instance_private_pypi):
 
 
 @pytest.mark.cli
-def test_pipenv_clean_pip_no_warnings(pipenv_instance_pypi):
+def test_pipenv_clean(pipenv_instance_pypi):
     with pipenv_instance_pypi(chdir=True) as p:
         with open('setup.py', 'w') as f:
             f.write('from setuptools import setup; setup(name="empty")')
         c = p.pipenv('install -e .')
         assert c.returncode == 0
-        c = p.pipenv(f'run pip install -i {p.index_url} pytz')
+        c = p.pipenv(f'run pip install -i {p.index_url} six')
         assert c.returncode == 0
         c = p.pipenv('clean')
         assert c.returncode == 0
-        assert c.stdout, f"{c.stdout} -- STDERR: {c.stderr}"
-
-
-@pytest.mark.cli
-def test_pipenv_clean_pip_warnings(pipenv_instance_pypi):
-    with pipenv_instance_pypi(chdir=True) as p:
-        with open('setup.py', 'w') as f:
-            f.write('from setuptools import setup; setup(name="empty")')
-        # create a fake git repo to trigger a pip freeze warning
-        os.mkdir('.git')
-        c = p.pipenv(f"run pip install -i {p.index_url} -e .")
-        assert c.returncode == 0
-        c = p.pipenv('clean')
-        assert c.returncode == 0
-        assert c.stderr
+        assert 'six' in c.stdout, f"{c.stdout} -- STDERR: {c.stderr}"
 
 
 @pytest.mark.cli

--- a/tests/integration/test_install_basic.py
+++ b/tests/integration/test_install_basic.py
@@ -395,7 +395,7 @@ def test_install_venv_project_directory(pipenv_instance_pypi):
 @pytest.mark.system
 def test_system_and_deploy_work(pipenv_instance_private_pypi):
     with pipenv_instance_private_pypi(chdir=True) as p:
-        c = p.pipenv("install tablib")
+        c = p.pipenv("install urllib3")
         assert c.returncode == 0
         c = p.pipenv("--rm")
         assert c.returncode == 0
@@ -403,17 +403,6 @@ def test_system_and_deploy_work(pipenv_instance_private_pypi):
         assert c.returncode == 0
         c = p.pipenv("install --system --deploy")
         assert c.returncode == 0
-        c = p.pipenv("--rm")
-        assert c.returncode == 0
-        Path(p.pipfile_path).write_text(
-            """
-[packages]
-tablib = "*"
-        """.strip()
-        )
-        c = p.pipenv("install --system")
-        assert c.returncode == 0
-
 
 @pytest.mark.basic
 @pytest.mark.install

--- a/tests/integration/test_install_basic.py
+++ b/tests/integration/test_install_basic.py
@@ -1,50 +1,23 @@
 import os
-import mock
-
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
 import pytest
 
-from flaky import flaky
-
 from pipenv.utils.processes import subprocess_run
 from pipenv.utils.shell import temp_environ
 
 
-@pytest.mark.setup
-@pytest.mark.basic
-@pytest.mark.install
-def test_basic_setup(pipenv_instance_private_pypi):
-    with pipenv_instance_private_pypi() as p:
-        with pipenv_instance_private_pypi(pipfile=False) as p:
-            c = p.pipenv("install requests")
-            assert c.returncode == 0
-
-            assert "requests" in p.pipfile["packages"]
-            assert "requests" in p.lockfile["default"]
-            assert "chardet" in p.lockfile["default"]
-            assert "idna" in p.lockfile["default"]
-            assert "urllib3" in p.lockfile["default"]
-            assert "certifi" in p.lockfile["default"]
-
-
-@flaky
 @pytest.mark.basic
 @pytest.mark.install
 def test_basic_install(pipenv_instance_private_pypi):
     with pipenv_instance_private_pypi() as p:
-        c = p.pipenv("install requests")
+        c = p.pipenv("install six")
         assert c.returncode == 0
-        assert "requests" in p.pipfile["packages"]
-        assert "requests" in p.lockfile["default"]
-        assert "chardet" in p.lockfile["default"]
-        assert "idna" in p.lockfile["default"]
-        assert "urllib3" in p.lockfile["default"]
-        assert "certifi" in p.lockfile["default"]
+        assert "six" in p.pipfile["packages"]
+        assert "six" in p.lockfile["default"]
 
 
-@flaky
 @pytest.mark.basic
 @pytest.mark.install
 def test_mirror_install(pipenv_instance_pypi):
@@ -65,7 +38,6 @@ def test_mirror_install(pipenv_instance_pypi):
         assert "dataclasses-json" in p.lockfile["default"]
 
 
-@flaky
 @pytest.mark.basic
 @pytest.mark.install
 @pytest.mark.needs_internet
@@ -77,7 +49,6 @@ def test_bad_mirror_install(pipenv_instance_pypi):
         assert c.returncode != 0
 
 
-@flaky
 @pytest.mark.dev
 @pytest.mark.run
 def test_basic_dev_install(pipenv_instance_pypi):
@@ -91,7 +62,6 @@ def test_basic_dev_install(pipenv_instance_pypi):
         assert c.returncode == 0
 
 
-@flaky
 @pytest.mark.dev
 @pytest.mark.basic
 @pytest.mark.install
@@ -119,7 +89,6 @@ tablib = "*"
         assert c.returncode == 0
 
 
-@flaky
 @pytest.mark.basic
 @pytest.mark.install
 def test_install_without_dev_section(pipenv_instance_pypi):
@@ -140,7 +109,6 @@ six = "*"
         assert c.returncode == 0
 
 
-@flaky
 @pytest.mark.lock
 @pytest.mark.extras
 @pytest.mark.install
@@ -158,7 +126,6 @@ def test_extras_install(pipenv_instance_private_pypi):
         assert "pysocks" in p.lockfile["default"]
 
 
-@flaky
 @pytest.mark.pin
 @pytest.mark.basic
 @pytest.mark.install
@@ -176,7 +143,6 @@ dataclasses-json = "==0.5.7"
         assert "dataclasses-json" in p.lockfile["default"]
 
 
-@flaky
 @pytest.mark.basic
 @pytest.mark.install
 @pytest.mark.resolver
@@ -195,7 +161,6 @@ def test_backup_resolver(pipenv_instance_private_pypi):
         assert "ibm-db-sa-py3" in p.lockfile["default"]
 
 
-@flaky
 @pytest.mark.run
 @pytest.mark.alt
 def test_alternative_version_specifier(pipenv_instance_private_pypi):
@@ -203,31 +168,26 @@ def test_alternative_version_specifier(pipenv_instance_private_pypi):
         with open(p.pipfile_path, "w") as f:
             contents = """
 [packages]
-requests = {version = "*"}
+six = {version = "*"}
             """.strip()
             f.write(contents)
 
         c = p.pipenv("install")
         assert c.returncode == 0
 
-        assert "requests" in p.lockfile["default"]
-        assert "idna" in p.lockfile["default"]
-        assert "urllib3" in p.lockfile["default"]
-        assert "certifi" in p.lockfile["default"]
-        assert "chardet" in p.lockfile["default"]
+        assert "six" in p.lockfile["default"]
 
-        c = p.pipenv('run python -c "import requests; import idna; import certifi;"')
+        c = p.pipenv('run python -c "import six;"')
         assert c.returncode == 0
 
 
-@flaky
 @pytest.mark.run
 @pytest.mark.alt
 def test_outline_table_specifier(pipenv_instance_private_pypi):
     with pipenv_instance_private_pypi() as p:
         with open(p.pipfile_path, "w") as f:
             contents = """
-[packages.requests]
+[packages.six]
 version = "*"
             """.strip()
             f.write(contents)
@@ -235,13 +195,9 @@ version = "*"
         c = p.pipenv("install")
         assert c.returncode == 0
 
-        assert "requests" in p.lockfile["default"]
-        assert "idna" in p.lockfile["default"]
-        assert "urllib3" in p.lockfile["default"]
-        assert "certifi" in p.lockfile["default"]
-        assert "chardet" in p.lockfile["default"]
+        assert "six" in p.lockfile["default"]
 
-        c = p.pipenv('run python -c "import requests; import idna; import certifi;"')
+        c = p.pipenv('run python -c "import six;"')
         assert c.returncode == 0
 
 
@@ -450,17 +406,16 @@ version = "*"
 extras = ["socks"]
             """.strip()
             f.write(contents)
-        c = p.pipenv("install flask")
+        c = p.pipenv("install colorama")
         assert c.returncode == 0
         with open(p.pipfile_path) as f:
             contents = f.read()
         assert "[packages.requests]" not in contents
         assert 'six = {version = "*"}' in contents
         assert 'requests = {version = "*"' in contents
-        assert 'flask = "*"' in contents
+        assert 'colorama = "*"' in contents
 
 
-@flaky
 @pytest.mark.dev
 @pytest.mark.basic
 @pytest.mark.install

--- a/tests/integration/test_install_twists.py
+++ b/tests/integration/test_install_twists.py
@@ -167,12 +167,6 @@ Requests = "==2.14.0"   # Inline comment
 """
             f.write(contents)
 
-        c = p.pipenv("install")
-        assert c.returncode == 0
-
-        c = p.pipenv("install requests")
-        assert c.returncode == 0
-        assert "requests" not in p.pipfile["packages"]
         assert p.pipfile["packages"]["Requests"] == "==2.14.0"
         c = p.pipenv("install requests==2.18.4")
         assert c.returncode == 0
@@ -235,22 +229,6 @@ def test_local_zip_file(pipenv_instance_private_pypi, testsroot):
         dep = p.lockfile["default"]["requests"]
 
         assert "file" in dep or "path" in dep
-
-
-@pytest.mark.install
-@pytest.mark.local
-@pytest.mark.local_file
-def test_install_local_file_collision(pipenv_instance_private_pypi):
-    with pipenv_instance_private_pypi() as p:
-        target_package = "alembic"
-        fake_file = os.path.join(p.path, target_package)
-        with open(fake_file, "w") as f:
-            f.write("")
-        c = p.pipenv(f"install {target_package}")
-        assert c.returncode == 0
-        assert target_package in p.pipfile["packages"]
-        assert p.pipfile["packages"][target_package] == "*"
-        assert target_package in p.lockfile["default"]
 
 
 @pytest.mark.urls

--- a/tests/integration/test_install_twists.py
+++ b/tests/integration/test_install_twists.py
@@ -4,7 +4,6 @@ import sys
 from pathlib import Path
 
 import pytest
-from flaky import flaky
 
 from pipenv.utils.shell import mkdir_p, temp_environ
 
@@ -62,7 +61,6 @@ testpipenv = {path = ".", editable = true, extras = ["dev"]}
 @pytest.mark.local
 @pytest.mark.install
 @pytest.mark.needs_internet
-@flaky
 class TestDirectDependencies:
     """Ensure dependency_links are parsed and installed.
 
@@ -92,7 +90,7 @@ setup(
         TestDirectDependencies.helper_dependency_links_install_make_setup(pipenv_instance, deplink)
         c = pipenv_instance.pipenv("install -v -e .")
         assert c.returncode == 0
-        assert "test-private-dependency" in pipenv_instance.lockfile["default"]
+        assert "six" in pipenv_instance.lockfile["default"]
 
     def test_https_dependency_links_install(self, pipenv_instance_pypi):
         """Ensure dependency_links are parsed and installed (needed for private repo dependencies).
@@ -101,23 +99,12 @@ setup(
             os.environ["PIP_NO_BUILD_ISOLATION"] = '1'
             TestDirectDependencies.helper_dependency_links_install_test(
                 p,
-                'test-private-dependency@ git+https://github.com/atzannes/test-private-dependency@v0.1'
-            )
-
-    @pytest.mark.needs_github_ssh
-    def test_ssh_dependency_links_install(self, pipenv_instance_pypi):
-        with temp_environ(), pipenv_instance_pypi(chdir=True) as p:
-            os.environ['PIP_PROCESS_DEPENDENCY_LINKS'] = '1'
-            os.environ["PIP_NO_BUILD_ISOLATION"] = '1'
-            TestDirectDependencies.helper_dependency_links_install_test(
-                p,
-                'test-private-dependency@ git+ssh://git@github.com/atzannes/test-private-dependency@v0.1'
+                'six@ git+https://github.com/benjaminp/six@1.11.0'
             )
 
 
 @pytest.mark.install
 @pytest.mark.multiprocessing
-@flaky
 def test_multiprocess_bug_and_install(pipenv_instance_pypi):
     with temp_environ():
         os.environ["PIPENV_MAX_SUBPROCESS"] = "2"
@@ -128,7 +115,7 @@ def test_multiprocess_bug_and_install(pipenv_instance_pypi):
 [packages]
 pytz = "*"
 six = "*"
-urllib3 = "*"
+dataclasses-json = "*"
                 """.strip()
                 f.write(contents)
 
@@ -137,15 +124,14 @@ urllib3 = "*"
 
             assert "pytz" in p.lockfile["default"]
             assert "six" in p.lockfile["default"]
-            assert "urllib3" in p.lockfile["default"]
+            assert "dataclasses-json" in p.lockfile["default"]
 
-            c = p.pipenv('run python -c "import six; import pytz; import urllib3;"')
+            c = p.pipenv('run python -c "import six; import pytz; import dataclasses_json;"')
             assert c.returncode == 0
 
 
 @pytest.mark.install
 @pytest.mark.sequential
-@flaky
 def test_sequential_mode(pipenv_instance_pypi):
 
     with pipenv_instance_pypi(chdir=True) as p:
@@ -200,7 +186,6 @@ Requests = "==2.14.0"   # Inline comment
             assert "# Inline comment" in contents
 
 
-@flaky
 @pytest.mark.eggs
 @pytest.mark.files
 @pytest.mark.local
@@ -231,19 +216,14 @@ def test_local_package(pipenv_instance_private_pypi, pip_src_dir, testsroot):
 
 @pytest.mark.files
 @pytest.mark.local
-@flaky
-def test_local_zipfiles(pipenv_instance_private_pypi, testsroot):
+def test_local_zip_file(pipenv_instance_private_pypi, testsroot):
     file_name = "requests-2.19.1.tar.gz"
-    # Not sure where travis/appveyor run tests from
-    source_path = os.path.join(testsroot, "test_artifacts", file_name)
 
     with pipenv_instance_private_pypi(chdir=True) as p:
-        # This tests for a bug when installing a zipfile in the current dir
-        destination = os.path.join(p.path, file_name)
-        shutil.copy(source_path, destination)
+        requests_path = p._pipfile.get_fixture_path(f"{file_name}").as_posix()
 
-        c = p.pipenv(f"install {file_name}")
-        os.unlink(destination)
+        # This tests for a bug when installing a zipfile
+        c = p.pipenv(f"install {requests_path}")
         assert c.returncode == 0
         key = [k for k in p.pipfile["packages"].keys()][0]
         dep = p.pipfile["packages"][key]
@@ -257,34 +237,9 @@ def test_local_zipfiles(pipenv_instance_private_pypi, testsroot):
         assert "file" in dep or "path" in dep
 
 
-@pytest.mark.local
-@pytest.mark.files
-@flaky
-def test_relative_paths(pipenv_instance_private_pypi, testsroot):
-    file_name = "requests-2.19.1.tar.gz"
-    source_path = os.path.abspath(os.path.join(testsroot, "test_artifacts", file_name))
-
-    with pipenv_instance_private_pypi() as p:
-        artifact_dir = "artifacts"
-        artifact_path = os.path.join(p.path, artifact_dir)
-        mkdir_p(artifact_path)
-        shutil.copy(source_path, os.path.join(artifact_path, file_name))
-        # Test installing a relative path in a subdirectory
-        c = p.pipenv(f"install {artifact_dir}/{file_name}")
-        os.unlink(f"{artifact_dir}/{file_name}")
-        assert c.returncode == 0
-        key = next(k for k in p.pipfile["packages"].keys())
-        dep = p.pipfile["packages"][key]
-
-        assert "path" in dep
-        assert Path(".", artifact_dir, file_name) == Path(dep["path"])
-        assert c.returncode == 0
-
-
 @pytest.mark.install
 @pytest.mark.local
 @pytest.mark.local_file
-@flaky
 def test_install_local_file_collision(pipenv_instance_private_pypi):
     with pipenv_instance_private_pypi() as p:
         target_package = "alembic"
@@ -334,7 +289,7 @@ def test_multiple_editable_packages_should_not_race(pipenv_instance_private_pypi
     So this test locally installs packages from tarballs that have already been committed in
     the local `pypi` dir to avoid using VCS packages.
     """
-    pkgs = ["requests", "flask", "six", "jinja2"]
+    pkgs = ["six", "jinja2"]
 
     pipfile_string = """
 [dev-packages]
@@ -355,7 +310,7 @@ def test_multiple_editable_packages_should_not_race(pipenv_instance_private_pypi
         c = p.pipenv('install')
         assert c.returncode == 0
 
-        c = p.pipenv('run python -c "import requests, flask, six, jinja2"')
+        c = p.pipenv('run python -c "import jinja2, six"')
         assert c.returncode == 0, c.stderr
 
 

--- a/tests/integration/test_install_uri.py
+++ b/tests/integration/test_install_uri.py
@@ -62,23 +62,6 @@ def test_file_urls_work(pipenv_instance_pypi, pip_src_dir):
         assert "file" in p.pipfile["packages"]["six"]
 
 
-@pytest.mark.urls
-@pytest.mark.files
-@pytest.mark.needs_internet
-def test_local_vcs_urls_work(pipenv_instance_pypi, tmpdir):
-    six_dir = tmpdir.join("six")
-    six_path = Path(six_dir.strpath)
-    with pipenv_instance_pypi(chdir=True) as p:
-        c = subprocess_run(
-            ["git", "clone", "https://github.com/benjaminp/six.git", six_dir.strpath]
-        )
-        assert c.returncode == 0
-
-        c = p.pipenv("install git+{0}#egg=six".format(six_path.as_uri()))
-        assert c.returncode == 0
-        assert "six" in p.pipfile["packages"]
-
-
 @pytest.mark.e
 @pytest.mark.vcs
 @pytest.mark.urls

--- a/tests/integration/test_lock.py
+++ b/tests/integration/test_lock.py
@@ -609,7 +609,13 @@ def test_lock_nested_direct_url(pipenv_instance_private_pypi):
     here along with its own dependencies.
     """
     with pipenv_instance_private_pypi() as p:
-        c = p.pipenv("install -v test_package")
+        contents = """
+        [packages]
+        test_package = "*"
+                """.strip()
+        with open(p.pipfile_path, 'w') as f:
+            f.write(contents)
+        c = p.pipenv("lock")
         assert c.returncode == 0
         assert "vistir" in p.lockfile["default"]
         assert "colorama" in p.lockfile["default"]

--- a/tests/integration/test_lock.py
+++ b/tests/integration/test_lock.py
@@ -512,7 +512,7 @@ def test_lockfile_corrupted(pipenv_instance_pypi):
     with pipenv_instance_pypi() as p:
         with open(p.lockfile_path, 'w') as f:
             f.write('{corrupted}')
-        c = p.pipenv('lock')
+        c = p.pipenv('install')
         assert c.returncode == 0
         assert 'Pipfile.lock is corrupted' in c.stderr
         assert p.lockfile['_meta']
@@ -523,7 +523,7 @@ def test_lockfile_with_empty_dict(pipenv_instance_pypi):
     with pipenv_instance_pypi() as p:
         with open(p.lockfile_path, 'w') as f:
             f.write('{}')
-        c = p.pipenv('lock')
+        c = p.pipenv('install')
         assert c.returncode == 0
         assert 'Pipfile.lock is corrupted' in c.stderr
         assert p.lockfile['_meta']

--- a/tests/integration/test_pipenv.py
+++ b/tests/integration/test_pipenv.py
@@ -27,11 +27,6 @@ flask = "==1.1.2"
 pytest = "==4.6.9"
             """.strip()
             f.write(contents)
-        c = p.pipenv('install --verbose')
-        if c.returncode != 0:
-            assert c.stderr == '' or c.stderr is None
-            assert c.stdout == ''
-        assert c.returncode == 0
         c = p.pipenv('lock')
         assert c.returncode == 0
         with open(p.pipfile_path, 'w') as f:

--- a/tests/integration/test_project.py
+++ b/tests/integration/test_project.py
@@ -150,24 +150,6 @@ six = {{version = "*", index = "pypi"}}
         assert c.returncode == 0
 
 
-@pytest.mark.install
-@pytest.mark.project
-def test_include_editable_packages(pipenv_instance_pypi, testsroot, pathlib_tmpdir):
-    file_name = "tablib-0.12.1.tar.gz"
-    package = pathlib_tmpdir.joinpath("tablib-0.12.1")
-    source_path = os.path.abspath(os.path.join(testsroot, "pypi", "tablib", file_name))
-    with pipenv_instance_pypi(chdir=True) as p:
-        with tarfile.open(source_path, "r:gz") as tarinfo:
-            tarinfo.extractall(path=str(pathlib_tmpdir))
-        c = p.pipenv(f'install -e {package.as_posix()}')
-        assert c.returncode == 0
-        project = Project()
-        assert "tablib" in [
-            package.project_name
-            for package in project.environment.get_installed_packages()
-        ]
-
-
 @pytest.mark.project
 @pytest.mark.virtualenv
 def test_run_in_virtualenv_with_global_context(pipenv_instance_pypi, virtualenv):

--- a/tests/integration/test_requirements.py
+++ b/tests/integration/test_requirements.py
@@ -43,10 +43,10 @@ def test_requirements_generates_requirements_from_lockfile(pipenv_instance_pypi)
 
 
 @pytest.mark.requirements
-def test_requirements_generates_requirements_from_lockfile_multiple_sources(pipenv_instance_pypi):
-    with pipenv_instance_pypi(chdir=True) as p:
-        packages = ('requests', '2.14.0')
-        dev_packages = ('flask', '0.12.2')
+def test_requirements_generates_requirements_from_lockfile_multiple_sources(pipenv_instance_private_pypi):
+    with pipenv_instance_private_pypi(chdir=True) as p:
+        packages = ('six', '1.12.0')
+        dev_packages = ('itsdangerous', '1.1.0')
         with open(p.pipfile_path, 'w') as f:
             contents = f"""
             [[source]]


### PR DESCRIPTION
On my fast laptop these were the 20 slowest tests:

```
259.54s call     tests/integration/test_lock.py::test_complex_lock_with_vcs_deps
254.14s call     tests/integration/test_install_uri.py::test_get_vcs_refs
253.65s call     tests/integration/test_install_twists.py::test_multiple_editable_packages_should_not_race
152.11s call     tests/integration/test_install_twists.py::test_local_zipfiles
137.95s call     tests/integration/test_lock.py::test_lock_editable_vcs_with_extras_without_install
133.73s call     tests/integration/test_lock.py::test_lock_nested_direct_url
133.52s call     tests/integration/test_lock.py::test_lock_editable_vcs_without_install
132.87s call     tests/integration/test_install_uri.py::test_install_editable_git_tag
130.86s call     tests/integration/test_lock.py::test_vcs_lock_respects_top_level_pins
130.70s call     tests/integration/test_uninstall.py::test_uninstall_all_local_files
127.40s call     tests/integration/test_install_twists.py::TestDirectDependencies::test_https_dependency_links_install
127.36s call     tests/integration/test_install_uri.py::test_basic_vcs_install_with_env_var
125.63s call     tests/integration/test_install_uri.py::test_basic_vcs_install
125.47s call     tests/integration/test_project.py::test_include_editable_packages
116.35s call     tests/integration/test_install_uri.py::test_editable_vcs_install
113.39s call     tests/integration/test_lock.py::test_lock_editable_vcs_with_markers_without_install
112.68s call     tests/integration/test_uninstall.py::test_uninstall_all_dev
111.80s call     tests/integration/test_lock.py::test_lock_editable_vcs_with_ref_in_git
109.92s call     tests/integration/test_cli.py::test_pipenv_clean_pip_no_warnings
109.60s call     tests/integration/test_install_twists.py::test_relative_paths
```

Here I examine them, make adjustments to what they should be doing to test (or if they should even exist in a couple cases, due to repeated test cases).   After running the tests again:

 