### PR TITLE
Reword active shell warning to reduce ambiguity

### DIFF
--- a/news/5681.trivial.rst
+++ b/news/5681.trivial.rst
@@ -1,0 +1,1 @@
+Reword active shell warning to reduce ambiguity

--- a/pipenv/cli/command.py
+++ b/pipenv/cli/command.py
@@ -412,7 +412,7 @@ def shell(
         venv_name = os.environ.get("VIRTUAL_ENV", "UNKNOWN_VIRTUAL_ENVIRONMENT")
         if not anyway:
             echo(
-                "{} {} {}\nNo action taken to avoid nested environments.".format(
+                "{} {} {}\nNew shell not activated to avoid nested environments.".format(
                     style("Shell for"),
                     style(venv_name, fg="green", bold=True),
                     style("already activated.", bold=True),


### PR DESCRIPTION
### The issue

#5680

`No action taken to avoid nested environments` can be read either way.

### The fix

Describes what action was not taken.

### The checklist

* [x] Associated issue
* [x] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.
