### PR TITLE
Replace deprecated BadZipfile with BadZipFile

### DIFF
--- a/pipenv/patched/pip/_internal/network/lazy_wheel.py
+++ b/pipenv/patched/pip/_internal/network/lazy_wheel.py
@@ -6,7 +6,7 @@ from bisect import bisect_left, bisect_right
 from contextlib import contextmanager
 from tempfile import NamedTemporaryFile
 from typing import Any, Dict, Generator, List, Optional, Tuple
-from zipfile import BadZipfile, ZipFile
+from zipfile import BadZipFile, ZipFile
 
 from pipenv.patched.pip._vendor.packaging.utils import canonicalize_name
 from pipenv.patched.pip._vendor.requests.models import CONTENT_CHUNK_SIZE, Response
@@ -160,7 +160,7 @@ class LazyZipOverHTTP:
                     # For read-only ZIP files, ZipFile only needs
                     # methods read, seek, seekable and tell.
                     ZipFile(self)  # type: ignore
-                except BadZipfile:
+                except BadZipFile:
                     pass
                 else:
                     break


### PR DESCRIPTION
Thank you for contributing to Pipenv!


### The issue

`BadZipfile` (with a small `f`) has been deprecated since Python 3.2.

* https://docs.python.org/3/library/zipfile.html#zipfile.BadZipfile
* https://github.com/python/cpython/issues/86437

### The fix

Use `BadZipFile` (big `F`) instead, added in 3.2.

### The checklist

* [ ] Associated issue
* [ ] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

<!--
### If this is a patch to the `vendor` directory...

Please try to refrain from submitting patches directly to `vendor` or `patched`, but raise your issue to the upstream project instead, and inform Pipenv to upgrade when the upstream project accepts the fix.

A pull request to upgrade vendor packages is strongly discouraged, unless there is a very good reason (e.g. you need to test Pipenv’s integration to a new vendor feature). Pipenv audits and performs vendor upgrades regularly, generally before a new release is about to drop.

If your patch is not or cannot be accepted by upstream, but is essential to Pipenv (make sure to discuss this with maintainers!), please remember to attach a patch file in `tasks/vendoring/patched`, so this divergence from upstream can be recorded and replayed afterwards.
-->
