### PR TITLE
Add missing backtick in the contributing documentation.

### DIFF
--- a/docs/dev/contributing.rst
+++ b/docs/dev/contributing.rst
@@ -131,7 +131,7 @@ Tests are written in ``pytest`` style and can be run very simply:
   pytest
 
 However many tests depend on running a private pypi server on localhost:8080.
-This can be accomplished by using either the ``run-tests.sh`` or ``run-tests.bat`
+This can be accomplished by using either the ``run-tests.sh`` or ``run-tests.bat``
 which will start the ``pypiserver`` process ahead of invoking pytest.
 
 You may also manually perform this step and then invoke pytest as you would normally.  Example::


### PR DESCRIPTION
I've noticed a missing backtick in the documentation that made some part of the documentation to look like code, when it shouldn't.
This PR fixes it.