### PR TITLE
fix PIPENV_MAX_DEPTH environment variable

### DIFF
--- a/pipenv/environments.py
+++ b/pipenv/environments.py
@@ -184,7 +184,7 @@ class Setting:
         """
 
         # NOTE: +1 because of a temporary bug in Pipenv.
-        self.PIPENV_MAX_DEPTH = int(get_from_env("PIPENV_MAX_DEPTH", default=3)) + 1
+        self.PIPENV_MAX_DEPTH = int(get_from_env("MAX_DEPTH", default=3)) + 1
         """Maximum number of directories to recursively search for a Pipfile.
 
         Default is 3. See also ``PIPENV_NO_INHERIT``.


### PR DESCRIPTION
### The issue

I upgraded  from 2022.10.25 to 2022.11.5 and I figured out that my PIPENV_MAX_DEPTH env variable was not taken into account anymore. I had to use PIPENV_PIPENV_MAX_DEPTH. So here is a PR to fix the issue.

Bug introduces here: https://github.com/pypa/pipenv/pull/5451/files#diff-f74d4ef3c891c83b08a2b15b21602d0c31859892478cc4f56bf5be1a2c5092ecL185