### PR TITLE
Add missing spaces to `--keep-outdated` deprecation text

### DIFF
--- a/news/5618.trivial.rst
+++ b/news/5618.trivial.rst
@@ -1,0 +1,1 @@
+Add missing spaces to the ``--keep-outdated`` flag's deprecation warning.

--- a/pipenv/cli/options.py
+++ b/pipenv/cli/options.py
@@ -157,7 +157,7 @@ def keep_outdated_option(f):
         state.installstate.keep_outdated = value
         if value:
             click.secho(
-                "The flag --keep-outdated has been deprecated for removal."
+                "The flag --keep-outdated has been deprecated for removal.  "
                 "The flag does not respect package resolver results and leads to inconsistent lock files.  "
                 "Please pin relevant requirements in your Pipfile and discontinue use of this flag.",
                 fg="yellow",


### PR DESCRIPTION
Fixes #5618.

### The checklist

* [x] Associated issue
* [x] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.
