### PR TITLE
Remove recommended packages link in doc sidebar

### DIFF
--- a/docs/_templates/sidebarlogo.html
+++ b/docs/_templates/sidebarlogo.html
@@ -60,12 +60,6 @@
 
 <h3>Useful Links</h3>
 <ul>
-    <li><a href="https://requests.readthedocs.io/en/latest/community/recommended/">Recommended Packages and
-        Extensions</a>
-    </li>
-
-    <p></p>
-
     <li><a href="https://github.com/pypa/pipenv">Pipenv @ GitHub</a></li>
     <li><a href="https://pypi.org/project/pipenv">Pipenv @ PyPI</a></li>
     <li><a href="https://launchpad.net/~pypa/+archive/ubuntu/ppa">Pipenv PPA (PyPA)</a></li>


### PR DESCRIPTION
### The issue

The documentation sidebar contains a "Recommended Packages " that points to a page in Request's documentation, not in Pipenv's

### The fix

Remove the bad link

### The checklist

* [ ] Associated issue
* [ ] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

<!--
### If this is a patch to the `vendor` directory...

Please try to refrain from submitting patches directly to `vendor` or `patched`, but raise your issue to the upstream project instead, and inform Pipenv to upgrade when the upstream project accepts the fix.

A pull request to upgrade vendor packages is strongly discouraged, unless there is a very good reason (e.g. you need to test Pipenv’s integration to a new vendor feature). Pipenv audits and performs vendor upgrades regularly, generally before a new release is about to drop.

If your patch is not or cannot be accepted by upstream, but is essential to Pipenv (make sure to discuss this with maintainers!), please remember to attach a patch file in `tasks/vendoring/patched`, so this divergence from upstream can be recorded and replayed afterwards.
-->
