### PR TITLE
Require the actual 'beautifulsoup4' package, not the 'bs4' redirect.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -76,7 +76,7 @@ jobs:
         with:
           api_key: ${{ secrets.FORESIGHT_API_KEY }}
       - run: |
-          python -m pip install --upgrade wheel invoke parver bs4 vistir towncrier requests parse
+          python -m pip install --upgrade wheel invoke parver beautifulsoup4 vistir towncrier requests parse
           python -m invoke vendoring.update
   tests:
     name: ${{matrix.os}} / ${{ matrix.python-version }}

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -92,12 +92,6 @@
             "markers": "python_version >= '3.7'",
             "version": "==23.1.0"
         },
-        "bs4": {
-            "hashes": [
-                "sha256:36ecea1fd7cc5c0c6e4a1ff075df26d50da647b75376626cc186e2212886dd3a"
-            ],
-            "version": "==0.0.1"
-        },
         "certifi": {
             "hashes": [
                 "sha256:35824b4c3a97115964b408844d64aa14db1cc518f6562e8d7261699d1350a9e3",

--- a/news/5620.trivial.rst
+++ b/news/5620.trivial.rst
@@ -1,0 +1,1 @@
+Use beautifulsoup4 as a dependency, not the bs4 redirect.

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ required = [
 extras = {
     "dev": [
         "towncrier",
-        "bs4",
+        "beautifulsoup4",
         "sphinx",
         "flake8>=3.3.0,<4.0",
         "black;python_version>='3.7'",


### PR DESCRIPTION
This shouldn't affect anything other than the shipped Pipfile.lock having one less package in it, and future-proofing in case the BeautifulSoup maintainer ever stops maintaining the redirect.

### The issue

The `bs4` on PyPI is just a redirect to the latest release of `beautifulsoup4`.  Might as well point to the actual package.
Notably, in some cases, a scanner of a package  downstream of pipenv will note that their dependency chain is including a package (`bs4`) that is marked "inactive" on PyPI.

### The fix

Swap `bs4` for `beautifulsoup4` in the two places where it's mentioned.

Surgically remove bs4 from the Pipfile.lock.

### The checklist

* [:x:] Associated issue
* [:heavy_check_mark:] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

