### PR TITLE
Deprecate --keep-outdated flag.

### DIFF
--- a/pipenv/cli/options.py
+++ b/pipenv/cli/options.py
@@ -158,14 +158,12 @@ def keep_outdated_option(f):
         state = ctx.ensure_object(State)
         state.installstate.keep_outdated = value
         if value:
-            click.echo(
-                click.style(
-                    "Use of --keep-outdated has been deprecated for removal."
-                    "The flag does not respect package resolver results and leads to inconsistent lock files.  "
-                    "Please pin relevant requirements in your Pipfile and discontinue use of this flag.",
-                    fg="yellow",
-                    bold=True,
-                ),
+            click.secho(
+                "The flag --keep-outdated has been deprecated for removal."
+                "The flag does not respect package resolver results and leads to inconsistent lock files.  "
+                "Please pin relevant requirements in your Pipfile and discontinue use of this flag.",
+                fg="yellow",
+                bold=True,
                 err=True,
             )
         return value

--- a/pipenv/cli/options.py
+++ b/pipenv/cli/options.py
@@ -2,6 +2,7 @@ import os
 
 from pipenv.project import Project
 from pipenv.utils.internet import is_valid_url
+from pipenv.vendor import click
 from pipenv.vendor.click import (
     BadArgumentUsage,
     BadParameter,
@@ -13,7 +14,6 @@ from pipenv.vendor.click import (
     option,
     secho,
 )
-from pipenv.vendor import click
 from pipenv.vendor.click import types as click_types
 from pipenv.vendor.click_didyoumean import DYMMixin
 
@@ -158,11 +158,16 @@ def keep_outdated_option(f):
         state = ctx.ensure_object(State)
         state.installstate.keep_outdated = value
         if value:
-            click.echo(click.style(
-                "Use of --keep-outdated has been deprecated for removal."
-                "The flag does not respect package resolver results and leads to inconsistent lock files.  "
-                "Please pin relevant requirements in your Pipfile and discontinue use of this flag.",
-                fg="yellow", bold=True), err=True)
+            click.echo(
+                click.style(
+                    "Use of --keep-outdated has been deprecated for removal."
+                    "The flag does not respect package resolver results and leads to inconsistent lock files.  "
+                    "Please pin relevant requirements in your Pipfile and discontinue use of this flag.",
+                    fg="yellow",
+                    bold=True,
+                ),
+                err=True,
+            )
         return value
 
     return option(

--- a/pipenv/cli/options.py
+++ b/pipenv/cli/options.py
@@ -13,6 +13,7 @@ from pipenv.vendor.click import (
     option,
     secho,
 )
+from pipenv.vendor import click
 from pipenv.vendor.click import types as click_types
 from pipenv.vendor.click_didyoumean import DYMMixin
 
@@ -156,6 +157,12 @@ def keep_outdated_option(f):
     def callback(ctx, param, value):
         state = ctx.ensure_object(State)
         state.installstate.keep_outdated = value
+        if value:
+            click.echo(click.style(
+                "Use of --keep-outdated has been deprecated for removal."
+                "The flag does not respect package resolver results and leads to inconsistent lock files.  "
+                "Please pin relevant requirements in your Pipfile and discontinue use of this flag.",
+                fg="yellow", bold=True), err=True)
         return value
 
     return option(


### PR DESCRIPTION
### The issue

This flag, which was never fully explained in the documentation, leads to a source of a lot of confusion and issue because the underlying concept is flawed.   It cannot be used until a consistent lock file is generated with `pipenv lock` or `pipenv install` and then when applied it will bring in any new package from a new consistent lock phase which is not already defined in the `Pipfile.lock` thus often creating inconsistent and unexpected locks. 

### The fix

This was always a workaround to avoid managing the Pipfile specifiers and packages listed/pinned in the Pipfile, which is the inputs into the resolver for the new lock phase whenever modifying package requirements.  Instead, users that do not want packages updated while upgrading other packages should be pinning those in the Pipfile so they can be used as proper inputs to the pip resolver.

How does this pull request fix your problem? Did you consider any alternatives? Why is this the *best* solution, in your opinion?

I have considered for a year now how to make `--keep-outdated` better, but the reality is it was a flawed idea that existed before the switch to using the pip resolver, and it no longer makes sense to keep around because it leads to confusion and support tickets that shouldn't exist.

### The checklist

* [ ] Associated issue
* [ ] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.
