### PR TITLE
Python specifiers

### DIFF
--- a/pipenv/resolver.py
+++ b/pipenv/resolver.py
@@ -817,9 +817,6 @@ def _main(
     parse_only=False,
     dev=False,
 ):
-    os.environ["PIPENV_REQUESTED_PYTHON_VERSION"] = ".".join(
-        [str(s) for s in sys.version_info[:3]]
-    )
     os.environ["PIP_PYTHON_PATH"] = str(sys.executable)
     if parse_only:
         parse_packages(

--- a/pipenv/utils/dependencies.py
+++ b/pipenv/utils/dependencies.py
@@ -1,4 +1,3 @@
-import os
 from contextlib import contextmanager
 from typing import Mapping, Sequence
 
@@ -28,22 +27,6 @@ def python_version(path_to_python):
 def clean_pkg_version(version):
     """Uses pip to prepare a package version string, from our internal version."""
     return pep440_version(str(version).replace("==", ""))
-
-
-class HackedPythonVersion:
-    """A Beautiful hack, which allows us to tell pip which version of Python we're using."""
-
-    def __init__(self, python_version, python_path):
-        self.python_version = python_version
-        self.python_path = python_path
-
-    def __enter__(self):
-        # Only inject when the value is valid
-        if self.python_path:
-            os.environ["PIP_PYTHON_PATH"] = str(self.python_path)
-
-    def __exit__(self, *args):
-        pass
 
 
 def get_canonical_names(packages):

--- a/pipenv/utils/dependencies.py
+++ b/pipenv/utils/dependencies.py
@@ -39,17 +39,11 @@ class HackedPythonVersion:
 
     def __enter__(self):
         # Only inject when the value is valid
-        if self.python_version:
-            os.environ["PIPENV_REQUESTED_PYTHON_VERSION"] = str(self.python_version)
         if self.python_path:
             os.environ["PIP_PYTHON_PATH"] = str(self.python_path)
 
     def __exit__(self, *args):
-        # Restore original Python version information.
-        try:
-            del os.environ["PIPENV_REQUESTED_PYTHON_VERSION"]
-        except KeyError:
-            pass
+        pass
 
 
 def get_canonical_names(packages):


### PR DESCRIPTION
Fixes #5195

### The issue

Right now it is not possible to specify python specifiers -- only the callout of specific versions.

This allows for specifying python such as:
```
[requires]
python_version = ">3.8"
```

```
[requires]
python_version = ">3.8,<3.11"
```

I'll be honest and say I am not sure what the side effects of people using different python versions to lock would be, but I am willing to find out.

Another thing, if you say 
```
[requires]
python_version = ">3.8,<=3.10"
```

then the specifier is not going to install 3.10.4 for example, because that is newer than 3.10.   I think that is technically correct as far as specifiers go so <3.11 is better if you intend to allow 3.10 than to say <=3.10, but maybe not what people would expect.