### PR TITLE
feat: Replace flake8 and isort with ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ exclude: '^(pipenv/patched/|pipenv/vendor/|tests/|pipenv/pipenv.1)'
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.1.0
+  rev: v4.4.0
   hooks:
   - id: check-builtin-literals
   - id: check-added-large-files
@@ -17,30 +17,19 @@ repos:
   - id: trailing-whitespace
     exclude: .patch
 
+- repo: https://github.com/charliermarsh/ruff-pre-commit
+  rev: v0.0.259
+  hooks:
+  - id: ruff
+    # args: [--fix, --exit-non-zero-on-fix]
+
 - repo: https://github.com/psf/black
-  rev: 22.3.0
+  rev: 23.1.0
   hooks:
   - id: black
 
-- repo: https://github.com/PyCQA/flake8
-  rev: 4.0.1
-  hooks:
-  - id: flake8
-    additional_dependencies: [
-        'flake8-bugbear==20.1.4',
-        'flake8-logging-format==0.6.0',
-        'flake8-implicit-str-concat==0.2.0',
-    ]
-    exclude: tests/data
-
-- repo: https://github.com/PyCQA/isort
-  rev: 5.12.0
-  hooks:
-  - id: isort
-    files: \.py$
-
 - repo: https://github.com/pre-commit/pygrep-hooks
-  rev: v1.7.0
+  rev: v1.10.0
   hooks:
   - id: python-no-log-warn
   - id: python-no-eval
@@ -58,7 +47,12 @@ repos:
     files: ^news/
 
 - repo: https://github.com/mgedmin/check-manifest
-  rev: '0.46'
+  rev: '0.49'
   hooks:
   - id: check-manifest
     stages: [manual]
+
+- repo: https://github.com/abravalheri/validate-pyproject
+  rev: v0.12.2
+  hooks:
+  - id: validate-pyproject

--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,7 @@ pre-bump:
 
 .PHONY: lint
 lint:
-	flake8 .
+	ruff .
 
 man:
 	$(MAKE) -C docs $@

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -383,7 +383,7 @@ Alternatively, you can configure a ``tox.ini`` like the one below for both local
 and external testing::
 
     [tox]
-    envlist = flake8-py3, py26, py27, py33, py34, py35, py36, pypy
+    envlist = py37, py38, py39, py310, py311, pypy3, ruff
 
     [testenv]
     deps = pipenv
@@ -391,12 +391,12 @@ and external testing::
         pipenv install --dev
         pipenv run pytest tests
 
-    [testenv:flake8-py3]
-    basepython = python3.4
+    [testenv:ruff]
+    basepython = python3.11
     commands=
         pipenv install --dev
-        pipenv run flake8 --version
-        pipenv run flake8 setup.py docs project test
+        pipenv run ruff --version
+        pipenv run ruff .
 
 Pipenv will automatically use the virtualenv provided by ``tox``. If ``pipenv install --dev`` installs e.g. ``pytest``, then installed command ``pytest`` will be present in given virtualenv and can be called directly by ``pytest tests`` instead of ``pipenv run pytest tests``.
 

--- a/news/ruff.feature.rst
+++ b/news/ruff.feature.rst
@@ -1,0 +1,1 @@
+Replace flake8 and isort with `ruff <https://beta.ruff.rs>`_.

--- a/pipenv/__init__.py
+++ b/pipenv/__init__.py
@@ -60,8 +60,8 @@ if os.name == "nt":
     if not os.getenv("NO_COLOR") or no_color:
         colorama.just_fix_windows_console()
 
-from . import resolver  # noqa
-from .cli import cli
+from . import resolver  # noqa: F401,E402
+from .cli import cli  # noqa: E402
 
 if __name__ == "__main__":
     cli()

--- a/pipenv/routines/update.py
+++ b/pipenv/routines/update.py
@@ -111,7 +111,6 @@ def upgrade(
     dev=False,
     lock_only=False,
 ):
-
     lockfile = project._lockfile()
     if not pre:
         pre = project.settings.get("allow_prereleases")

--- a/pipenv/utils/pip.py
+++ b/pipenv/utils/pip.py
@@ -217,7 +217,7 @@ def pip_install_deps(
         if project.s.is_verbose():
             while True:
                 line = c.stdout.readline()
-                if line == "":
+                if not line:
                     break
                 if "Ignoring" in line:
                     click.secho(line, fg="red", err=True)

--- a/pipenv/utils/resolver.py
+++ b/pipenv/utils/resolver.py
@@ -257,7 +257,6 @@ class Resolver:
         markers_lookup: Dict[str, str] = None,
         project: Optional[Project] = None,
     ) -> Tuple[Requirement, Dict[str, str], Dict[str, str]]:
-
         if index_lookup is None:
             index_lookup = {}
         if markers_lookup is None:
@@ -435,7 +434,6 @@ class Resolver:
         pre: bool = False,
         category: str = None,
     ) -> "Resolver":
-
         if not req_dir:
             req_dir = create_tracked_tempdir(suffix="-requirements", prefix="pipenv-")
         if index_lookup is None:
@@ -705,7 +703,6 @@ class Resolver:
                     requires_python = candidate.link.requires_python
                     if requires_python:
                         try:
-
                             marker = marker_from_specifier(requires_python)
                             self.markers[result.name] = marker
                             result.markers = marker

--- a/pipenv/utils/shell.py
+++ b/pipenv/utils/shell.py
@@ -416,7 +416,7 @@ def env_to_bool(val):
 
 def is_env_truthy(name):
     """An environment variable is truthy if it exists and isn't one of (0, false, no, off)"""
-    return env_to_bool(os.getenv(name, False))
+    return env_to_bool(os.getenv(name, False))  # noqa: PLW1508
 
 
 def project_python(project, system=False):

--- a/pipenv/utils/virtualenv.py
+++ b/pipenv/utils/virtualenv.py
@@ -360,7 +360,7 @@ def find_a_system_python(line):
     if not line:
         return next(iter(finder.find_all_python_versions()), None)
     # Use the windows finder executable
-    if (line.startswith("py ") or line.startswith("py.exe ")) and os.name == "nt":
+    if (line.startswith(("py ", "py.exe "))) and os.name == "nt":
         line = line.split(" ", 1)[1].lstrip("-")
     python_entry = find_python(finder, line)
     return python_entry

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,17 +28,6 @@ exclude = '''
 )
 '''
 
-[tool.isort]
-atomic = true
-lines_after_imports = 2
-lines_between_types = 1
-multi_line_output = 5
-line_length = 80
-known_first_party = [
-    "pipenv",
-    "tests",
-]
-
 [tool.mypy]
 ignore_missing_imports = true
 follow_imports = "skip"
@@ -100,6 +89,58 @@ markers = [
     "extended",
     "ext: extra non-categorized tests",
 ]
+
+[tool.ruff]
+exclude = [
+    "pipenv/patched/*",
+    "pipenv/vendor/*",
+]
+select = [
+    "B",
+    "C9",
+    "E",
+    "F",
+    "G",
+    "I",
+    "ISC",
+    "PIE",
+    "PL",
+    "TID",
+    "W",
+    "YTT"
+]
+ignore = [
+    "B028",
+    "B904",
+    "PIE790",
+    "PLR2004",
+    "PLR5501",
+    "PLW2901",
+]
+line-length = 137
+target-version = "py37"
+
+[tool.ruff.mccabe]
+max-complexity = 32
+
+[tool.ruff.pylint]
+max-args = 18
+max-branches = 38
+max-returns = 9
+max-statements = 155
+
+[tool.ruff.per-file-ignores]
+"docs/conf.py" = ["E402", "E501"]
+"get-pipenv.py" = ["E402"]
+"pipenv/__init__.py" = ["E401"]
+"pipenv/cli/command.py" = ["TID252"]
+"pipenv/utils/internet.py" = ["PLW0603"]
+"tests/*" = ["E501", "F401", "I", "PLC1901", "S101"]
+"tests/integration/conftest.py" = ["B003", "PIE800", "PLW0603"]
+"tests/integration/test_pipenv.py" = ["E741"]
+"tests/integration/test_requirements.py" = ["E741"]
+"tests/unit/test_funktools.py" = ["B015"]
+"tests/unit/test_utils.py" = ["F811"]
 
 [tool.towncrier]
 package = "pipenv"

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,29 +3,5 @@ long_description = file: README.md
 license = MIT
 license_files = LICENSE
 
-# Currently flake8 does not support pyproject.toml
-[flake8]
-extend-exclude =
-    docs/,
-    pipenv/vendor/,
-    pipenv/patched/,
-    get-pipenv.py,
-    setup.py,
-    tests/fixtures/,
-    tests/test_artifacts/
-ignore =
-    # The default ignore list:
-    E121,E123,E126,E226,E24,E704,
-    # Our additions:
-    # E127: continuation line over-indented for visual indent
-    # E128: continuation line under-indented for visual indent
-    # E129: visually indented line with same indent as next logical line
-    # E222: multiple spaces after operator
-    # E231: missing whitespace after ','
-    # E402: module level import not at top of file
-    # E501: line too long
-    # W503: line break before binary operator
-    E402,E501,W503,E203
-
 [coverage:run]
 parallel = true

--- a/tasks/vendoring/__init__.py
+++ b/tasks/vendoring/__init__.py
@@ -515,7 +515,6 @@ def download_licenses(
             ctx.run(exe_cmd)
         except invoke.exceptions.UnexpectedExit as e:
             if "ModuleNotFoundErr" in e.result.stderr.strip():
-
                 target = parse.parse(
                     "ModuleNotFoundError: No module named '{backend}'",
                     e.result.stderr.strip().split("\n")[-1],

--- a/tests/fixtures/fake-package/tasks/__init__.py
+++ b/tests/fixtures/fake-package/tasks/__init__.py
@@ -1,4 +1,5 @@
 import pathlib
+import re
 import shutil
 import subprocess
 
@@ -31,7 +32,7 @@ def typecheck(ctx):
 def clean(ctx):
     """Clean previously built package artifacts.
     """
-    ctx.run(f'python setup.py clean')
+    ctx.run('python setup.py clean')
     dist = ROOT.joinpath('dist')
     print(f'[clean] Removing {dist}')
     if dist.exists():
@@ -125,7 +126,7 @@ def release(ctx, type_, repo, prebump=PREBUMP):
     tag_content = tag_content.replace('"', '\\"')
     ctx.run(f'git tag -a {version} -m "Version {version}\n\n{tag_content}"')
 
-    ctx.run(f'python setup.py sdist bdist_wheel')
+    ctx.run('python setup.py sdist bdist_wheel')
 
     dist_pattern = f'{PACKAGE_NAME.replace("-", "[-_]")}-*'
     artifacts = list(ROOT.joinpath('dist').glob(dist_pattern))

--- a/tests/integration/test_install_basic.py
+++ b/tests/integration/test_install_basic.py
@@ -1,4 +1,5 @@
-import os, sys
+import os
+import sys
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
@@ -418,7 +419,7 @@ def test_rewrite_outline_table(pipenv_instance_private_pypi):
 url = "{0}"
 verify_ssl = false
 name = "testindex"
-            
+
 [packages]
 six = {1}
 

--- a/tests/integration/test_install_misc.py
+++ b/tests/integration/test_install_misc.py
@@ -1,5 +1,5 @@
 import os
-import pytest 
+import pytest
 
 @pytest.mark.urls
 @pytest.mark.extras

--- a/tests/integration/test_install_uri.py
+++ b/tests/integration/test_install_uri.py
@@ -231,9 +231,9 @@ Jinja2 = {{ref = "2.11.0", git = "{0}"}}
         c = p.pipenv("install")
         assert c.returncode == 0
         installed_packages = ["Flask", "Jinja2"]
-        assert all([k in p.pipfile["packages"] for k in installed_packages])
-        assert all([k.lower() in p.lockfile["default"] for k in installed_packages])
-        assert all([k in p.lockfile["default"]["jinja2"] for k in ["ref", "git"]]), str(p.lockfile["default"])
+        assert all(k in p.pipfile["packages"] for k in installed_packages)
+        assert all(k.lower() in p.lockfile["default"] for k in installed_packages)
+        assert all(k in p.lockfile["default"]["jinja2"] for k in ["ref", "git"]), str(p.lockfile["default"])
         assert p.lockfile["default"]["jinja2"].get("ref") is not None
         assert (
             p.lockfile["default"]["jinja2"]["git"]

--- a/tests/integration/test_uninstall.py
+++ b/tests/integration/test_uninstall.py
@@ -116,7 +116,7 @@ def test_uninstall_all_dev(pipenv_instance_private_pypi):
         name = "pypi"
         url = "{0}"
         verify_ssl = true
-            
+
         [packages]
         tablib = "*"
 


### PR DESCRIPTION
Thank you for contributing to Pipenv!


### The issue

Continuation of #5361

[Ruff](https://beta.ruff.rs/) supports [over 500 lint rules](https://beta.ruff.rs/docs/rules) and can be used to replace [Flake8](https://pypi.org/project/flake8/) (plus dozens of plugins), [isort](https://pypi.org/project/isort/), [pydocstyle](https://pypi.org/project/pydocstyle/), [yesqa](https://github.com/asottile/yesqa), [eradicate](https://pypi.org/project/eradicate/), [pyupgrade](https://pypi.org/project/pyupgrade/), and [autoflake](https://pypi.org/project/autoflake/), all while executing (in Rust) tens or hundreds of times faster than any individual tool.

### The fix

Added ruff in all the right places and removed flake8 and isort.

### The checklist

* [ ] Associated issue
* [x] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

<!--
### If this is a patch to the `vendor` directory...

Please try to refrain from submitting patches directly to `vendor` or `patched`, but raise your issue to the upstream project instead, and inform Pipenv to upgrade when the upstream project accepts the fix.

A pull request to upgrade vendor packages is strongly discouraged unless there is a very good reason (e.g. you need to test Pipenv’s integration to a new vendor feature). Pipenv audits and performs vendor upgrades regularly before a new release is about to drop.

If your patch is not or cannot be accepted by upstream, but is essential to Pipenv (make sure to discuss this with maintainers!), please remember to attach a patch file in `tasks/vendoring/patched`, so this divergence from upstream can be recorded and replayed afterward.
-->
