### PR TITLE
Stop building universal wheels

### DIFF
--- a/news/5496.bugfix.rst
+++ b/news/5496.bugfix.rst
@@ -1,0 +1,1 @@
+Stop building universal wheels since Python 2 is no longer supported.

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,6 +29,3 @@ ignore =
 
 [coverage:run]
 parallel = true
-
-[bdist_wheel]
-universal = 1


### PR DESCRIPTION
Resolve #5496 

https://packaging.python.org/en/latest/guides/dropping-older-python-versions/#dealing-with-the-universal-wheels

> Traditionally, projects providing Python code that is semantically compatible with both Python 2 and Python 3, produce [wheels](https://packaging.python.org/en/latest/glossary/#term-Wheel) that have a `py2.py3` tag in their names. When dropping support for Python 2, it is important not to forget to change this tag to just `py3`. It is often configured within setup.cfg under the `[bdist_wheel]` section by setting `universal = 1` if they use setuptools.

### The checklist

* [x] Associated issue
* [x] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.