### PR TITLE
Fix dev flag support in update/upgrade.

### DIFF
--- a/pipenv/cli/command.py
+++ b/pipenv/cli/command.py
@@ -282,6 +282,7 @@ def upgrade(state, **kwargs):
         packages=state.installstate.packages,
         editable_packages=state.installstate.editables,
         categories=state.installstate.categories,
+        dev=state.installstate.dev,
         system=state.system,
         lock_only=state.installstate.lock_only,
     )

--- a/pipenv/routines/update.py
+++ b/pipenv/routines/update.py
@@ -170,7 +170,10 @@ def upgrade(
             packages = project.get_pipfile_section(pipfile_category)
         for package_name, requirement in requested_packages.items():
             requested_package = reqs[package_name]
-            packages[package_name] = requested_package
+            if package_name not in packages:
+                packages.append(package_name, requested_package)
+            else:
+                packages[package_name] = requested_package
             if lock_only is False:
                 project.add_package_to_pipfile(requirement, category=pipfile_category)
 

--- a/pipenv/routines/update.py
+++ b/pipenv/routines/update.py
@@ -80,6 +80,7 @@ def do_update(
             editable_packages=editable,
             pypi_mirror=pypi_mirror,
             categories=categories,
+            dev=dev,
             lock_only=lock_only,
         )
 
@@ -106,13 +107,16 @@ def upgrade(
     editable_packages=None,
     pypi_mirror=None,
     categories=None,
+    dev=False,
     lock_only=False,
 ):
 
     lockfile = project._lockfile()
     if not pre:
         pre = project.settings.get("allow_prereleases")
-    if not categories:
+    if dev:
+        categories = ["develop"]
+    elif not categories:
         categories = ["default"]
 
     package_args = [p for p in packages] + [f"-e {pkg}" for pkg in editable_packages]

--- a/pipenv/routines/update.py
+++ b/pipenv/routines/update.py
@@ -188,8 +188,9 @@ def upgrade(
         )
         # Mutate the existing lockfile with the upgrade data for the categories
         for package_name, _ in upgrade_lock_data.items():
-            correct_package_lock = full_lock_resolution[package_name]
-            lockfile[category][package_name] = correct_package_lock
+            correct_package_lock = full_lock_resolution.get(package_name)
+            if correct_package_lock:
+                lockfile[category][package_name] = correct_package_lock
 
     lockfile.update({"_meta": project.get_lockfile_meta()})
     project.write_lockfile(lockfile)

--- a/pipenv/routines/update.py
+++ b/pipenv/routines/update.py
@@ -7,6 +7,7 @@ from pipenv.utils.dependencies import (
     convert_deps_to_pip,
     get_pipfile_category_using_lockfile_section,
     is_star,
+    pep423_name,
 )
 from pipenv.utils.project import ensure_project
 from pipenv.utils.resolver import venv_resolve_deps
@@ -128,6 +129,7 @@ def upgrade(
         section = {}
         package = Requirement.from_line(package)
         package_name, package_val = package.pipfile_entry
+        package_name = pep423_name(package_name)
         requested_packages[package_name] = package
         try:
             if not is_star(section[package_name]) and is_star(package_val):
@@ -168,10 +170,7 @@ def upgrade(
             packages = project.get_pipfile_section(pipfile_category)
         for package_name, requirement in requested_packages.items():
             requested_package = reqs[package_name]
-            if package_name not in packages:
-                packages.append(package_name, requested_package)
-            else:
-                packages[package_name] = requested_package
+            packages[package_name] = requested_package
             if lock_only is False:
                 project.add_package_to_pipfile(requirement, category=pipfile_category)
 


### PR DESCRIPTION
Thank you for contributing to Pipenv!


### The issue

Fixes #5624 

No news fragment requirement since the upgrade command hasn't been released yet.

### The checklist

* [X] Associated issue
* [X] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

<!--
### If this is a patch to the `vendor` directory...

Please try to refrain from submitting patches directly to `vendor` or `patched`, but raise your issue to the upstream project instead, and inform Pipenv to upgrade when the upstream project accepts the fix.

A pull request to upgrade vendor packages is strongly discouraged, unless there is a very good reason (e.g. you need to test Pipenv’s integration to a new vendor feature). Pipenv audits and performs vendor upgrades regularly, generally before a new release is about to drop.

If your patch is not or cannot be accepted by upstream, but is essential to Pipenv (make sure to discuss this with maintainers!), please remember to attach a patch file in `tasks/vendoring/patched`, so this divergence from upstream can be recorded and replayed afterwards.
-->
