### PR TITLE
Remove usage of vistir.cmdparse

### DIFF
--- a/news/5419.removal.rst
+++ b/news/5419.removal.rst
@@ -1,0 +1,1 @@
+Remove usage of vistir.cmdparse in favor of pipenv.cmdparse

--- a/pipenv/environment.py
+++ b/pipenv/environment.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from sysconfig import get_paths, get_python_version, get_scheme_names
 
 import pipenv
+from pipenv import cmdparse
 from pipenv.patched.pip._internal.commands.install import InstallCommand
 from pipenv.patched.pip._internal.index.package_finder import PackageFinder
 from pipenv.patched.pip._internal.req.req_uninstall import UninstallPathSet
@@ -815,7 +816,7 @@ class Environment:
 
         c = None
         with self.activated():
-            script = vistir.cmdparse.Script.parse(cmd)
+            script = cmdparse.Script.parse(cmd)
             c = vistir.misc.run(
                 script._parts,
                 return_object=True,
@@ -837,9 +838,9 @@ class Environment:
 
         c = None
         if isinstance(cmd, str):
-            script = vistir.cmdparse.Script.parse(f"{self.python} -c {cmd}")
+            script = cmdparse.Script.parse(f"{self.python} -c {cmd}")
         else:
-            script = vistir.cmdparse.Script.parse([self.python, "-c"] + list(cmd))
+            script = cmdparse.Script.parse([self.python, "-c"] + list(cmd))
         with self.activated():
             c = vistir.misc.run(
                 script._parts,


### PR DESCRIPTION
Following #5390 I realized this code is duplicated into pipenv, and we can use that instead of the one in vistir.