### PR TITLE
Replace deprecated workflow command

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -84,7 +84,7 @@ jobs:
       - name: Get python path
         id: python-path
         run: |
-          echo ::set-output name=path::$(python -c "import sys; print(sys.executable)")
+          echo "path=$(python -c 'import sys; print(sys.executable)')" >> $GITHUB_OUTPUT
       - name: Install latest pip, setuptools, wheel
         run: |
           python -m pip install --upgrade pip setuptools wheel


### PR DESCRIPTION
Hi

- Fixes for deprecated workflow syntax: #5404

### The checklist

* [X] Associated issue #5404 
* [ ] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.
