### PR TITLE
Issue 5486 null markers

### DIFF
--- a/news/5486.bugfix.rst
+++ b/news/5486.bugfix.rst
@@ -1,0 +1,1 @@
+Solve issue where null markers were getting added to lock file when extras were provided.

--- a/pipenv/utils/dependencies.py
+++ b/pipenv/utils/dependencies.py
@@ -234,7 +234,8 @@ def clean_resolved_dep(dep, is_top_level=False, pipfile_entry=None):
         else:
             try:
                 pipfile_entry = translate_markers(pipfile_entry)
-                lockfile["markers"] = pipfile_entry.get("markers")
+                if pipfile_entry.get("markers"):
+                    lockfile["markers"] = pipfile_entry.get("markers")
             except TypeError:
                 pass
     return {name: lockfile}

--- a/tests/integration/test_lock.py
+++ b/tests/integration/test_lock.py
@@ -1,6 +1,5 @@
 import json
 import os
-import sys
 from pathlib import Path
 
 import pytest
@@ -719,3 +718,17 @@ six = "*"
         assert c.returncode == 0
         assert p.lockfile["prereq"]["six"]["index"] == "test"
         assert p.lockfile["default"]["requests"]["index"] == "test"
+
+def test_pinned_pipfile_no_null_markers_when_extras(pipenv_instance_pypi):
+    with pipenv_instance_pypi() as p:
+        with open(p.pipfile_path, "w") as f:
+            contents = """
+[packages]
+dataclasses-json = {extras = ["dev"], version = "==0.5.7"}
+            """.strip()
+            f.write(contents)
+        c = p.pipenv("lock")
+        assert c.returncode == 0
+        assert "dataclasses-json" in p.pipfile["packages"]
+        assert "dataclasses-json" in p.lockfile["default"]
+        assert "markers" not in p.lockfile["default"]["dataclasses-json"]


### PR DESCRIPTION
Thank you for contributing to Pipenv!


### The issue

Fixes #5486 

### The fix

This checks if the marker has a value before adding it to the lock file.

### The checklist

* [X] Associated issue
* [X] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.