### PR TITLE
Revert back to build isolation by default; support extra-pip-args on sync command.

### DIFF
--- a/pipenv/cli/options.py
+++ b/pipenv/cli/options.py
@@ -561,6 +561,7 @@ def install_base_options(f):
     f = common_options(f)
     f = pre_option(f)
     f = keep_outdated_option(f)
+    f = extra_pip_args(f)
     return f
 
 
@@ -597,7 +598,6 @@ def install_options(f):
     f = ignore_pipfile_option(f)
     f = editable_option(f)
     f = package_arg(f)
-    f = extra_pip_args(f)
     return f
 
 

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -1340,7 +1340,7 @@ def get_pip_args(
     verbose: bool = False,
     upgrade: bool = False,
     require_hashes: bool = False,
-    no_build_isolation: bool = True,
+    no_build_isolation: bool = False,
     no_use_pep517: bool = False,
     no_deps: bool = False,
     selective_upgrade: bool = False,

--- a/tests/integration/test_install_categories.py
+++ b/tests/integration/test_install_categories.py
@@ -69,5 +69,5 @@ six = "*"
         assert "testpipenv" in p.lockfile["default"]
         assert "testpipenv" not in p.lockfile["prereq"]
         assert "six" in p.lockfile["prereq"]
-        c = p.pipenv('sync --categories="prereq packages" -v')
+        c = p.pipenv('sync --categories="prereq packages" --extra-pip-args="--no-build-isolation" -v')
         assert c.returncode == 0


### PR DESCRIPTION
### The issue

Lack of build isolation means that build requirements no longer are implicitly installed and have to be installed ahead of time.  I am revisiting that decision to change the default isolation level because I feel it has already caused enough problems with existing workflows, and I realized an alternate solution is to recommend users that have issues requiring pre-requisites to pass ` --extra-pip-args="--no-build-isolation"` in their install or sync commands.

Fixes #5391 
Fixes #5398 


### The checklist

* [X] Associated issue
* [ ] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.
