### PR TITLE
Prefer to use the lockfile sources if available since this is used in install phase

### DIFF
--- a/news/5380.bugfix.rst
+++ b/news/5380.bugfix.rst
@@ -1,0 +1,1 @@
+Prefer to use the lockfile sources if available during the install phase.

--- a/pipenv/utils/indexes.py
+++ b/pipenv/utils/indexes.py
@@ -84,12 +84,12 @@ def get_source_list(
             if not sources or extra_src["url"] != sources[0]["url"]:
                 sources.append(extra_src)
 
-        for source in project.pipfile_sources:
+        for source in project.sources:
             if not sources or source["url"] != sources[0]["url"]:
                 sources.append(source)
 
     if not sources:
-        sources = project.pipfile_sources[:]
+        sources = project.sources[:]
     if pypi_mirror:
         sources = [
             create_mirror_source(pypi_mirror) if is_pypi_url(source["url"]) else source


### PR DESCRIPTION
Prefer to use the lockfile sources if available since this is used in install phase


### The issue

Fixes #5353 whereby the user was only supplying the lockfile to the docker build for sync/deploy/install phase--we should prefer in install to use the sources from the lockfile.


### The checklist

* [X] Associated issue
* [ ] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.
