### PR TITLE
[fix] `update --outdated` raises NonExistentKey with dev package

### DIFF
--- a/news/5540.bugfix.rst
+++ b/news/5540.bugfix.rst
@@ -1,1 +1,1 @@
-Fix: `update --outdated` raises NonExistentKey with outdated dev packages
+Fix: ``update --outdated`` raises NonExistentKey with outdated dev packages

--- a/news/5540.bugfix.rst
+++ b/news/5540.bugfix.rst
@@ -1,0 +1,1 @@
+Fix: `update --outdated` raises NonExistentKey with outdated dev packages

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -2081,7 +2081,9 @@ def do_outdated(project, pypi_mirror=None, pre=False, clear=False):
             )
             if name_in_pipfile:
                 required = ""
-                version = get_version(project.packages[name_in_pipfile])
+                version = get_version(
+                    project.get_pipfile_section(category)[name_in_pipfile]
+                )
                 rdeps = reverse_deps.get(canonicalize_name(package))
                 if isinstance(rdeps, Mapping) and "required" in rdeps:
                     required = " {} required".format(rdeps["required"])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,7 @@ filterwarnings = [
 # `pipenv run pytest --markers` will list all markers inlcuding these
 markers = [
     "install: tests having to do with `pipenv install`",
+    "update: tests having to do with `pipenv update`",
     "needs_internet: integration tests that require internet to pass",
     "basic: basic pipenv tests grouping",
     "dev: tests having to do with dev and dev packages",

--- a/tests/integration/test_update.py
+++ b/tests/integration/test_update.py
@@ -1,0 +1,12 @@
+import pytest
+
+@pytest.mark.parametrize("cmd_option", ["", "--dev"])
+@pytest.mark.basic
+@pytest.mark.update
+def test_update_outdated_with_outdated_package(pipenv_instance_private_pypi, cmd_option):
+    with pipenv_instance_private_pypi() as p:
+        package_name = "six"
+        p.pipenv(f"install {cmd_option} {package_name}==1.11")
+        c = p.pipenv("update --outdated")
+        assert isinstance(c.exception, SystemExit)
+        assert c.stdout_bytes.decode("utf-8").startswith(f"Package '{package_name}' out-of-date:")


### PR DESCRIPTION
closes https://github.com/pypa/pipenv/issues/5540

### The issue

https://github.com/pypa/pipenv/issues/5540

### The fix

Lookup the target package from the correct category instead of always using `[package]` category.

### The checklist

* [x] Associated issue
* [x] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

<!--
### If this is a patch to the `vendor` directory...

Please try to refrain from submitting patches directly to `vendor` or `patched`, but raise your issue to the upstream project instead, and inform Pipenv to upgrade when the upstream project accepts the fix.

A pull request to upgrade vendor packages is strongly discouraged, unless there is a very good reason (e.g. you need to test Pipenv’s integration to a new vendor feature). Pipenv audits and performs vendor upgrades regularly, generally before a new release is about to drop.

If your patch is not or cannot be accepted by upstream, but is essential to Pipenv (make sure to discuss this with maintainers!), please remember to attach a patch file in `tasks/vendoring/patched`, so this divergence from upstream can be recorded and replayed afterwards.
-->
