### PR TITLE
Migrate isort, mypy, and pytest config into pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,52 @@ exclude = '''
 )
 '''
 
+[tool.isort]
+atomic = true
+lines_after_imports = 2
+lines_between_types = 1
+multi_line_output = 5
+line_length = 80
+known_first_party = [
+    "pipenv",
+    "tests",
+]
+
+[tool.mypy]
+ignore_missing_imports = true
+follow_imports = "skip"
+html_report = "mypyhtml"
+python_version = "3.7"
+mypy_path = "typeshed/pyi:typeshed/imports"
+
+[tool.pytest.ini_options]
+addopts = "-ra"
+plugins = "xdist"
+testpaths = ["tests"]
+# Add vendor and patched in addition to the default list of ignored dirs
+# Additionally, ignore tasks, news, test subdirectories and peeps directory
+norecursedirs = [
+    ".*", "build",
+    "dist",
+    "CVS",
+    "_darcs",
+    "{arch}",
+    "*.egg",
+    "vendor",
+    "patched",
+    "news",
+    "tasks",
+    "docs",
+    "tests/test_artifacts",
+    "tests/pytest-pypi",
+    "tests/pypi",
+    "peeps",
+]
+filterwarnings = [
+    "ignore::DeprecationWarning",
+    "ignore::PendingDeprecationWarning",
+]
+
 [tool.towncrier]
 package = "pipenv"
 filename = "CHANGELOG.rst"

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,6 +3,7 @@ long_description = file: README.md
 license = MIT
 license_files = LICENSE
 
+# Currently flake8 does not support pyproject.toml
 [flake8]
 extend-exclude =
     docs/,
@@ -25,49 +26,6 @@ ignore =
     # E501: line too long
     # W503: line break before binary operator
     E402,E501,W503,E203
-
-[isort]
-atomic=true
-lines_after_imports=2
-lines_between_types=1
-multi_line_output=5
-line_length=80
-known_first_party =
-    pipenv
-    tests
-
-[mypy]
-ignore_missing_imports=true
-follow_imports=skip
-html_report=mypyhtml
-python_version=3.7
-mypy_path=typeshed/pyi:typeshed/imports
-
-[tool:pytest]
-addopts = -ra
-plugins = xdist
-testpaths = tests
-; Add vendor and patched in addition to the default list of ignored dirs
-; Additionally, ignore tasks, news, test subdirectories and peeps directory
-norecursedirs =
-    .* build
-    dist
-    CVS
-    _darcs
-    {arch}
-    *.egg
-    vendor
-    patched
-    news
-    tasks
-    docs
-    tests/test_artifacts
-    tests/pytest-pypi
-    tests/pypi
-    peeps
-filterwarnings =
-    ignore::DeprecationWarning
-    ignore::PendingDeprecationWarning
 
 [coverage:run]
 parallel = true


### PR DESCRIPTION
Thank you for contributing to Pipenv!


### The issue

What is the thing you want to fix? Is it associated with an issue on GitHub? Please mention it.

[PEP621](https://peps.python.org/pep-0621/) encourages the Python community to migrate away from complex `setup.cfg` + `setup.py` files by putting config data in `pyproject.toml`.  Let's keep moving in that direction.  https://github.com/abravalheri/ini2toml

Always consider opening an issue first to describe your problem, so we can discuss what is the best way to amend it.  Note that if you do not describe the goal of this change or link to a related issue, the maintainers may close the PR without further review.

If your pull request makes a non-insignificant change to Pipenv, such as the user interface or intended functionality, please file a PEEP.

    https://github.com/pypa/pipenv/blob/master/peeps/PEEP-000.md

### The fix

How does this pull request fix your problem? Did you consider any alternatives? Why is this the *best* solution, in your opinion?


### The checklist

* [ ] Associated issue
* [ ] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

<!--
### If this is a patch to the `vendor` directory...

Please try to refrain from submitting patches directly to `vendor` or `patched`, but raise your issue to the upstream project instead, and inform Pipenv to upgrade when the upstream project accepts the fix.

A pull request to upgrade vendor packages is strongly discouraged, unless there is a very good reason (e.g. you need to test Pipenv’s integration to a new vendor feature). Pipenv audits and performs vendor upgrades regularly, generally before a new release is about to drop.

If your patch is not or cannot be accepted by upstream, but is essential to Pipenv (make sure to discuss this with maintainers!), please remember to attach a patch file in `tasks/vendoring/patched`, so this divergence from upstream can be recorded and replayed afterwards.
-->
