### PR TITLE
Remove deprecated flag --three

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,8 +144,6 @@ activate a virtualenv, run `$ pipenv shell`).
 -   A virtualenv will automatically be created, when one doesn\'t exist.
 -   When no parameters are passed to `install`, all packages
     `[packages]` specified will be installed.
--   To initialize a virtual environment with system python3, run
-    `$ pipenv --three`.
 -   Otherwise, whatever virtualenv defaults to will be the default.
 
 ### Other Commands
@@ -198,7 +196,6 @@ Usage
                                       [env var: PIPENV_SITE_PACKAGES]
       --python TEXT                   Specify which version of Python virtualenv
                                       should use.
-      --three                         Use Python 3 when creating virtualenv.
       --clear                         Clears caches (pipenv, pip).  [env var:
                                       PIPENV_CLEAR]
       -q, --quiet                     Quiet mode.

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -787,7 +787,7 @@ package manager, and hence unavailable for installation into virtual
 environments with ``pip``. In these cases, the virtual environment can
 be created with access to the system ``site-packages`` directory::
 
-    $ pipenv --three --site-packages
+    $ pipenv --site-packages
 
 To ensure that all ``pip``-installable components actually are installed
 into the virtual environment and system packages are only used for
@@ -829,4 +829,4 @@ You can force Pipenv to use a different cache location by setting the environmen
 ☤ Changing Default Python Versions
 ----------------------------------
 
-By default, Pipenv will initialize a project using whatever version of python the system has as default. Besides starting a project with the ``--python`` or ``--three`` flags, you can also use ``PIPENV_DEFAULT_PYTHON_VERSION`` to specify what version to use when starting a project when ``--python`` or ``--three`` aren't used.
+By default, Pipenv will initialize a project using whatever version of python the system has as default. Besides starting a project with the ``--python`` flag, you can also use ``PIPENV_DEFAULT_PYTHON_VERSION`` to specify what version to use when starting a project when ``--python`` isn't used.

--- a/docs/basics.rst
+++ b/docs/basics.rst
@@ -331,7 +331,6 @@ Along with the basic install command, which takes the form::
 
 The user can provide these additional parameters:
 
-    - ``--three`` — Performs the installation in a virtualenv using the system ``python3`` link.
     - ``--python`` — Performs the installation in a virtualenv using the provided Python interpreter.
 
     .. warning:: None of the above commands should be used together. They are also

--- a/news/5576.removal.rst
+++ b/news/5576.removal.rst
@@ -1,0 +1,1 @@
+Remove deprecated --three flag from the CLI.

--- a/pipenv/cli/command.py
+++ b/pipenv/cli/command.py
@@ -19,7 +19,6 @@ from pipenv.cli.options import (
     skip_lock_option,
     sync_options,
     system_option,
-    three_option,
     uninstall_options,
     verbose_option,
 )
@@ -205,11 +204,10 @@ def cli(
                     err=True,
                 )
                 ctx.abort()
-    # --python or --three was passed...
-    if (state.python or state.three is not None) or state.site_packages:
+    # --python was passed...
+    if (state.python) or state.site_packages:
         ensure_project(
             state.project,
-            three=state.three,
             python=state.python,
             warn=True,
             site_packages=state.site_packages,
@@ -239,7 +237,6 @@ def install(state, **kwargs):
     do_install(
         state.project,
         dev=state.installstate.dev,
-        three=state.three,
         python=state.python,
         pypi_mirror=state.pypi_mirror,
         system=state.system,
@@ -286,7 +283,6 @@ def uninstall(ctx, state, all_dev=False, all=False, **kwargs):
         state.project,
         packages=state.installstate.packages,
         editable_packages=state.installstate.editables,
-        three=state.three,
         python=state.python,
         system=state.system,
         lock=not state.installstate.skip_lock,
@@ -330,7 +326,6 @@ def lock(ctx, state, **kwargs):
     # handled in do_lock
     ensure_project(
         state.project,
-        three=state.three,
         python=state.python,
         pypi_mirror=state.pypi_mirror,
         warn=(not state.quiet),
@@ -368,7 +363,6 @@ def lock(ctx, state, **kwargs):
 )
 @argument("shell_args", nargs=-1)
 @pypi_mirror_option
-@three_option
 @python_option
 @pass_state
 def shell(
@@ -401,7 +395,6 @@ def shell(
         fancy = True
     do_shell(
         state.project,
-        three=state.three,
         python=state.python,
         fancy=fancy,
         shell_args=shell_args,
@@ -425,7 +418,6 @@ def run(state, command, args):
         state.project,
         command=command,
         args=args,
-        three=state.three,
         python=state.python,
         pypi_mirror=state.pypi_mirror,
     )
@@ -509,7 +501,6 @@ def check(
 
     do_check(
         state.project,
-        three=state.three,
         python=state.python,
         system=state.system,
         db=db,
@@ -539,7 +530,6 @@ def update(ctx, state, bare=False, dry_run=None, outdated=False, **kwargs):
 
     ensure_project(
         state.project,
-        three=state.three,
         python=state.python,
         pypi_mirror=state.pypi_mirror,
         warn=(not state.quiet),
@@ -591,7 +581,6 @@ def update(ctx, state, bare=False, dry_run=None, outdated=False, **kwargs):
     do_sync(
         state.project,
         dev=state.installstate.dev,
-        three=state.three,
         python=state.python,
         bare=bare,
         dont_upgrade=not state.installstate.keep_outdated,
@@ -640,7 +629,6 @@ def run_open(state, module, *args, **kwargs):
     # Ensure that virtualenv is available.
     ensure_project(
         state.project,
-        three=state.three,
         python=state.python,
         validate=False,
         pypi_mirror=state.pypi_mirror,
@@ -681,7 +669,6 @@ def sync(ctx, state, bare=False, user=False, unused=False, **kwargs):
     retcode = do_sync(
         state.project,
         dev=state.installstate.dev,
-        three=state.three,
         python=state.python,
         bare=bare,
         dont_upgrade=(not state.installstate.keep_outdated),
@@ -704,7 +691,6 @@ def sync(ctx, state, bare=False, user=False, unused=False, **kwargs):
 @option("--bare", is_flag=True, default=False, help="Minimal output.")
 @option("--dry-run", is_flag=True, default=False, help="Just output unneeded packages.")
 @verbose_option
-@three_option
 @python_option
 @pass_state
 def clean(state, dry_run=False, bare=False, user=False):
@@ -713,7 +699,6 @@ def clean(state, dry_run=False, bare=False, user=False):
 
     do_clean(
         state.project,
-        three=state.three,
         python=state.python,
         dry_run=dry_run,
         system=state.system,

--- a/pipenv/cli/options.py
+++ b/pipenv/cli/options.py
@@ -12,7 +12,6 @@ from pipenv.vendor.click import (
     echo,
     make_pass_decorator,
     option,
-    secho,
 )
 from pipenv.vendor.click import types as click_types
 from pipenv.vendor.click_didyoumean import DYMMixin
@@ -65,8 +64,6 @@ class State:
         self.quiet = False
         self.pypi_mirror = None
         self.python = None
-        self.two = None
-        self.three = None
         self.site_packages = None
         self.clear = False
         self.system = False
@@ -316,28 +313,6 @@ def extra_pip_args(f):
     )(f)
 
 
-def three_option(f):
-    def callback(ctx, param, value):
-        state = ctx.ensure_object(State)
-        if value is not None:
-            secho(
-                "WARNING: --three is deprecated! pipenv uses python3 by default",
-                err=True,
-                fg="yellow",
-            )
-            state.three = value
-        return value
-
-    return option(
-        "--three",
-        is_flag=True,
-        default=None,
-        help="Use Python 3 when creating virtualenv. Deprecated",
-        callback=callback,
-        expose_value=False,
-    )(f)
-
-
 def python_option(f):
     def callback(ctx, param, value):
         state = ctx.ensure_object(State)
@@ -562,7 +537,6 @@ def common_options(f):
     f = verbose_option(f)
     f = quiet_option(f)
     f = clear_option(f)
-    f = three_option(f)
     f = python_option(f)
     return f
 

--- a/pipenv/environments.py
+++ b/pipenv/environments.py
@@ -124,7 +124,7 @@ class Setting:
 
         This can be set to a version string, e.g. ``3.9``, or a path. Default is to use
         whatever Python Pipenv is installed under (i.e. ``sys.executable``). Command
-        line flags (e.g. ``--python`` and ``--three``) are prioritized over
+        line flags (e.g. ``--python``) are prioritized over
         this configuration.
         """
 

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -242,14 +242,6 @@ def test_pipenv_clear(pipenv_instance_pypi):
         assert 'Clearing caches' in c.stdout
 
 
-@pytest.mark.cli
-def test_pipenv_three(pipenv_instance_pypi):
-    with pipenv_instance_pypi() as p:
-        c = p.pipenv('--three')
-        assert c.returncode == 0
-        assert 'Successfully created virtual environment' in c.stderr
-
-
 @pytest.mark.outdated
 def test_pipenv_outdated_prerelease(pipenv_instance_pypi):
     with pipenv_instance_pypi(chdir=True) as p:


### PR DESCRIPTION
The flag was deprecated 4 months ago and it's time to let it go.
Doing so removes a lot of state and checks. 