### PR TITLE
Use creator venv when creating virtual environments

### DIFF
--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -903,6 +903,7 @@ def do_create_virtualenv(project, python=None, site_packages=None, pypi_mirror=N
         Path(sys.executable).absolute().as_posix(),
         "-m",
         "virtualenv",
+        "--creator=venv",
         f"--prompt={project.name}",
         f"--python={python}",
         project.get_location_for_virtualenv(),

--- a/pipenv/environment.py
+++ b/pipenv/environment.py
@@ -183,8 +183,6 @@ class Environment:
             return "venv"
         elif os.name == "nt":
             return "nt"
-        elif "posix_local" in get_scheme_names():
-            return "posix_local"
         else:
             return "posix_prefix"
 

--- a/pipenv/environment.py
+++ b/pipenv/environment.py
@@ -183,6 +183,8 @@ class Environment:
             return "venv"
         elif os.name == "nt":
             return "nt"
+        elif "posix_local" in get_scheme_names():
+            return "posix_local"
         else:
             return "posix_prefix"
 


### PR DESCRIPTION
I did not realize how broken pipenv is out of the box on the latest ubuntu until I upgraded.   It has to do with it defaulting to `posix_local` when creating a virtualenv, which has different paths for the python binaries.  I initially tried preferring `posix_local` for the paths but it had the side effect of trying to install everything to local site packages.

Risks:  The venv creator should be available on all systems, but the documentation points out:
> venv - this delegates the creation process towards the venv module, as described in [PEP 405](https://www.python.org/dev/peps/pep-0405). This is only available on Python interpreters having version 3.5 or later, and also has the downside that virtualenv must create a process to invoke that module (unless virtualenv is installed in the system python), which can be an expensive operation (especially true on Windows).