### PR TITLE
Add support for multiple categories in exported requirements

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -363,6 +363,27 @@ used to write them to a file::
     pytest==3.2.3
     setuptools==65.4.1 ; python_version >= '3.7'
 
+If you have multiple categories in your Pipfile and wish to generate
+a requirements file for only some categories, you can do that too,
+using the ``--categories`` option::
+
+    $ pipenv requirements --categories="tests" > requirements-tests.txt
+    $ pipenv requirements --categories="docs" > requirements-docs.txt
+    $ cat requirements-tests.txt
+    -i https://pypi.org/simple
+    attrs==22.1.0 ; python_version >= '3.5'
+    iniconfig==1.1.1
+    packaging==21.3 ; python_version >= '3.6'
+    pluggy==1.0.0 ; python_version >= '3.6'
+    py==1.11.0 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
+    pyparsing==3.0.9 ; python_full_version >= '3.6.8'
+    pytest==7.1.3
+    tomli==2.0.1 ; python_version >= '3.7'
+
+It can be used to specify multiple categories also.
+
+    $ pipenv requirements --categories="tests,docs"
+
 ☤ Detection of Security Vulnerabilities
 ---------------------------------------
 

--- a/news/5431.feature.rst
+++ b/news/5431.feature.rst
@@ -1,0 +1,1 @@
+Add support to export requirements file for a specified set of categories.

--- a/pipenv/cli/command.py
+++ b/pipenv/cli/command.py
@@ -740,9 +740,9 @@ def verify(state):
 )
 @option("--hash", is_flag=True, default=False, help="Add package hashes.")
 @option("--exclude-markers", is_flag=True, default=False, help="Exclude markers.")
-@option("--category", is_flag=False, default='', help="Only add requirement of the specified category.")
+@option("--categories", is_flag=False, default='', help="Only add requirement of the specified categories.")
 @pass_state
-def requirements(state, dev=False, dev_only=False, hash=False, exclude_markers=False, category=''):
+def requirements(state, dev=False, dev_only=False, hash=False, exclude_markers=False, categories=''):
 
     from pipenv.utils.dependencies import convert_deps_to_pip
 
@@ -753,9 +753,11 @@ def requirements(state, dev=False, dev_only=False, hash=False, exclude_markers=F
         echo(" ".join([prefix, package_index["url"]]))
 
     deps = {}
+    categories_list = categories.split(',') if categories else []
 
-    if category:
-        deps.update(lockfile.get(category, {}))
+    if categories_list:
+        for category in categories_list:
+            deps.update(lockfile.get(category, {}))
     else:
         if dev or dev_only:
             deps.update(lockfile["develop"])

--- a/pipenv/cli/command.py
+++ b/pipenv/cli/command.py
@@ -740,9 +740,16 @@ def verify(state):
 )
 @option("--hash", is_flag=True, default=False, help="Add package hashes.")
 @option("--exclude-markers", is_flag=True, default=False, help="Exclude markers.")
-@option("--categories", is_flag=False, default='', help="Only add requirement of the specified categories.")
+@option(
+    "--categories",
+    is_flag=False,
+    default="",
+    help="Only add requirement of the specified categories.",
+)
 @pass_state
-def requirements(state, dev=False, dev_only=False, hash=False, exclude_markers=False, categories=''):
+def requirements(
+    state, dev=False, dev_only=False, hash=False, exclude_markers=False, categories=""
+):
 
     from pipenv.utils.dependencies import convert_deps_to_pip
 
@@ -753,7 +760,7 @@ def requirements(state, dev=False, dev_only=False, hash=False, exclude_markers=F
         echo(" ".join([prefix, package_index["url"]]))
 
     deps = {}
-    categories_list = categories.split(',') if categories else []
+    categories_list = categories.split(",") if categories else []
 
     if categories_list:
         for category in categories_list:

--- a/pipenv/cli/command.py
+++ b/pipenv/cli/command.py
@@ -764,6 +764,7 @@ def requirements(
 
     if categories_list:
         for category in categories_list:
+            category = category.strip()
             deps.update(lockfile.get(category, {}))
     else:
         if dev or dev_only:

--- a/pipenv/cli/command.py
+++ b/pipenv/cli/command.py
@@ -1,4 +1,3 @@
-from gc import is_finalized
 import os
 import sys
 
@@ -86,7 +85,7 @@ def cli(
 
     load_dot_env(state.project, quiet=state.quiet)
 
-    from pipenv.core import (
+    from ..core import (
         cleanup_virtualenv,
         do_clear,
         do_py,

--- a/tests/integration/test_requirements.py
+++ b/tests/integration/test_requirements.py
@@ -78,7 +78,7 @@ def test_requirements_generates_requirements_from_lockfile_from_categories(pipen
         packages = ('six', '1.12.0')
         dev_packages = ('itsdangerous', '1.1.0')
         test_packages = ('pytest', '7.1.3')
-        doc_packages = ('Sphinx', '5.3.0')
+        doc_packages = ('docutils', '0.19')
 
         with open(p.pipfile_path, 'w') as f:
             contents = f"""

--- a/tests/integration/test_requirements.py
+++ b/tests/integration/test_requirements.py
@@ -90,9 +90,9 @@ def test_requirements_generates_requirements_from_lockfile_from_categories(pipen
             {packages[0]}= "=={packages[1]}"
             [dev-packages]
             {dev_packages[0]}= "=={dev_packages[1]}"
-            [test-packages]
+            [test]
             {test_packages[0]}= "=={test_packages[1]}"
-            [doc-packages]
+            [doc]
             {doc_packages[0]}= "=={doc_packages[1]}"
             """.strip()
             f.write(contents)
@@ -105,7 +105,7 @@ def test_requirements_generates_requirements_from_lockfile_from_categories(pipen
         assert f'{test_packages[0]}=={test_packages[1]}' not in c.stdout
         assert f'{dev_packages[0]}=={dev_packages[1]}' in c.stdout
 
-        d = p.pipenv('requirements --category test,doc')
+        d = p.pipenv('requirements --categories="test, doc"')
         assert d.returncode == 0
         assert f'{packages[0]}=={packages[1]}' not in d.stdout
         assert f'{dev_packages[0]}=={dev_packages[1]}' not in c.stdout

--- a/tests/integration/test_requirements.py
+++ b/tests/integration/test_requirements.py
@@ -98,17 +98,18 @@ def test_requirements_generates_requirements_from_lockfile_from_categories(pipen
             f.write(contents)
         l = p.pipenv('lock')
         assert l.returncode == 0
-        
+
         c = p.pipenv('requirements --dev-only')
         assert c.returncode == 0
         assert f'{packages[0]}=={packages[1]}' not in c.stdout
         assert f'{test_packages[0]}=={test_packages[1]}' not in c.stdout
+        assert f'{doc_packages[0]}=={doc_packages[1]}' not in c.stdout
         assert f'{dev_packages[0]}=={dev_packages[1]}' in c.stdout
 
         d = p.pipenv('requirements --categories="test, doc"')
         assert d.returncode == 0
         assert f'{packages[0]}=={packages[1]}' not in d.stdout
-        assert f'{dev_packages[0]}=={dev_packages[1]}' not in c.stdout
+        assert f'{dev_packages[0]}=={dev_packages[1]}' not in d.stdout
         assert f'{test_packages[0]}=={test_packages[1]}' in d.stdout
         assert f'{doc_packages[0]}=={doc_packages[1]}' in d.stdout
 

--- a/tests/integration/test_requirements.py
+++ b/tests/integration/test_requirements.py
@@ -73,11 +73,13 @@ def test_requirements_generates_requirements_from_lockfile_multiple_sources(pipe
 
 
 @pytest.mark.requirements
-def test_requirements_generates_requirements_from_lockfile_from_a_category(pipenv_instance_private_pypi):
+def test_requirements_generates_requirements_from_lockfile_from_categories(pipenv_instance_private_pypi):
     with pipenv_instance_private_pypi(chdir=True) as p:
         packages = ('six', '1.12.0')
         dev_packages = ('itsdangerous', '1.1.0')
         test_packages = ('pytest', '7.1.3')
+        doc_packages = ('Sphinx', '5.3.0')
+
         with open(p.pipfile_path, 'w') as f:
             contents = f"""
             [[source]]
@@ -90,6 +92,8 @@ def test_requirements_generates_requirements_from_lockfile_from_a_category(pipen
             {dev_packages[0]}= "=={dev_packages[1]}"
             [test-packages]
             {test_packages[0]}= "=={test_packages[1]}"
+            [doc-packages]
+            {doc_packages[0]}= "=={doc_packages[1]}"
             """.strip()
             f.write(contents)
         l = p.pipenv('lock')
@@ -101,11 +105,12 @@ def test_requirements_generates_requirements_from_lockfile_from_a_category(pipen
         assert f'{test_packages[0]}=={test_packages[1]}' not in c.stdout
         assert f'{dev_packages[0]}=={dev_packages[1]}' in c.stdout
 
-        d = p.pipenv('requirements --category test')
+        d = p.pipenv('requirements --category test,doc')
         assert d.returncode == 0
         assert f'{packages[0]}=={packages[1]}' not in d.stdout
         assert f'{dev_packages[0]}=={dev_packages[1]}' not in c.stdout
         assert f'{test_packages[0]}=={test_packages[1]}' in d.stdout
+        assert f'{doc_packages[0]}=={doc_packages[1]}' in d.stdout
 
 @pytest.mark.requirements
 def test_requirements_with_git_requirements(pipenv_instance_pypi):


### PR DESCRIPTION
Closes: https://github.com/pypa/pipenv/issues/5397

This adds a `category` option to the `requirements` command. If specified a category, it will only generate the requirements of that category.