### PR TITLE
Catch StopIteration error and alert user and exit failure.

### DIFF
--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -766,8 +766,11 @@ def batch_install(
                     extra_pip_args=extra_pip_args,
                 )
             except StopIteration:
-                click.secho(f"Unable to find {index_name} in sources, please check dependencies: {dependencies}",
-                            fg="red", bold=True)
+                click.secho(
+                    f"Unable to find {index_name} in sources, please check dependencies: {dependencies}",
+                    fg="red",
+                    bold=True,
+                )
                 sys.exit(1)
 
 

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -750,20 +750,25 @@ def batch_install(
                 deps_by_index[project.sources_default["name"]].append(dependency)
         # Treat each index as its own pip install phase
         for index_name, dependencies in deps_by_index.items():
-            install_source = next(filter(lambda s: s["name"] == index_name, sources))
-            batch_install_iteration(
-                project,
-                dependencies,
-                [install_source],
-                procs,
-                failed_deps_queue,
-                requirements_dir,
-                no_deps=no_deps,
-                ignore_hashes=ignore_hashes,
-                allow_global=allow_global,
-                retry=retry,
-                extra_pip_args=extra_pip_args,
-            )
+            try:
+                install_source = next(filter(lambda s: s["name"] == index_name, sources))
+                batch_install_iteration(
+                    project,
+                    dependencies,
+                    [install_source],
+                    procs,
+                    failed_deps_queue,
+                    requirements_dir,
+                    no_deps=no_deps,
+                    ignore_hashes=ignore_hashes,
+                    allow_global=allow_global,
+                    retry=retry,
+                    extra_pip_args=extra_pip_args,
+                )
+            except StopIteration:
+                click.secho(f"Unable to find {index_name} in sources, please check dependencies: {dependencies}",
+                            fg="red", bold=True)
+                sys.exit(1)
 
 
 def batch_install_iteration(


### PR DESCRIPTION
Thank you for contributing to Pipenv!

Fixes #5462 


### The issue

Sometimes users have index names defined in their Pipfile that do not correspond to actually defined sources.

### The fix

Alert the user when this happens with a human friendly message and exit with failure code.


### The checklist

* [X] Associated issue
* [ ] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

<!--
### If this is a patch to the `vendor` directory...

Please try to refrain from submitting patches directly to `vendor` or `patched`, but raise your issue to the upstream project instead, and inform Pipenv to upgrade when the upstream project accepts the fix.

A pull request to upgrade vendor packages is strongly discouraged, unless there is a very good reason (e.g. you need to test Pipenv’s integration to a new vendor feature). Pipenv audits and performs vendor upgrades regularly, generally before a new release is about to drop.

If your patch is not or cannot be accepted by upstream, but is essential to Pipenv (make sure to discuss this with maintainers!), please remember to attach a patch file in `tasks/vendoring/patched`, so this divergence from upstream can be recorded and replayed afterwards.
-->
