### PR TITLE
Fix a typo in the document

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -17,7 +17,7 @@ Running the above will install the package `<package_name>` and add it to the de
 
 The user can provide these additional parameters:
 
-    --python=<path/to/pyton> — Performs the installation in a virtualenv using the provided Python interpreter.
+    --python=<path/to/python> — Performs the installation in a virtualenv using the provided Python interpreter.
 warning: The above commands should only be used when initially creating the environment.
 
 The user can provide these additional parameters:


### PR DESCRIPTION
### The issue
There is a typo in the command part of the document. Since this is a very tiny change, I didn't file an issue or add news.

### The fix

Fixed the typo.


### The checklist

* [ ] Associated issue
* [ ] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.
