### PR TITLE
Remove CI from deprecation warning and only alert if env vars are set.

### DIFF
--- a/pipenv/__init__.py
+++ b/pipenv/__init__.py
@@ -44,16 +44,16 @@ if os.name == "nt":
 
     # Backward compatability with vistir
     no_color = False
-    for item in ("ANSI_COLORS_DISABLED", "VISTIR_DISABLE_COLORS", "CI"):
-        warnings.warn(
-            (
-                f"Please do not use {item}, as it will be removed in future versions."
-                "\nUse NO_COLOR instead."
-            ),
-            DeprecationWarning,
-            stacklevel=2,
-        )
+    for item in ("ANSI_COLORS_DISABLED", "VISTIR_DISABLE_COLORS"):
         if os.getenv(item):
+            warnings.warn(
+                (
+                    f"Please do not use {item}, as it will be removed in future versions."
+                    "\nUse NO_COLOR instead."
+                ),
+                DeprecationWarning,
+                stacklevel=2,
+            )
             no_color = True
 
     if not os.getenv("NO_COLOR") or no_color:


### PR DESCRIPTION
Thank you for contributing to Pipenv!


### The issue

Clean up the windows deprecation warnings for pipenv main branch.
