### PR TITLE
Rewrite Environment.sys_path without vistir.misc.run

### DIFF
--- a/pipenv/environment.py
+++ b/pipenv/environment.py
@@ -311,19 +311,12 @@ class Environment:
             return sys.path
         elif any([sys.prefix == self.prefix, not self.is_venv]):
             return sys.path
-        cmd_args = [self.python, "-c", "import json, sys; print(json.dumps(sys.path))"]
-        path, _ = vistir.misc.run(
-            cmd_args,
-            return_object=False,
-            nospin=True,
-            block=True,
-            combine_stderr=False,
-            write_to_stdout=False,
-        )
+
         try:
-            path = json.loads(path.strip())
-        except json.JSONDecodeError:
+            path = pipenv.utils.shell.load_path(self.python)
+        except json.decoder.JSONDecodeError:
             path = sys.path
+
         return path
 
     def build_command(

--- a/pipenv/resolver.py
+++ b/pipenv/resolver.py
@@ -819,11 +819,11 @@ def main(argv=None):
     _ensure_modules()
     import warnings
 
-    from pipenv.vendor.vistir.misc import replace_with_text_stream
+    from pipenv.vendor.click.utils import get_text_stream
 
     warnings.simplefilter("ignore", category=ResourceWarning)
-    replace_with_text_stream("stdout")
-    replace_with_text_stream("stderr")
+    sys.stdout = get_text_stream("stdout")
+    sys.stderr = get_text_stream("stderr")
     os.environ["PIP_DISABLE_PIP_VERSION_CHECK"] = "1"
     os.environ["PYTHONIOENCODING"] = "utf-8"
     os.environ["PYTHONUNBUFFERED"] = "1"

--- a/pipenv/utils/shell.py
+++ b/pipenv/utils/shell.py
@@ -73,8 +73,7 @@ def load_path(python):
     from pathlib import Path
 
     python = Path(python).as_posix()
-    json_dump_commmand = '"import json, sys; print(json.dumps(sys.path));"'
-    c = subprocess_run([python, "-c", json_dump_commmand])
+    c = subprocess_run([python, "-c", "import json, sys; print(json.dumps(sys.path))"])
     if c.returncode == 0:
         return json.loads(c.stdout.strip())
     else:


### PR DESCRIPTION
Instead, we use `pipenv.utils.shell.load_path`.

