### PR TITLE
Remove foresight

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,11 +53,6 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
-      - name: Collect Workflow Telemetry
-        uses: runforesight/foresight-workflow-kit-action@v1
-        if: ${{ always() }}
-        with:
-          api_key: ${{ secrets.FORESIGHT_API_KEY }}
       - run: |
           python -m pip install pre-commit
           pre-commit run --all-files --verbose --show-diff-on-failure
@@ -69,12 +64,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
-      - name: Collect Workflow Telemetry
-        uses: runforesight/foresight-workflow-kit-action@v1
-        if: ${{ always() }}
-        with:
-          api_key: ${{ secrets.FORESIGHT_API_KEY }}
+          python-version: "3.11"
       - run: |
           python -m pip install --upgrade wheel invoke parver beautifulsoup4 vistir towncrier requests parse hatch-fancy-pypi-readme
           python -m invoke vendoring.update
@@ -95,12 +85,6 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-
-      - name: Collect Workflow Telemetry
-        uses: runforesight/foresight-workflow-kit-action@v1
-        if: ${{ always() }}
-        with:
-          api_key: ${{ secrets.FORESIGHT_API_KEY }}
 
       - name: Get python path
         id: python-path
@@ -143,15 +127,7 @@ jobs:
           PYTHONIOENCODING: "utf-8"
           GIT_SSH_COMMAND: ssh -o StrictHostKeyChecking=accept-new -o CheckHostIP=no
         run: |
-          pipenv run pytest --junitxml=./reports/results.xml -ra -n auto -v --fulltrace tests
-      - name: Analyze Test and/or Coverage Results
-        uses: runforesight/foresight-test-kit-action@v1
-        if: ${{ always() }}
-        with:
-          api_key: ${{ secrets.FORESIGHT_API_KEY }}
-          test_format: JUNIT
-          test_framework: PYTEST
-          test_path: ./reports/**
+          pipenv run pytest -ra -n auto -v --fulltrace tests
 
   build:
     name: Build Package
@@ -162,11 +138,6 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
-      - name: Collect Workflow Telemetry
-        uses: runforesight/foresight-workflow-kit-action@v1
-        if: ${{ always() }}
-        with:
-          api_key: ${{ secrets.FORESIGHT_API_KEY }}
       - run: pip install -U build twine
       - run: |
           python -m build

--- a/.github/workflows/pypi_upload.yml
+++ b/.github/workflows/pypi_upload.yml
@@ -21,12 +21,6 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v3
 
-    - name: Collect Workflow Telemetry
-      uses: runforesight/foresight-workflow-kit-action@v1
-      if: ${{ always() }}
-      with:
-        api_key: ${{ secrets.FORESIGHT_API_KEY }}
-
     - name: Create Release
       id: create_release
       uses: actions/create-release@v1

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ Pipenv: Python Development Workflow for Humans
 [![image](https://img.shields.io/pypi/l/pipenv.svg)](https://python.org/pypi/pipenv)
 [![CI](https://github.com/pypa/pipenv/actions/workflows/ci.yaml/badge.svg)](https://github.com/pypa/pipenv/actions/workflows/ci.yaml)
 [![image](https://img.shields.io/pypi/pyversions/pipenv.svg)](https://python.org/pypi/pipenv)
-[![image](https://api-public.service.runforesight.com/api/v1/badge/test?repoId=a9acfd31-fca9-4ebb-a449-c7bf0f85a481)](https://pypa.app.runforesight.com)
 
 ------------------------------------------------------------------------
 


### PR DESCRIPTION
### The issue

My understanding is Foresight is shutting down in May, and we will no longer be able to report telemetry, so we may as well remove it from our builds.

