### PR TITLE
Switch to Nushell overlays

### DIFF
--- a/news/5603.bugfix.rst
+++ b/news/5603.bugfix.rst
@@ -1,0 +1,1 @@
+Use Nushell overlays when running ``pipenv shell``.

--- a/pipenv/shells.py
+++ b/pipenv/shells.py
@@ -46,7 +46,7 @@ def _get_activate_script(cmd, venv):
         command = "source"
     elif "nu" in cmd:
         suffix = ".nu"
-        command = "source"
+        command = "overlay use"
     else:
         suffix = ""
         command = "."


### PR DESCRIPTION
This adds support for Nushell overlays. See #5583 for info.

### The issue

Nushell support is broken due to a change in the `virtualenv` package which expects users to load the file using overlays instead of the `source` command. See #5583 for info.

### The fix

Changing the command from `source` to `overlay use` resolves the issue.

### The checklist

* [x] Associated issue
* [x] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

<!--
### If this is a patch to the `vendor` directory...

Please try to refrain from submitting patches directly to `vendor` or `patched`, but raise your issue to the upstream project instead, and inform Pipenv to upgrade when the upstream project accepts the fix.

A pull request to upgrade vendor packages is strongly discouraged, unless there is a very good reason (e.g. you need to test Pipenv’s integration to a new vendor feature). Pipenv audits and performs vendor upgrades regularly, generally before a new release is about to drop.

If your patch is not or cannot be accepted by upstream, but is essential to Pipenv (make sure to discuss this with maintainers!), please remember to attach a patch file in `tasks/vendoring/patched`, so this divergence from upstream can be recorded and replayed afterwards.
-->
