### PR TITLE
Scripts run package functions

### DIFF
--- a/news/5294.feature.rst
+++ b/news/5294.feature.rst
@@ -1,0 +1,1 @@
+Add ability for callable scripts in Pipfile under [scripts]. Callables can now be added like: ``<pathed.module>:<func>`` and can also take arguments. For exaple: ``func = {call = "package.module:func('arg1', 'arg2')"}`` then this can be activated in the shell with ``pipenv run func``

--- a/pipenv/cmdparse.py
+++ b/pipenv/cmdparse.py
@@ -1,6 +1,7 @@
 import itertools
 import re
 import shlex
+
 import tomlkit
 
 
@@ -19,21 +20,22 @@ def _quote_if_contains(value, pattern):
 
 
 def _parse_toml_inline_table(value: tomlkit.items.InlineTable) -> str:
-    """parses the [scripts] in pipfile and converts: `{call = "package.module:func('arg')"}` into an executable command
-    """
+    """parses the [scripts] in pipfile and converts: `{call = "package.module:func('arg')"}` into an executable command"""
     keys_list = list(value.keys())
     if len(keys_list) > 1:
         raise ScriptParseError("More than 1 key in toml script line")
     cmd_key = keys_list[0]
     if cmd_key not in Script.script_types:
-        raise ScriptParseError(f"Not an accepted script callabale, options are: {Script.script_types}")
+        raise ScriptParseError(
+            f"Not an accepted script callabale, options are: {Script.script_types}"
+        )
     if cmd_key == "call":
         module, _, func = str(value["call"]).partition(":")
         if not module or not func:
             raise ScriptParseError("Callable must be like: <pathed.module>:<func>")
         if re.search(r"\(.*?\)", func) is None:
             func += "()"
-        return f"python -c \"import {module} as _m; _m.{func}\""
+        return f'python -c "import {module} as _m; _m.{func}"'
 
 
 class Script(object):
@@ -41,6 +43,7 @@ class Script(object):
 
     This always works in POSIX mode, even on Windows.
     """
+
     script_types = ["call"]
 
     def __init__(self, command, args=None):

--- a/pipenv/cmdparse.py
+++ b/pipenv/cmdparse.py
@@ -2,7 +2,7 @@ import itertools
 import re
 import shlex
 
-import tomlkit
+from pipenv.vendor import tomlkit
 
 
 class ScriptEmptyError(ValueError):

--- a/tests/unit/test_vendor.py
+++ b/tests/unit/test_vendor.py
@@ -7,7 +7,7 @@ import os
 
 import pytest
 import pytz
-import tomlkit
+from pipenv.vendor import tomlkit
 
 
 @pytest.mark.parametrize('dt, content', [


### PR DESCRIPTION
### The issue

Requested new feature to add the ability to include something like:
```[scripts]
main = {call = "foo_package.bar_module:main('dev')"}
```

   https://github.com/pypa/pipenv/issues/5294

### The fix

This adds the ability to parse a callable with module.func in scripts


### The checklist

* [x] Associated issue
* [x] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

<!--
### If this is a patch to the `vendor` directory...

Please try to refrain from submitting patches directly to `vendor` or `patched`, but raise your issue to the upstream project instead, and inform Pipenv to upgrade when the upstream project accepts the fix.

A pull request to upgrade vendor packages is strongly discouraged, unless there is a very good reason (e.g. you need to test Pipenv’s integration to a new vendor feature). Pipenv audits and performs vendor upgrades regularly, generally before a new release is about to drop.

If your patch is not or cannot be accepted by upstream, but is essential to Pipenv (make sure to discuss this with maintainers!), please remember to attach a patch file in `tasks/vendoring/patched`, so this divergence from upstream can be recorded and replayed afterwards.
-->
