### PR TITLE
Fix spelling error in docs/quickstart.rst

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -21,7 +21,7 @@ The main commands are:
 
 - ``uninstall`` - Will remove the dependency
 
-- ``lock`` - Regenarate ``Pipfile.lock`` and updates the dependencies inside it.
+- ``lock`` - Regenerate ``Pipfile.lock`` and updates the dependencies inside it.
 
 These are intended to replace ``$ pip install`` usage, as well as manual virtualenv management.
 


### PR DESCRIPTION
Thank you for contributing to Pipenv!


### The issue

Noticed a spelling error in the Quickstart docs when reading https://pipenv.pypa.io/en/latest/

### The fix

Fixed spelling of word "regenerate" in `docs/quickstart.rst`

This seemed like such a simple fix, I did not bother with adding a news item, et al. Apologies if this means more work for the maintainers.