### PR TITLE
pipenv shell: support xonsh

### DIFF
--- a/pipenv/shells.py
+++ b/pipenv/shells.py
@@ -44,6 +44,9 @@ def _get_activate_script(cmd, venv):
     elif "csh" in cmd:
         suffix = ".csh"
         command = "source"
+    elif "xonsh" in cmd:
+        suffix = ".xsh"
+        command = "source"
     elif "nu" in cmd:
         suffix = ".nu"
         command = "overlay use"


### PR DESCRIPTION
xonsh supports virtualenv with a plugin. So if pipenv creates a virtualenv in xonsh, it would have a bin/activate.xsh. This change uses that script in 'pipenv shell'.