### PR TITLE
Python full version in pipfile

### DIFF
--- a/news/5345.behavior.rst
+++ b/news/5345.behavior.rst
@@ -1,0 +1,1 @@
+New pipfiles show python_full_version under [requires] if specified

--- a/news/5345.behavior.rst
+++ b/news/5345.behavior.rst
@@ -1,1 +1,1 @@
-New pipfiles show python_full_version under [requires] if specified
+New pipfiles show python_full_version under [requires] if specified. Previously creating a new pipenv project would only specify in the Pipfile the major and minor version, i.e. "python_version = 3.7". Now if you create a new project with a fully named python version it will record both in the Pipfile. So: "python_version = 3.7" and "python_full_version = 3.7.2"

--- a/pipenv/project.py
+++ b/pipenv/project.py
@@ -675,8 +675,10 @@ class Project:
             else:
                 required_python = self.which("python")
         version = python_version(required_python) or self.s.PIPENV_DEFAULT_PYTHON_VERSION
-        if version and len(version.split(".")) > 2:
+        if version:
             data["requires"] = {"python_version": ".".join(version.split(".")[:2])}
+        if python and version and len(version.split(".")) > 2:
+            data["requires"].update({"python_full_version": version})
         self.write_toml(data)
 
     @classmethod

--- a/tests/integration/test_install_basic.py
+++ b/tests/integration/test_install_basic.py
@@ -392,15 +392,6 @@ def test_create_pipfile_requires_python_full_version(pipenv_instance_pypi):
 
 @pytest.mark.basic
 @pytest.mark.install
-def test_create_pipfile_requires_python_full_version(pipenv_instance_pypi):
-    with pipenv_instance_pypi(chdir=True) as p:
-        c = p.pipenv("--python 3.10.7")
-        assert c.returncode == 0
-        assert p.pipfile["requires"] == {'python__full_version': '3.10.7'}
-
-
-@pytest.mark.basic
-@pytest.mark.install
 def test_install_non_exist_dep(pipenv_instance_pypi):
     with pipenv_instance_pypi(chdir=True) as p:
         c = p.pipenv("install dateutil")

--- a/tests/integration/test_install_basic.py
+++ b/tests/integration/test_install_basic.py
@@ -1,4 +1,4 @@
-import os
+import os, sys
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
@@ -372,6 +372,22 @@ def test_install_creates_pipfile(pipenv_instance_pypi):
         c = p.pipenv("install")
         assert c.returncode == 0
         assert os.path.isfile(p.pipfile_path)
+        python_version = str(sys.version_info.major) + "." + str(sys.version_info.minor)
+        assert p.pipfile["requires"] == {'python_version': python_version}
+
+
+@pytest.mark.basic
+@pytest.mark.install
+def test_create_pipfile_requires_python_full_version(pipenv_instance_pypi):
+    with pipenv_instance_pypi(chdir=True) as p:
+        python_version = str(sys.version_info.major) + "." + str(sys.version_info.minor)
+        python_full_version = python_version + "." + str(sys.version_info.micro)
+        c = p.pipenv(f"--python {python_full_version}")
+        assert c.returncode == 0
+        assert p.pipfile["requires"] == {
+            'python_full_version': python_full_version,
+            'python_version': python_version
+            }
 
 
 @pytest.mark.basic

--- a/tests/integration/test_install_basic.py
+++ b/tests/integration/test_install_basic.py
@@ -376,6 +376,15 @@ def test_install_creates_pipfile(pipenv_instance_pypi):
 
 @pytest.mark.basic
 @pytest.mark.install
+def test_create_pipfile_requires_python_full_version(pipenv_instance_pypi):
+    with pipenv_instance_pypi(chdir=True) as p:
+        c = p.pipenv("--python 3.10.7")
+        assert c.returncode == 0
+        assert p.pipfile["requires"] == {'python__full_version': '3.10.7'}
+
+
+@pytest.mark.basic
+@pytest.mark.install
 def test_install_non_exist_dep(pipenv_instance_pypi):
     with pipenv_instance_pypi(chdir=True) as p:
         c = p.pipenv("install dateutil")


### PR DESCRIPTION
Thank you for contributing to Pipenv!


### The issue
https://github.com/pypa/pipenv/issues/5345

A user requested that when the full version is specified that it gets added to a new pipfile when it is created so that he/she wouldn't need to manually add it themselves.


### The fix

Found the spot where the pipefile [requires] section gets created and modified it slightly to save based on if full version was specified or not.


### The checklist

* [x] Associated issue
* [x] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

<!--
### If this is a patch to the `vendor` directory...

Please try to refrain from submitting patches directly to `vendor` or `patched`, but raise your issue to the upstream project instead, and inform Pipenv to upgrade when the upstream project accepts the fix.

A pull request to upgrade vendor packages is strongly discouraged, unless there is a very good reason (e.g. you need to test Pipenv’s integration to a new vendor feature). Pipenv audits and performs vendor upgrades regularly, generally before a new release is about to drop.

If your patch is not or cannot be accepted by upstream, but is essential to Pipenv (make sure to discuss this with maintainers!), please remember to attach a patch file in `tasks/vendoring/patched`, so this divergence from upstream can be recorded and replayed afterwards.
-->
