### PR TITLE
Issue 5456

### DIFF
--- a/news/5456.bugfix.rst
+++ b/news/5456.bugfix.rst
@@ -1,0 +1,2 @@
+Fix regression of lock generation that caused the keep-outdated behavior to be default.
+

--- a/news/5456.bugfix.rst
+++ b/news/5456.bugfix.rst
@@ -1,2 +1,1 @@
 Fix regression of lock generation that caused the keep-outdated behavior to be default.
-

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -2033,7 +2033,7 @@ def do_outdated(project, pypi_mirror=None, pre=False, clear=False):
         project, clear=clear, pre=pre, write=False, pypi_mirror=pypi_mirror
     )
     for category in project.get_package_categories(for_lockfile=True):
-        for package in lockfile[category]:
+        for package in lockfile.get(category, []):
             try:
                 updated_packages[package] = lockfile[category][package]["version"]
             except KeyError:

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -1157,6 +1157,13 @@ def do_lock(
                 err=True,
             )
 
+        # Prune old lockfile category as new one will be created.
+        if not keep_outdated:
+            try:
+                del lockfile[category]
+            except KeyError:
+                pass
+
         from pipenv.utils.resolver import venv_resolve_deps
 
         # Mutates the lockfile

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -219,11 +219,11 @@ class _Pipfile:
         self.document["source"] = self.document.get("source", tomlkit.aot())
         self.document["requires"] = self.document.get("requires", tomlkit.table())
         self.document["packages"] = self.document.get("packages", tomlkit.table())
-        self.document["dev_packages"] = self.document.get("dev_packages", tomlkit.table())
+        self.document["dev-packages"] = self.document.get("dev-packages", tomlkit.table())
         super().__init__()
 
     def install(self, package, value, dev=False):
-        section = "packages" if not dev else "dev_packages"
+        section = "packages" if not dev else "dev-packages"
         if isinstance(value, dict):
             table = tomlkit.inline_table()
             table.update(value)
@@ -233,10 +233,10 @@ class _Pipfile:
         self.write()
 
     def remove(self, package, dev=False):
-        section = "packages" if not dev else "dev_packages"
+        section = "packages" if not dev else "dev-packages"
         if not dev and package not in self.document[section]:
-            if package in self.document["dev_packages"]:
-                section = "dev_packages"
+            if package in self.document["dev-packages"]:
+                section = "dev-packages"
         del self.document[section][package]
         self.write()
 

--- a/tests/integration/test_uninstall.py
+++ b/tests/integration/test_uninstall.py
@@ -252,5 +252,5 @@ def test_uninstall_multiple_categories(pipenv_instance_private_pypi):
         c = p.pipenv('uninstall six --categories="prereq after"')
         assert c.returncode == 0
 
-        assert "six" not in p.lockfile["prereq"]
+        assert "six" not in p.lockfile.get("prereq", {})
         assert "six" not in p.lockfile["default"]


### PR DESCRIPTION
Thank you for contributing to Pipenv!


### The issue

Fixes #5456

After named package categories was released, the lock file generation had the default behavior of `--keep-outdated` being passed true.
