### PR TITLE
Message for Pipfile.lock packages vulnerabilities check

### DIFF
--- a/news/5628.trivial.rst
+++ b/news/5628.trivial.rst
@@ -1,0 +1,1 @@
+Show a different message for ``pipenv check`` depending on the ``--use-installed`` option.

--- a/pipenv/routines/check.py
+++ b/pipenv/routines/check.py
@@ -95,10 +95,16 @@ def do_check(
         if not quiet and not project.s.is_quiet():
             click.secho("Passed!", fg="green")
     if not quiet and not project.s.is_quiet():
-        click.secho(
-            "Checking installed packages for vulnerabilities...",
-            bold=True,
-        )
+        if use_installed:
+            click.secho(
+                "Checking installed packages for vulnerabilities...",
+                bold=True,
+            )
+        else:
+            click.secho(
+                "Checking Pipfile.lock packages for vulnerabilities...",
+                bold=True,
+            )
     if ignore:
         if not isinstance(ignore, (tuple, list)):
             ignore = [ignore]


### PR DESCRIPTION
### The issue

pipenv check still prints "Checking installed packages for vulnerabilities...", regardless of it's using the installed environment with --use-installed or if it's using the dependencies from Pipfile.lock. If using default behavior, this should read something like "Checking Pipfile.lock packages for vulnerabilities..."

Fix #5600 

### The fix

Show a different message if  `--use-installed` is specified in `pipenv check`


### The checklist

* [x] Associated issue
* [x] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

<!--
### If this is a patch to the `vendor` directory...

Please try to refrain from submitting patches directly to `vendor` or `patched`, but raise your issue to the upstream project instead, and inform Pipenv to upgrade when the upstream project accepts the fix.

A pull request to upgrade vendor packages is strongly discouraged, unless there is a very good reason (e.g. you need to test Pipenv’s integration to a new vendor feature). Pipenv audits and performs vendor upgrades regularly, generally before a new release is about to drop.

If your patch is not or cannot be accepted by upstream, but is essential to Pipenv (make sure to discuss this with maintainers!), please remember to attach a patch file in `tasks/vendoring/patched`, so this divergence from upstream can be recorded and replayed afterwards.
-->
