### PR TITLE
added foresight workflow and test kit actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,6 +48,11 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
+      - name: Collect Workflow Telemetry
+        uses: runforesight/foresight-workflow-kit-action@v1
+        if: ${{ always() }}
+        with:
+          api_key: ${{ secrets.FORESIGHT_API_KEY }}
       - run: |
           python -m pip install pre-commit
           pre-commit run --all-files --verbose --show-diff-on-failure
@@ -60,6 +65,11 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
+      - name: Collect Workflow Telemetry
+        uses: runforesight/foresight-workflow-kit-action@v1
+        if: ${{ always() }}
+        with:
+          api_key: ${{ secrets.FORESIGHT_API_KEY }}
       - run: |
           python -m pip install --upgrade wheel invoke parver bs4 vistir towncrier requests
           python -m invoke vendoring.update
@@ -80,6 +90,12 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+
+      - name: Collect Workflow Telemetry
+        uses: runforesight/foresight-workflow-kit-action@v1
+        if: ${{ always() }}
+        with:
+          api_key: ${{ secrets.FORESIGHT_API_KEY }}
 
       - name: Get python path
         id: python-path
@@ -122,7 +138,15 @@ jobs:
           PYTHONIOENCODING: "utf-8"
           GIT_SSH_COMMAND: ssh -o StrictHostKeyChecking=accept-new -o CheckHostIP=no
         run: |
-          pipenv run pytest -ra -n auto -v --fulltrace tests
+          pipenv run pytest --junitxml=./reports/results.xml -ra -n auto -v --fulltrace tests
+      - name: Analyze Test and/or Coverage Results
+        uses: runforesight/foresight-test-kit-action@v1
+        if: ${{ always() }}
+        with:
+          api_key: ${{ secrets.FORESIGHT_API_KEY }}
+          test_format: JUNIT
+          test_framework: PYTEST
+          test_path: ./reports/**
 
   build:
     name: Build Package
@@ -133,6 +157,11 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
+      - name: Collect Workflow Telemetry
+        uses: runforesight/foresight-workflow-kit-action@v1
+        if: ${{ always() }}
+        with:
+          api_key: ${{ secrets.FORESIGHT_API_KEY }}
       - run: pip install -U build twine
       - run: |
           python -m build

--- a/.github/workflows/pypi_upload.yml
+++ b/.github/workflows/pypi_upload.yml
@@ -21,6 +21,12 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v3
 
+    - name: Collect Workflow Telemetry
+      uses: runforesight/foresight-workflow-kit-action@v1
+      if: ${{ always() }}
+      with:
+        api_key: ${{ secrets.FORESIGHT_API_KEY }}
+
     - name: Create Release
       id: create_release
       uses: actions/create-release@v1


### PR DESCRIPTION
Hi `pipenv` community,

### The issue

Currently, Foresight (https://www.runforesight.com/) is integrated into this repository to monitor CI pipelines and insights are publicly available here: pypa.app.runforesight.com

But for more detailed monitoring and richer insights, Foresight needs its Github actions to be added into the workflows.

### The fix

This pull request adds Foresight `workflow-kit` and `test-kit` Github actions into **`CI `** (`ci.yml`) and **`Upload Python Package`** (`pypi_upload.yml`) workflows to collect workflow resource usage metrics, process traces and test results.

Note that in the PR, even though `FORESIGHT_API_KEY` is passed to the Foresight Github actions from secrets, it is OK to leave it undefined/empty. Because there is no need for an API key as we support "tokenless authentication" for open-source projects :)

### The checklist

* [ ] Associated issue
* [ ] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

