### PR TITLE
Add Homebrew to installers

### DIFF
--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -359,9 +359,9 @@ def ensure_python(project, three=None, python=None):
             err=True,
         )
         # check for python installers
-        from .installers import Asdf, InstallerError, InstallerNotFound, Pyenv
+        from .installers import Asdf, Homebrew, InstallerError, InstallerNotFound, Pyenv
 
-        # prefer pyenv if both pyenv and asdf are installed as it's
+        # prefer pyenv over asdf and Homebrew as it's
         # dedicated to python installs so probably the preferred
         # method of the user for new python installs.
         installer = None
@@ -375,9 +375,16 @@ def ensure_python(project, three=None, python=None):
                 installer = Asdf(project)
             except InstallerNotFound:
                 pass
+        if installer is None and not project.s.PIPENV_DONT_USE_HOMEBREW:
+            try:
+                installer = Homebrew(project)
+            except InstallerNotFound:
+                pass
 
         if not installer:
-            abort("Neither 'pyenv' nor 'asdf' could be found to install Python.")
+            abort(
+                "Neither 'pyenv', 'asdf' nor 'Homebrew (brew)' could be found to install Python."
+            )
         else:
             if environments.SESSION_IS_INTERACTIVE or project.s.PIPENV_YES:
                 try:
@@ -432,7 +439,13 @@ def ensure_python(project, three=None, python=None):
                     version = str(version)
                     path_to_python = find_a_system_python(version)
                     try:
-                        assert python_version(path_to_python) == version
+                        installed_python_version = python_version(path_to_python)
+                        if isinstance(installer, Homebrew):
+                            # Versions specified for Homebrew,
+                            # do not contain a patch version
+                            assert installed_python_version.startswith(version)
+                        else:
+                            assert installed_python_version == version
                     except AssertionError:
                         click.echo(
                             "{}: The Python you just installed is not available on your {}, apparently."

--- a/pipenv/environments.py
+++ b/pipenv/environments.py
@@ -152,6 +152,14 @@ class Setting:
         Default is to install Python automatically via asdf when needed, if possible.
         """
 
+        self.PIPENV_DONT_USE_HOMEBREW = bool(
+            get_from_env("DONT_USE_HOMEBREW", check_for_negation=False)
+        )
+        """If set, Pipenv does not attempt to install Python with Homebrew.
+
+        Default is to install Python automatically via Homebrew when needed, if possible.
+        """
+
         self.PIPENV_DOTENV_LOCATION = get_from_env(
             "DOTENV_LOCATION", check_for_negation=False
         )

--- a/pipenv/installers.py
+++ b/pipenv/installers.py
@@ -1,3 +1,4 @@
+import json
 import operator
 import os
 import re
@@ -230,3 +231,68 @@ class Asdf(Installer):
             timeout=self.project.s.PIPENV_INSTALL_TIMEOUT,
         )
         return c
+
+
+class Homebrew(Installer):
+    def _find_installer(self):
+        # Homebrew does not use any environment variables.
+        # Therefore, the environment variable parameter is set to an empty string.
+        return self._find_python_installer_by_name("brew")
+
+    def iter_installable_versions(self):
+        """Iterate through CPython versions available for Homebrew to install."""
+        info_json = self._run("info", "--json", "python").stdout
+        for name in self._parse_homebrew_info(info_json):
+            try:
+                version = Version.parse(name.strip())
+            except ValueError:
+                continue
+            yield version
+
+    @staticmethod
+    def _parse_homebrew_info(info_json):
+        # Homebrew returns an array. The first python is the python, we desire
+        python_info = json.loads(info_json)[0]
+        available_versions = []
+        # The current version which is associated with homebrew's python
+        available_versions.append(python_info["name"])
+        # All other available versions
+        available_versions.extend(python_info["versioned_formulae"])
+        return list(map(lambda x: x.replace("python@", ""), available_versions))
+
+    def install(self, version):
+        """Install the given version with Homebrew.
+        The version must be a ``Version`` instance representing a version
+        found in Homebrew.
+        A ValueError is raised if the given version does not have a match in
+        Homebrew. A InstallerError is raised if the brew command fails.
+        """
+        c = self._run(
+            "install",
+            f"python@{version}",
+            timeout=self.project.s.PIPENV_INSTALL_TIMEOUT,
+        )
+        return c
+
+    @staticmethod
+    def _find_python_installer_by_name(name):
+        """
+        Try to locate the binary for the Homebrew package manager.
+
+        Since Homebrew has to be setup via builtin command, it is always available on
+        the path.
+        Therefore, this method differs from the static method
+        `_find_python_installer_by_name_and_env` of it's parent class and only searches
+        on the PATH. This is equivalent to which(1).
+        """
+        # Look for the Python installer using the equivalent of 'which'. On
+        # Homebrew-installed systems, the env var may not be set, but this
+        # strategy will work.
+        candidate = find_windows_executable("", name)
+        if (
+            candidate is not None
+            and os.path.isfile(candidate)
+            and os.access(candidate, os.X_OK)
+        ):
+            return candidate
+        raise InstallerNotFound()


### PR DESCRIPTION
Add an installer for Homebrew.
Homebrew is one of the main package managers on OSX.
It would be great to be able to use it,
as it can install multiple python versions and is
often installed on Mac or Linux.