### PR TITLE
Begin converting away from pkg_resources

### DIFF
--- a/news/5349.bugfix.rst
+++ b/news/5349.bugfix.rst
@@ -1,0 +1,1 @@
+Modernize ``pipenv`` path patch with ``importlib.util`` to eliminate import of ``pkg_resources``

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -968,7 +968,6 @@ def do_create_virtualenv(project, python=None, site_packages=None, pypi_mirror=N
         pipfile=project.parsed_pipfile,
         project=project,
     )
-    project._environment.add_dist("pipenv")
     # Say where the virtualenv is.
     do_where(project, virtualenv=True, bare=False)
 

--- a/pipenv/environment.py
+++ b/pipenv/environment.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import contextlib
 import importlib
+import importlib.util
 import itertools
 import json
 import operator
@@ -11,12 +12,11 @@ import sys
 from pathlib import Path
 from sysconfig import get_paths, get_python_version, get_scheme_names
 
-import pkg_resources
-
 import pipenv
 from pipenv.patched.pip._internal.commands.install import InstallCommand
 from pipenv.patched.pip._internal.index.package_finder import PackageFinder
 from pipenv.patched.pip._internal.req.req_uninstall import UninstallPathSet
+from pipenv.patched.pip._vendor import pkg_resources
 from pipenv.patched.pip._vendor.packaging.utils import canonicalize_name
 from pipenv.utils.constants import is_type_checking
 from pipenv.utils.indexes import prepare_pip_source_args
@@ -41,7 +41,6 @@ if is_type_checking():
     from pipenv.project import Project, TPipfile, TSource
 
 BASE_WORKING_SET = pkg_resources.WorkingSet(sys.path)
-# TODO: Unittests for this class
 
 
 class Environment:
@@ -863,7 +862,7 @@ class Environment:
                 exec(code, dict(__file__=activate_this))
 
     @contextlib.contextmanager
-    def activated(self, include_extras=True, extra_dists=None):
+    def activated(self):
         """Helper context manager to activate the environment.
 
         This context manager will set the following variables for the duration
@@ -882,16 +881,8 @@ class Environment:
         to `os.environ["PATH"]` to ensure that calls to `~Environment.run()` use the
         environment's path preferentially.
         """
-
-        if not extra_dists:
-            extra_dists = []
         original_path = sys.path
         original_prefix = sys.prefix
-        parent_path = Path(__file__).absolute().parent
-        vendor_dir = parent_path.joinpath("vendor").as_posix()
-        patched_dir = parent_path.joinpath("patched").as_posix()
-        parent_path = parent_path.as_posix()
-        self.add_dist("pip")
         prefix = self.prefix.as_posix()
         with vistir.contextmanagers.temp_environ(), vistir.contextmanagers.temp_path():
             os.environ["PATH"] = os.pathsep.join(
@@ -914,21 +905,6 @@ class Environment:
                     os.environ.pop("PYTHONHOME", None)
             sys.path = self.sys_path
             sys.prefix = self.sys_prefix
-            site.addsitedir(self.base_paths["purelib"])
-            pip = self.safe_import("pip")  # noqa
-            pip_vendor = self.safe_import("pip._vendor")
-            pep517_dir = os.path.join(os.path.dirname(pip_vendor.__file__), "pep517")
-            site.addsitedir(pep517_dir)
-            os.environ["PYTHONPATH"] = os.pathsep.join(
-                [os.environ.get("PYTHONPATH", self.base_paths["PYTHONPATH"]), pep517_dir]
-            )
-            if include_extras:
-                site.addsitedir(parent_path)
-                sys.path.extend([parent_path, patched_dir, vendor_dir])
-                extra_dists = list(self.extra_dists) + extra_dists
-                for extra_dist in extra_dists:
-                    if extra_dist not in self.get_working_set():
-                        extra_dist.activate(self.sys_path)
             try:
                 yield
             finally:

--- a/pipenv/resolver.py
+++ b/pipenv/resolver.py
@@ -1,3 +1,4 @@
+import importlib.util
 import json
 import logging
 import os
@@ -6,65 +7,13 @@ import sys
 os.environ["PIP_PYTHON_PATH"] = str(sys.executable)
 
 
-def find_site_path(pkg, site_dir=None):
-    import pkg_resources
-
-    if site_dir is None:
-        site_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-    working_set = pkg_resources.WorkingSet([site_dir] + sys.path[:])
-    for dist in working_set:
-        root = dist.location
-        base_name = dist.project_name if dist.project_name else dist.key
-        name = None
-        if "top_level.txt" in dist.metadata_listdir(""):
-            name = next(
-                iter(
-                    [
-                        line.strip()
-                        for line in dist.get_metadata_lines("top_level.txt")
-                        if line is not None
-                    ]
-                ),
-                None,
-            )
-        if name is None:
-            name = pkg_resources.safe_name(base_name).replace("-", "_")
-        if not any(pkg == _ for _ in [base_name, name]):
-            continue
-        path_options = [name, f"{name}.py"]
-        path_options = [os.path.join(root, p) for p in path_options if p is not None]
-        path = next(iter(p for p in path_options if os.path.exists(p)), None)
-        if path is not None:
-            return dist, path
-    return None, None
-
-
-def _patch_path(pipenv_site=None):
-    import site
-
-    pipenv_libdir = os.path.dirname(os.path.abspath(__file__))
-    pipenv_site_dir = os.path.dirname(pipenv_libdir)
-    if pipenv_site is not None:
-        pipenv_dist, pipenv_path = find_site_path("pipenv", site_dir=pipenv_site)
-    else:
-        pipenv_dist, pipenv_path = find_site_path("pipenv", site_dir=pipenv_site_dir)
-    if pipenv_dist is not None:
-        pipenv_dist.activate()
-    else:
-        site.addsitedir(
-            next(
-                iter(
-                    sitedir
-                    for sitedir in (pipenv_site, pipenv_site_dir)
-                    if sitedir is not None
-                ),
-                None,
-            )
-        )
-    if pipenv_path is not None:
-        pipenv_libdir = pipenv_path
-    for _dir in ("vendor", "patched", pipenv_libdir):
-        sys.path.insert(0, os.path.join(pipenv_libdir, _dir))
+def _ensure_pipenv_module():
+    spec = importlib.util.spec_from_file_location(
+        "pipenv", location=os.path.join(os.path.dirname(__file__), "__init__.py")
+    )
+    pipenv = importlib.util.module_from_spec(spec)
+    sys.modules["pipenv"] = pipenv
+    spec.loader.exec_module(pipenv)
 
 
 def get_parser():
@@ -838,7 +787,7 @@ def _main(
 def main(argv=None):
     parser = get_parser()
     parsed, remaining = parser.parse_known_args(argv)
-    _patch_path(pipenv_site=parsed.pipenv_site)
+    _ensure_pipenv_module()
     import warnings
 
     from pipenv.vendor.vistir.misc import replace_with_text_stream

--- a/pipenv/resolver.py
+++ b/pipenv/resolver.py
@@ -7,7 +7,7 @@ import sys
 os.environ["PIP_PYTHON_PATH"] = str(sys.executable)
 
 
-def _ensure_pipenv_module():
+def _ensure_modules():
     spec = importlib.util.spec_from_file_location(
         "pipenv", location=os.path.join(os.path.dirname(__file__), "__init__.py")
     )
@@ -787,7 +787,7 @@ def _main(
 def main(argv=None):
     parser = get_parser()
     parsed, remaining = parser.parse_known_args(argv)
-    _ensure_pipenv_module()
+    _ensure_modules()
     import warnings
 
     from pipenv.vendor.vistir.misc import replace_with_text_stream

--- a/tasks/vendoring/__init__.py
+++ b/tasks/vendoring/__init__.py
@@ -21,6 +21,7 @@ LIBRARY_DIRNAMES = {
     "requirements-parser": "requirements",
     "backports.shutil_get_terminal_size": "backports/shutil_get_terminal_size",
     "python-dotenv": "dotenv",
+    "setuptools": "pkg_resources",
     "msgpack-python": "msgpack",
     "attrs": "attr",
 }

--- a/tasks/vendoring/__init__.py
+++ b/tasks/vendoring/__init__.py
@@ -21,7 +21,6 @@ LIBRARY_DIRNAMES = {
     "requirements-parser": "requirements",
     "backports.shutil_get_terminal_size": "backports/shutil_get_terminal_size",
     "python-dotenv": "dotenv",
-    "setuptools": "pkg_resources",
     "msgpack-python": "msgpack",
     "attrs": "attr",
 }
@@ -62,6 +61,7 @@ LIBRARY_RENAMES = {
     "pip_shims:": "pipenv.vendor.pip_shims",
     "requests": "pipenv.patched.pip._vendor.requests",
     "packaging": "pipenv.patched.pip._vendor.packaging",
+    "pkg_resources": "pipenv.patched.pip._vendor.pkg_resources",
     "urllib3": "pipenv.patched.pip._vendor.urllib3",
     "zipp": "pipenv.vendor.zipp",
 }

--- a/tasks/vendoring/__init__.py
+++ b/tasks/vendoring/__init__.py
@@ -62,7 +62,6 @@ LIBRARY_RENAMES = {
     "pip_shims:": "pipenv.vendor.pip_shims",
     "requests": "pipenv.patched.pip._vendor.requests",
     "packaging": "pipenv.patched.pip._vendor.packaging",
-    "pkg_resources": "pipenv.patched.pip._vendor.pkg_resources",
     "urllib3": "pipenv.patched.pip._vendor.urllib3",
     "zipp": "pipenv.vendor.zipp",
 }


### PR DESCRIPTION
Starts fixing #5349


### The issue

* Cleanup some patching to be consistent with how we patch pipenv to be available internal to pip `__main__.py` which is a more modern way using importlib that does not rely on pkg_resoruces.

There is more work to do to fully drop `pkg_resources` which seems to be what we are supposed to do:  https://setuptools.pypa.io/en/latest/pkg_resources.html

![image](https://user-images.githubusercontent.com/479892/189470109-c7755d36-610e-46a1-94c0-26b8fc2a724a.png)


The problem enters with `pipdeptree` is expecting the `pkg_resources` Distribution.  I opened https://github.com/tox-dev/pipdeptree/issues/175 to have that discussion.