### PR TITLE
Fix syntax error in requirementslib vendor

### DIFF
--- a/pipenv/vendor/requirementslib/models/metadata.py
+++ b/pipenv/vendor/requirementslib/models/metadata.py
@@ -14,7 +14,7 @@ import pipenv.vendor.attr as attr
 import pipenv.patched.pip._vendor.requests as requests
 import pipenv.vendor.vistir as vistir
 from pipenv.patched.pip._vendor.distlib import wheel
-from pipenv.patched.pip._vendor.distlib.metadata import import Metadata
+from pipenv.patched.pip._vendor.distlib.metadata import Metadata
 from pipenv.patched.pip._vendor.packaging.markers import Marker
 from pipenv.patched.pip._vendor.packaging.requirements import Requirement as PackagingRequirement
 from pipenv.patched.pip._vendor.packaging.specifiers import Specifier, SpecifierSet

--- a/tasks/vendoring/__init__.py
+++ b/tasks/vendoring/__init__.py
@@ -87,7 +87,10 @@ GLOBAL_REPLACEMENT = [
         "from pipenv.patched.pip._vendor.platformdirs import user_cache_dir",
     ),
     ("from distlib import", "from pipenv.patched.pip._vendor.distlib import"),
-    ("from distlib.metadata", "from pipenv.patched.pip._vendor.distlib.metadata import"),
+    (
+        "from distlib.metadata import",
+        "from pipenv.patched.pip._vendor.distlib.metadata import",
+    ),
     ("from distlib.wheel import", "from pipenv.patched.pip._vendor.distlib.wheel import"),
 ]
 


### PR DESCRIPTION
Compiling [vendor/requirementslib/models/metadata.py](https://github.com/pypa/pipenv/blob/30be4768010493cbcbef56752ae85f5c27b13b93/pipenv/vendor/requirementslib/models/metadata.py) raised a `SyntaxError`:

    ***   File "/gnu/store/62ms8p25ilrw7vrz5fn8fjf4pds10b02-pipenv-2022.11.11/lib/python3.9/site-packages/pipenv/vendor/requirementslib/models/metadata.py", line 17
        from pipenv.patched.pip._vendor.distlib.metadata import import Metadata
                                                                ^
    SyntaxError: invalid syntax

Found through `python -m compileall /pipenv/source/` when trying to add pipenv to [Guix](https://guix.gnu.org/).