### PR TITLE
Improve detection of unparsable ASTs

### DIFF
--- a/pipenv/vendor/requirementslib/models/setup_info.py
+++ b/pipenv/vendor/requirementslib/models/setup_info.py
@@ -356,7 +356,9 @@ class SetupReader:
             variable = cls._find_variable_in_body(body, value.id)
 
             if variable is not None and isinstance(variable, ast.List):
-                return [el.s for el in variable.elts]
+                r = [el.s for el in variable.elts if hasattr(el, 's')]
+                if r:
+                    return r
 
         raise Unparsable()
 


### PR DESCRIPTION
Thank you for contributing to Pipenv!


### The issue

While running pipenv lock, I got this,

```
File "/usr/local/lib/python3.7/site-packages/pipenv/vendor/requirementslib/models/setup_info.py", line 198, in caller
    return func(*args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/pipenv/vendor/requirementslib/models/setup_info.py", line 366, in _find_install_requires
    return [el.s for el in variable.elts]
  File "/usr/local/lib/python3.7/site-packages/pipenv/vendor/requirementslib/models/setup_info.py", line 366, in <listcomp>
    return [el.s for el in variable.elts]
AttributeError: 'BinOp' object has no attribute 's'
```
It seems that some situations in which the AST cannot be parsed are passing undetected.

Always consider opening an issue first to describe your problem, so we can discuss what is the best way to amend it.  Note that if you do not describe the goal of this change or link to a related issue, the maintainers may close the PR without further review.

If your pull request makes a non-insignificant change to Pipenv, such as the user interface or intended functionality, please file a PEEP.

    https://github.com/pypa/pipenv/blob/master/peeps/PEEP-000.md

### The fix

How does this pull request fix your problem? Did you consider any alternatives? Why is this the *best* solution, in your opinion?


### The checklist

* [ ] Associated issue
* [ ] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

<!--
### If this is a patch to the `vendor` directory...

Please try to refrain from submitting patches directly to `vendor` or `patched`, but raise your issue to the upstream project instead, and inform Pipenv to upgrade when the upstream project accepts the fix.

A pull request to upgrade vendor packages is strongly discouraged, unless there is a very good reason (e.g. you need to test Pipenv’s integration to a new vendor feature). Pipenv audits and performs vendor upgrades regularly, generally before a new release is about to drop.

If your patch is not or cannot be accepted by upstream, but is essential to Pipenv (make sure to discuss this with maintainers!), please remember to attach a patch file in `tasks/vendoring/patched`, so this divergence from upstream can be recorded and replayed afterwards.
-->
