### PR TITLE
Remove usage of mkdir_p in favour of os.makedirs

### DIFF
--- a/pipenv/project.py
+++ b/pipenv/project.py
@@ -18,7 +18,6 @@ from pipenv.environment import Environment
 from pipenv.environments import Setting, is_in_virtualenv, normalize_pipfile_path
 from pipenv.patched.pip._internal.commands.install import InstallCommand
 from pipenv.patched.pip._vendor import pkg_resources
-from pipenv.utils.constants import is_type_checking
 from pipenv.utils.dependencies import (
     get_canonical_names,
     is_editable,
@@ -48,16 +47,14 @@ except ImportError:
     # eventually distlib will remove cached property when they drop Python3.7
     from pipenv.patched.pip._vendor.distlib.util import cached_property
 
+from typing import Dict, List, Optional, Set, Text, Tuple, Union
 
-if is_type_checking():
-    from typing import Dict, List, Optional, Set, Text, Tuple, Union
-
-    TSource = Dict[Text, Union[Text, bool]]
-    TPackageEntry = Dict[str, Union[bool, str, List[str]]]
-    TPackage = Dict[str, TPackageEntry]
-    TScripts = Dict[str, str]
-    TPipenv = Dict[str, bool]
-    TPipfile = Dict[str, Union[TPackage, TScripts, TPipenv, List[TSource]]]
+TSource = Dict[Text, Union[Text, bool]]
+TPackageEntry = Dict[str, Union[bool, str, List[str]]]
+TPackage = Dict[str, TPackageEntry]
+TScripts = Dict[str, str]
+TPipenv = Dict[str, bool]
+TPipfile = Dict[str, Union[TPackage, TScripts, TPipenv, List[TSource]]]
 
 
 DEFAULT_NEWLINES = "\n"

--- a/pipenv/project.py
+++ b/pipenv/project.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import base64
 import fnmatch
 import hashlib
@@ -421,7 +419,7 @@ class Project:
             loc = os.sep.join([self.virtualenv_location, "src"])
         else:
             loc = os.sep.join([self.project_directory, "src"])
-        vistir.path.mkdir_p(loc)
+        os.makedirs(loc, exist_ok=True)
         return loc
 
     @property
@@ -430,7 +428,7 @@ class Project:
             loc = os.sep.join([self.virtualenv_location, "downloads"])
             self._download_location = loc
         # Create the directory, if it doesn't exist.
-        vistir.path.mkdir_p(self._download_location)
+        os.makedirs(self._download_location, exist_ok=True)
         return self._download_location
 
     @property

--- a/pipenv/project.py
+++ b/pipenv/project.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import base64
 import fnmatch
 import hashlib
@@ -18,6 +20,7 @@ from pipenv.environment import Environment
 from pipenv.environments import Setting, is_in_virtualenv, normalize_pipfile_path
 from pipenv.patched.pip._internal.commands.install import InstallCommand
 from pipenv.patched.pip._vendor import pkg_resources
+from pipenv.utils.constants import is_type_checking
 from pipenv.utils.dependencies import (
     get_canonical_names,
     is_editable,
@@ -47,14 +50,15 @@ except ImportError:
     # eventually distlib will remove cached property when they drop Python3.7
     from pipenv.patched.pip._vendor.distlib.util import cached_property
 
-from typing import Dict, List, Optional, Set, Text, Tuple, Union
+if is_type_checking():
+    from typing import Dict, List, Optional, Set, Text, Tuple, Union
 
-TSource = Dict[Text, Union[Text, bool]]
-TPackageEntry = Dict[str, Union[bool, str, List[str]]]
-TPackage = Dict[str, TPackageEntry]
-TScripts = Dict[str, str]
-TPipenv = Dict[str, bool]
-TPipfile = Dict[str, Union[TPackage, TScripts, TPipenv, List[TSource]]]
+    TSource = Dict[Text, Union[Text, bool]]
+    TPackageEntry = Dict[str, Union[bool, str, List[str]]]
+    TPackage = Dict[str, TPackageEntry]
+    TScripts = Dict[str, str]
+    TPipenv = Dict[str, bool]
+    TPipfile = Dict[str, Union[TPackage, TScripts, TPipenv, List[TSource]]]
 
 
 DEFAULT_NEWLINES = "\n"

--- a/pipenv/utils/shell.py
+++ b/pipenv/utils/shell.py
@@ -200,7 +200,7 @@ def get_workon_home():
             )
     # Create directory if it does not already exist
     expanded_path = Path(os.path.expandvars(workon_home)).expanduser()
-    mkdir_p(str(expanded_path))
+    os.makedirs(expanded_path, exist_ok=True)
     return expanded_path
 
 
@@ -237,39 +237,6 @@ def is_virtual_environment(path):
             if exeness:
                 return True
     return False
-
-
-def mkdir_p(newdir):
-    """works the way a good mkdir should :)
-    - already exists, silently complete
-    - regular file in the way, raise an exception
-    - parent directory(ies) does not exist, make them as well
-    From: http://code.activestate.com/recipes/82465-a-friendly-mkdir/
-    """
-    if os.path.isdir(newdir):
-        pass
-    elif os.path.isfile(newdir):
-        raise OSError(
-            "a file with the same name as the desired dir, '{}', already exists.".format(
-                newdir
-            )
-        )
-
-    else:
-        head, tail = os.path.split(newdir)
-        if head and not os.path.isdir(head):
-            mkdir_p(head)
-        if tail:
-            # Even though we've checked that the directory doesn't exist above, it might exist
-            # now if some other process has created it between now and the time we checked it.
-            try:
-                os.mkdir(newdir)
-            except OSError as exn:
-                # If we failed because the directory does exist, that's not a problem -
-                # that's what we were trying to do anyway. Only re-raise the exception
-                # if we failed for some other reason.
-                if exn.errno != errno.EEXIST:
-                    raise
 
 
 def find_python(finder, line=None):

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -23,7 +23,7 @@ from pipenv.vendor import toml, tomlkit
 from pipenv.vendor.vistir.contextmanagers import temp_environ
 from pipenv.vendor.vistir.misc import run
 from pipenv.vendor.vistir.path import (
-    create_tracked_tempdir, handle_remove_readonly, mkdir_p
+    create_tracked_tempdir, handle_remove_readonly
 )
 
 from pytest_pypi.app import prepare_fixtures
@@ -186,7 +186,7 @@ def isolate(create_tmpdir):
     # Create a directory to use as our home location.
     home_dir = os.path.join(str(create_tmpdir()), "home")
     os.makedirs(home_dir)
-    mkdir_p(os.path.join(home_dir, ".config", "git"))
+    os.makedirs(os.path.join(home_dir, ".config", "git"), exist_ok=True)
     git_config_file = os.path.join(home_dir, ".config", "git", "config")
     with open(git_config_file, "wb") as fp:
         fp.write(
@@ -199,7 +199,7 @@ def isolate(create_tmpdir):
     workon_home = create_tmpdir()
     os.environ["WORKON_HOME"] = str(workon_home)
     os.environ["HOME"] = os.path.abspath(home_dir)
-    mkdir_p(os.path.join(home_dir, "projects"))
+    os.makedirs(os.path.join(home_dir, "projects"), exist_ok=True)
     # Ignore PIPENV_ACTIVE so that it works as under a bare environment.
     os.environ.pop("PIPENV_ACTIVE", None)
     os.environ.pop("VIRTUAL_ENV", None)

--- a/tests/integration/test_install_twists.py
+++ b/tests/integration/test_install_twists.py
@@ -1,11 +1,10 @@
 import os
 import shutil
 import sys
-from pathlib import Path
 
 import pytest
 
-from pipenv.utils.shell import mkdir_p, temp_environ
+from pipenv.utils.shell import temp_environ
 
 
 @pytest.mark.extras
@@ -187,7 +186,7 @@ def test_install_local_uri_special_character(pipenv_instance_private_pypi, tests
     with pipenv_instance_private_pypi() as p:
         artifact_dir = "artifacts"
         artifact_path = os.path.join(p.path, artifact_dir)
-        mkdir_p(artifact_path)
+        os.makedirs(artifact_path, exist_ok=True)
         shutil.copy(source_path, os.path.join(artifact_path, file_name))
         with open(p.pipfile_path, "w") as f:
             contents = """

--- a/tests/integration/test_run.py
+++ b/tests/integration/test_run.py
@@ -4,7 +4,6 @@ import pytest
 
 from pipenv.project import Project
 from pipenv.utils.shell import subprocess_run, temp_environ
-from pipenv.utils.shell import mkdir_p
 
 
 @pytest.mark.run
@@ -69,7 +68,7 @@ def test_scripts_with_package_functions(pipenv_instance_pypi):
     with pipenv_instance_pypi(chdir=True) as p:
         p.pipenv('install')
         pkg_path = os.path.join(p.path, "pkg")
-        mkdir_p(pkg_path)
+        os.makedirs(pkg_path, exist_ok=True)
         file_path = os.path.join(pkg_path, "mod.py")
         with open(file_path, "w+") as f:
             f.write("""


### PR DESCRIPTION
As the last commit says, this function is obsolete.