### PR TITLE
cli: set `click_types.Path` for `-r` and `-e` options

### DIFF
--- a/news/5352.trivial.rst
+++ b/news/5352.trivial.rst
@@ -1,0 +1,1 @@
+emit file-based shell completions for -r and -e options

--- a/pipenv/cli/options.py
+++ b/pipenv/cli/options.py
@@ -128,7 +128,7 @@ def editable_option(f):
         expose_value=False,
         multiple=True,
         callback=callback,
-        type=click_types.STRING,
+        type=click_types.Path(file_okay=False),
         help="An editable Python package URL or path, often to a VCS repository.",
     )(f)
 
@@ -479,7 +479,7 @@ def requirementstxt_option(f):
         expose_value=False,
         help="Import a requirements.txt file.",
         callback=callback,
-        type=click_types.STRING,
+        type=click_types.Path(dir_okay=False),
     )(f)
 
 


### PR DESCRIPTION
### The issue

pipenv can generate its own shell completions using the click framework. Prior to this PR, there are no file/path completions for the `-r` and `-e` options. See #3478 for a discussion.

### The fix

This PR changes the option type to `click_types.Path` for `-r` and `-e`. This is enough for click to know that file/path completions are desired here.
And this isn't only beneficial for fish shell, it automatically applies to bash and zsh also.

This fixes partially issue #3478 but not the part concerning `pipenv run` completions.


### The checklist

* [x] Associated issue
* [x] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

I'm not sure whether the news fragment is mandatory and which type would be appropriate. If you tell me, I could add one.