### PR TITLE
Removal/vistir misc

### DIFF
--- a/pipenv/__init__.py
+++ b/pipenv/__init__.py
@@ -43,6 +43,7 @@ if os.name == "nt":
     from pipenv.vendor import colorama
 
     # Backward compatability with vistir
+    # These variables will be removed in vistir 0.8.0
     no_color = False
     for item in ("ANSI_COLORS_DISABLED", "VISTIR_DISABLE_COLORS"):
         if os.getenv(item):

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -1468,7 +1468,7 @@ def write_requirement_to_file(
         click.echo(
             f"Writing supplied requirement line to temporary file: {line!r}", err=True
         )
-    f.write(line)
+    f.write(line.encode())
     r = f.name
     f.close()
     return r
@@ -1661,8 +1661,8 @@ def pip_install_deps(
                 err=True,
             )
         target = editable_requirements if vcs_or_editable else standard_requirements
-        target.write(line)
-        target.write("\n")
+        target.write(line.encode())
+        target.write(b"\n")
     standard_requirements.close()
     editable_requirements.close()
 

--- a/pipenv/core.py
+++ b/pipenv/core.py
@@ -1468,7 +1468,7 @@ def write_requirement_to_file(
         click.echo(
             f"Writing supplied requirement line to temporary file: {line!r}", err=True
         )
-    f.write(vistir.misc.to_bytes(line))
+    f.write(line)
     r = f.name
     f.close()
     return r
@@ -1661,8 +1661,8 @@ def pip_install_deps(
                 err=True,
             )
         target = editable_requirements if vcs_or_editable else standard_requirements
-        target.write(vistir.misc.to_bytes(line))
-        target.write(vistir.misc.to_bytes("\n"))
+        target.write(line)
+        target.write("\n")
     standard_requirements.close()
     editable_requirements.close()
 

--- a/pipenv/environment.py
+++ b/pipenv/environment.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import contextlib
 import importlib
 import importlib.util

--- a/pipenv/environment.py
+++ b/pipenv/environment.py
@@ -18,6 +18,7 @@ from pipenv.patched.pip._internal.req.req_uninstall import UninstallPathSet
 from pipenv.patched.pip._vendor import pkg_resources
 from pipenv.patched.pip._vendor.packaging.utils import canonicalize_name
 from pipenv.utils.constants import is_type_checking
+from pipenv.utils.funktools import chunked, unnest
 from pipenv.utils.indexes import prepare_pip_source_args
 from pipenv.utils.processes import subprocess_run
 from pipenv.utils.shell import make_posix, normalize_path
@@ -714,8 +715,6 @@ class Environment:
         yield new_node
 
     def reverse_dependencies(self):
-        from vistir.misc import chunked, unnest
-
         rdeps = {}
         for req in self.get_package_requirements():
             for d in self.reverse_dependency(req):

--- a/pipenv/environment.py
+++ b/pipenv/environment.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import contextlib
 import importlib
 import importlib.util
@@ -7,6 +9,7 @@ import operator
 import os
 import site
 import sys
+import typing
 from pathlib import Path
 from sysconfig import get_paths, get_python_version, get_scheme_names
 
@@ -17,7 +20,6 @@ from pipenv.patched.pip._internal.index.package_finder import PackageFinder
 from pipenv.patched.pip._internal.req.req_uninstall import UninstallPathSet
 from pipenv.patched.pip._vendor import pkg_resources
 from pipenv.patched.pip._vendor.packaging.utils import canonicalize_name
-from pipenv.utils.constants import is_type_checking
 from pipenv.utils.funktools import chunked, unnest
 from pipenv.utils.indexes import prepare_pip_source_args
 from pipenv.utils.processes import subprocess_run
@@ -32,7 +34,7 @@ except ImportError:
     from pipenv.patched.pip._vendor.distlib.util import cached_property
 
 
-if is_type_checking():
+if typing.TYPE_CHECKING:
     from types import ModuleType
     from typing import ContextManager, Dict, Generator, List, Optional, Set, Union
 

--- a/pipenv/exceptions.py
+++ b/pipenv/exceptions.py
@@ -4,7 +4,7 @@ from collections import namedtuple
 from traceback import format_tb
 
 from pipenv import environments
-from pipenv.vendor import click, vistir
+from pipenv.vendor import click
 from pipenv.vendor.click.exceptions import ClickException, FileError, UsageError
 
 if sys.version_info[:2] >= (3, 7):
@@ -67,7 +67,7 @@ class PipenvException(ClickException):
 
     def show(self, file=None):
         if file is None:
-            file = vistir.misc.get_text_stderr()
+            file = sys.stderr
         if self.extra:
             if isinstance(self.extra, str):
                 self.extra = [self.extra]
@@ -90,7 +90,7 @@ class PipenvCmdError(PipenvException):
 
     def show(self, file=None):
         if file is None:
-            file = vistir.misc.get_text_stderr()
+            file = sys.stderr
         click.echo(
             "{} {}".format(
                 click.style("Error running command: ", fg="red"),
@@ -120,7 +120,7 @@ class JSONParseError(PipenvException):
 
     def show(self, file=None):
         if file is None:
-            file = vistir.misc.get_text_stderr()
+            file = sys.stderr
         message = "{}\n{}".format(
             click.style("Failed parsing JSON results:", bold=True),
             print(self.message.strip(), file=file),
@@ -150,7 +150,7 @@ class PipenvUsageError(UsageError):
 
     def show(self, file=None):
         if file is None:
-            file = vistir.misc.get_text_stderr()
+            file = sys.stderr
         color = None
         if self.ctx is not None:
             color = self.ctx.color
@@ -189,7 +189,7 @@ class PipenvFileError(FileError):
 
     def show(self, file=None):
         if file is None:
-            file = vistir.misc.get_text_stderr()
+            file = sys.stderr
         if self.extra:
             if isinstance(self.extra, str):
                 self.extra = [self.extra]

--- a/pipenv/utils/funktools.py
+++ b/pipenv/utils/funktools.py
@@ -1,9 +1,12 @@
 """
 A small collection of useful functional tools for working with iterables.
-"""
-from functools import islice, partial, tee
 
-from typings import Any, Iterable
+This module should be in requirementslib. Once we release a new version of requirementslib
+we can remove this file and use the one in requirementslib.
+"""
+from functools import partial
+from itertools import islice, tee
+from typing import Any, Iterable
 
 
 def _is_iterable(elem: Any) -> bool:

--- a/pipenv/utils/funktools.py
+++ b/pipenv/utils/funktools.py
@@ -70,3 +70,11 @@ def unnest(elem: Iterable) -> Any:
                     yield sub
             else:
                 yield el
+
+
+def dedup(iterable: Iterable) -> Iterable:
+    # type: (Iterable) -> Iterable
+    """Deduplicate an iterable object like iter(set(iterable)) but order-
+    preserved."""
+
+    return iter(dict.fromkeys(iterable))

--- a/pipenv/utils/funktools.py
+++ b/pipenv/utils/funktools.py
@@ -1,0 +1,69 @@
+"""
+A small collection of useful functional tools for working with iterables.
+"""
+from functools import islice, partial, tee
+
+from typings import Any, Iterable
+
+
+def _is_iterable(elem: Any) -> bool:
+    if getattr(elem, "__iter__", False) or isinstance(elem, Iterable):
+        return True
+    return False
+
+
+def take(n: int, iterable: Iterable) -> Iterable:
+    """Take n elements from the supplied iterable without consuming it.
+
+    :param int n: Number of unique groups
+    :param iter iterable: An iterable to split up
+    """
+    return list(islice(iterable, n))
+
+
+def chunked(n: int, iterable: Iterable) -> Iterable:
+    """Split an iterable into lists of length *n*.
+
+    :param int n: Number of unique groups
+    :param iter iterable: An iterable to split up
+
+    """
+    return iter(partial(take, n, iter(iterable)), [])
+
+
+def unnest(elem: Iterable) -> Any:
+    # type: (Iterable) -> Any
+    """Flatten an arbitrarily nested iterable.
+
+    :param elem: An iterable to flatten
+    :type elem: :class:`~collections.Iterable`
+    >>> nested_iterable = (
+            1234, (3456, 4398345, (234234)), (
+                2396, (
+                    928379, 29384, (
+                        293759, 2347, (
+                            2098, 7987, 27599
+                        )
+                    )
+                )
+            )
+        )
+    >>> list(unnest(nested_iterable))
+    [1234, 3456, 4398345, 234234, 2396, 928379, 29384, 293759,
+     2347, 2098, 7987, 27599]
+    """
+
+    if isinstance(elem, Iterable) and not isinstance(elem, str):
+        elem, target = tee(elem, 2)
+    else:
+        target = elem
+    if not target or not _is_iterable(target):
+        yield target
+    else:
+        for el in target:
+            if isinstance(el, Iterable) and not isinstance(el, str):
+                el, el_copy = tee(el, 2)
+                for sub in unnest(el_copy):
+                    yield sub
+            else:
+                yield el

--- a/tests/unit/test_funktools.py
+++ b/tests/unit/test_funktools.py
@@ -1,0 +1,50 @@
+import pytest
+
+from pipenv.utils.funktools import dedup, unnest, _is_iterable
+
+
+def test_unnest():
+    nested_iterable = (
+            1234, (3456, 4398345, (234234)), (
+                2396, (
+                    928379, 29384, (
+                        293759, 2347, (
+                            2098, 7987, 27599
+                        )
+                    )
+                )
+            )
+        )
+    list(unnest(nested_iterable)) == [1234, 3456, 4398345, 234234,
+                                      2396, 928379, 29384, 293759,
+                                      2347, 2098, 7987, 27599]
+
+
+@pytest.mark.parametrize(
+    "iterable, result",
+    [
+        [["abc", "def"], True],
+        [("abc", "def"), True],
+        ["abcdef", True],
+        [None, False],
+        [1234, False],
+    ],
+)
+def test_is_iterable(iterable, result):
+    assert _is_iterable(iterable) is result
+
+
+def test_unnest_none():
+    assert list(unnest(None)) == [None]
+
+
+def test_dedup():
+    dup_strings = ["abcde", "fghij", "klmno", "pqrst", "abcde", "klmno"]
+    assert list(dedup(dup_strings)) == [
+        "abcde",
+        "fghij",
+        "klmno",
+        "pqrst",
+    ]
+    dup_ints = (12345, 56789, 12345, 54321, 98765, 54321)
+    assert list(dedup(dup_ints)) == [12345, 56789, 54321, 98765]


### PR DESCRIPTION
Remove more old code that depends on vistir misc.

This PR has two distinct part:

First, remove `vistir.misc.to_bytes` and `vistir.misc.get_text_stderr()`. 
Second, add funktools, which was included in `vistir.misc`. These functions are dropped from vistir 0.8.0 (to be released).
