### PR TITLE
Vendor in latest requirementslib.

### DIFF
--- a/news/5659.vendor.rst
+++ b/news/5659.vendor.rst
@@ -1,0 +1,1 @@
+Vendor in latest ``requirementslib==2.2.5`` which includes updates for pip 23.1

--- a/pipenv/vendor/requirementslib/__init__.py
+++ b/pipenv/vendor/requirementslib/__init__.py
@@ -5,7 +5,7 @@ from .models.lockfile import Lockfile
 from .models.pipfile import Pipfile
 from .models.requirements import Requirement
 
-__version__ = "2.2.4"
+__version__ = "2.2.5"
 
 
 logger = logging.getLogger(__name__)

--- a/pipenv/vendor/vendor.txt
+++ b/pipenv/vendor/vendor.txt
@@ -12,7 +12,7 @@ plette[validation]==0.4.4
 ptyprocess==0.7.0
 python-dotenv==1.0.0
 pythonfinder==1.3.2
-requirementslib==2.2.4
+requirementslib==2.2.5
 ruamel.yaml==0.17.21
 shellingham==1.5.0.post1
 toml==0.10.2


### PR DESCRIPTION
### The issue

Vendor in latest requirementslib which includes the update for pip 23.1 so revendoring pipenv will be consistent.


### The checklist

* [ ] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.
