### PR TITLE
Add news fragment for dropping six

### DIFF
--- a/news/5187.vendor.rst
+++ b/news/5187.vendor.rst
@@ -1,0 +1,1 @@
+Drop vendored six - we no longer depend on this library, as we migrated from pipfile to plette.


### PR DESCRIPTION
I accidentally pushed the actual change directly to the master branch.
Hence, this PR only includes the news fragment.
