### PR TITLE
Explore hashed URL fragments PEP 503

### DIFF
--- a/pipenv/project.py
+++ b/pipenv/project.py
@@ -850,14 +850,21 @@ class Project:
 
     def pipfile_sources(self, expand_vars=True):
         if self.pipfile_is_empty or "source" not in self.parsed_pipfile:
-            return [self.default_source]
+            sources = [self.default_source]
+            if os.environ.get("PIPENV_PYPI_MIRROR"):
+                sources[0]["url"] = os.environ["PIPENV_PYPI_MIRROR"]
+            return sources
         # We need to make copies of the source info so we don't
         # accidentally modify the cache. See #2100 where values are
         # written after the os.path.expandvars() call.
-        return [
+        sources = [
             {k: safe_expandvars(v) if expand_vars else v for k, v in source.items()}
             for source in self.parsed_pipfile["source"]
         ]
+        for source in sources:
+            if os.environ.get("PIPENV_PYPI_MIRROR") and is_pypi_url(source.get("url")):
+                source["url"] = os.environ["PIPENV_PYPI_MIRROR"]
+        return sources
 
     @property
     def sources(self):

--- a/pipenv/utils/shell.py
+++ b/pipenv/utils/shell.py
@@ -242,6 +242,10 @@ def find_python(finder, line=None):
 
     if line and not isinstance(line, str):
         raise TypeError(f"Invalid python search type: expected string, received {line!r}")
+    if line and os.path.isabs(line):
+        if os.name == "nt":
+            line = make_posix(line)
+        return line
 
     if not finder:
         from pipenv.vendor.pythonfinder import Finder

--- a/pipenv/utils/shell.py
+++ b/pipenv/utils/shell.py
@@ -242,8 +242,6 @@ def find_python(finder, line=None):
 
     if line and not isinstance(line, str):
         raise TypeError(f"Invalid python search type: expected string, received {line!r}")
-    if line and not line.startswith("python"):
-        line = f"python{line}"
 
     if not finder:
         from pipenv.vendor.pythonfinder import Finder
@@ -257,6 +255,9 @@ def find_python(finder, line=None):
         result = finder.find_python_version(name=line)
     if not result:
         result = finder.which(line)
+    if not result and not line.startswith("python"):
+        line = f"python{line}"
+        result = find_python(finder, line)
 
     if result:
         if not isinstance(result, str):

--- a/pipenv/utils/shell.py
+++ b/pipenv/utils/shell.py
@@ -242,10 +242,9 @@ def find_python(finder, line=None):
 
     if line and not isinstance(line, str):
         raise TypeError(f"Invalid python search type: expected string, received {line!r}")
-    if line and os.path.isabs(line):
-        if os.name == "nt":
-            line = make_posix(line)
-        return line
+    if line and not line.startswith("python"):
+        line = f"python{line}"
+
     if not finder:
         from pipenv.vendor.pythonfinder import Finder
 
@@ -258,9 +257,6 @@ def find_python(finder, line=None):
         result = finder.find_python_version(name=line)
     if not result:
         result = finder.which(line)
-    if not result and not line.startswith("python"):
-        line = f"python{line}"
-        result = find_python(finder, line)
 
     if result:
         if not isinstance(result, str):

--- a/pipenv/utils/virtualenv.py
+++ b/pipenv/utils/virtualenv.py
@@ -317,12 +317,6 @@ def ensure_python(project, python=None):
                             )
                             # Print the results, in a beautiful blue...
                             click.secho(c.stdout, fg="cyan", err=True)
-                            # Clear the pythonfinder caches
-                            from pipenv.vendor.pythonfinder import Finder
-
-                            finder = Finder(system=False, global_search=True)
-                            finder.find_python_version.cache_clear()
-                            finder.find_all_python_versions.cache_clear()
                     # Find the newly installed Python, hopefully.
                     version = str(version)
                     path_to_python = find_a_system_python(version)

--- a/pipenv/vendor/pythonfinder/environment.py
+++ b/pipenv/vendor/pythonfinder/environment.py
@@ -17,7 +17,6 @@ def is_type_checking():
     return TYPE_CHECKING
 
 
-ASDF_INSTALLED = bool(os.environ.get("ASDF_DIR"))
 PYENV_ROOT = os.path.expanduser(
     os.path.expandvars(os.environ.get("PYENV_ROOT", "~/.pyenv"))
 )
@@ -30,6 +29,7 @@ PYENV_INSTALLED = shutil.which("pyenv") != None
 ASDF_DATA_DIR = os.path.expanduser(
     os.path.expandvars(os.environ.get("ASDF_DATA_DIR", "~/.asdf"))
 )
+ASDF_INSTALLED = shutil.which("asdf") != None
 IS_64BIT_OS = None
 SYSTEM_ARCH = platform.architecture()[0]
 
@@ -59,11 +59,20 @@ def join_path_for_platform(path, path_parts):
         raise Exception("Unknown environment")
 
 
-def get_shim_paths():
-    shim_paths = []
+def set_asdf_paths():
     if ASDF_INSTALLED:
-        shim_paths.append(os.path.join(ASDF_DATA_DIR, "shims"))
-    return [os.path.normpath(os.path.normcase(p)) for p in shim_paths]
+        python_versions = join_path_for_platform(ASDF_DATA_DIR, ["installs", "python"])
+        try:
+            # Get a list of all files and directories in the given path
+            all_files_and_dirs = os.listdir(python_versions)
+            # Filter out files and keep only directories
+            for name in all_files_and_dirs:
+                if os.path.isdir(os.path.join(python_versions, name)):
+                    asdf_path = os.path.join(python_versions, name)
+                    asdf_path = os.path.join(asdf_path, "bin")
+                    os.environ['PATH'] = asdf_path + os.pathsep + os.environ['PATH']
+        except FileNotFoundError:
+            pass
 
 
 def set_pyenv_paths():

--- a/pipenv/vendor/pythonfinder/environment.py
+++ b/pipenv/vendor/pythonfinder/environment.py
@@ -6,6 +6,7 @@ import sys
 import posixpath
 import ntpath
 import re
+import shutil
 
 
 def is_type_checking():
@@ -16,9 +17,6 @@ def is_type_checking():
     return TYPE_CHECKING
 
 
-PYENV_INSTALLED = bool(os.environ.get("PYENV_SHELL")) or bool(
-    os.environ.get("PYENV_ROOT")
-)
 ASDF_INSTALLED = bool(os.environ.get("ASDF_DIR"))
 PYENV_ROOT = os.path.expanduser(
     os.path.expandvars(os.environ.get("PYENV_ROOT", "~/.pyenv"))
@@ -28,6 +26,7 @@ if PYENV_ROOT.startswith('/') and os.name == 'nt':
     # Convert to Windows-style path
     drive, tail = re.match(r"^/([a-zA-Z])/(.*)", PYENV_ROOT).groups()
     PYENV_ROOT = drive.upper() + ":\\" + tail.replace('/', '\\')
+PYENV_INSTALLED = shutil.which("pyenv") != None
 ASDF_DATA_DIR = os.path.expanduser(
     os.path.expandvars(os.environ.get("ASDF_DATA_DIR", "~/.asdf"))
 )
@@ -69,8 +68,10 @@ def get_shim_paths():
 
 def set_pyenv_paths():
     if PYENV_INSTALLED:
+        is_windows = False
         if os.name == "nt":
             python_versions = join_path_for_platform(PYENV_ROOT, ["pyenv-win", "versions"])
+            is_windows = True
         else:
             python_versions = join_path_for_platform(PYENV_ROOT, ["versions"])
         try:
@@ -80,6 +81,8 @@ def set_pyenv_paths():
             for name in all_files_and_dirs:
                 if os.path.isdir(os.path.join(python_versions, name)):
                     pyenv_path = os.path.join(python_versions, name)
+                    if not is_windows:
+                        pyenv_path = os.path.join(pyenv_path, "bin")
                     os.environ['PATH'] = pyenv_path + os.pathsep + os.environ['PATH']
         except FileNotFoundError:
             pass

--- a/pipenv/vendor/pythonfinder/models/mixins.py
+++ b/pipenv/vendor/pythonfinder/models/mixins.py
@@ -372,7 +372,6 @@ class PathEntry(BaseModel):
         :param str name: Name of the python version, e.g. ``anaconda3-5.3.0``
         :return: A new instance of the class.
         """
-
         target = ensure_path(path)
         guessed_name = False
         if not name:

--- a/pipenv/vendor/pythonfinder/models/path.py
+++ b/pipenv/vendor/pythonfinder/models/path.py
@@ -27,7 +27,6 @@ from ..environment import (
     ASDF_INSTALLED,
     PYENV_INSTALLED,
     PYENV_ROOT,
-    get_shim_paths,
 )
 from ..utils import (
     dedup,
@@ -523,9 +522,6 @@ class SystemPath(FinderBaseModel):
                 }
             )
             paths = [path, *paths]
-        paths = [
-            p for p in paths if not any(is_in_path(p, shim) for shim in get_shim_paths())
-        ]
         _path_objects = [ensure_path(p.strip('"')) for p in paths]
         path_entries.update(
             {

--- a/pipenv/vendor/pythonfinder/models/path.py
+++ b/pipenv/vendor/pythonfinder/models/path.py
@@ -180,10 +180,6 @@ class SystemPath(FinderBaseModel):
         path_instances = [
             ensure_path(p.strip('"'))
             for p in path_order
-            if not any(
-                is_in_path(normalize_path(str(p)), normalize_path(shim))
-                for shim in get_shim_paths()
-            )
         ]
         self.paths.update(
             {
@@ -249,6 +245,16 @@ class SystemPath(FinderBaseModel):
         self.path_order = path_order
         return self
 
+    def _remove_shims(self):
+        path_copy = [p for p in self.path_order[:]]
+        new_order = []
+        for current_path in path_copy:
+            if not current_path.endswith("shims"):
+                normalized = normalize_path(current_path)
+                new_order.append(normalized)
+        new_order = [ensure_path(p).as_posix() for p in new_order]
+        self.path_order = new_order
+
     def _remove_path(self, path) -> SystemPath:
         path_copy = [p for p in reversed(self.path_order[:])]
         new_order = []
@@ -306,7 +312,6 @@ class SystemPath(FinderBaseModel):
             version_glob_path="versions/*",
             ignore_unsupported=self.ignore_unsupported,
         )
-        pyenv_index = None
         try:
             pyenv_index = self._get_last_instance(PYENV_ROOT)
         except ValueError:
@@ -321,7 +326,7 @@ class SystemPath(FinderBaseModel):
         self.paths[pyenv_finder.root] = pyenv_finder
         self.paths.update(pyenv_finder.roots)
         self.pyenv_finder = pyenv_finder
-        self._remove_path(os.path.join(PYENV_ROOT, "shims"))
+        self._remove_shims()
         self._register_finder("pyenv", pyenv_finder)
         return self
 

--- a/pipenv/vendor/pythonfinder/models/python.py
+++ b/pipenv/vendor/pythonfinder/models/python.py
@@ -53,8 +53,6 @@ class PythonFinder(PathEntry):
     roots: Dict = Field(default_factory=lambda: defaultdict())
     #: List of paths discovered during search
     paths: List = Field(default_factory=lambda: list())
-    #: shim directory
-    shim_dir: str = "shims"
     #: Versions discovered in the specified paths
     _versions: Dict = Field(default_factory=lambda: defaultdict())
     pythons_ref: Dict = Field(default_factory=lambda: defaultdict())

--- a/pipenv/vendor/pythonfinder/pythonfinder.py
+++ b/pipenv/vendor/pythonfinder/pythonfinder.py
@@ -7,6 +7,7 @@ from .exceptions import InvalidPythonVersion
 from .models.common import FinderBaseModel
 from .models.path import PathEntry, SystemPath
 from .models.python import PythonVersion
+from .environment import set_pyenv_paths
 from .utils import Iterable, version_re
 
 
@@ -32,6 +33,7 @@ class Finder(FinderBaseModel):
         return self.__hash__ == other.__hash__
 
     def create_system_path(self) -> SystemPath:
+        set_pyenv_paths()
         return SystemPath.create(
             path=self.path_prepend,
             system=self.system,

--- a/pipenv/vendor/pythonfinder/pythonfinder.py
+++ b/pipenv/vendor/pythonfinder/pythonfinder.py
@@ -7,7 +7,7 @@ from .exceptions import InvalidPythonVersion
 from .models.common import FinderBaseModel
 from .models.path import PathEntry, SystemPath
 from .models.python import PythonVersion
-from .environment import set_pyenv_paths
+from .environment import set_asdf_paths, set_pyenv_paths
 from .utils import Iterable, version_re
 
 
@@ -33,6 +33,7 @@ class Finder(FinderBaseModel):
         return self.__hash__ == other.__hash__
 
     def create_system_path(self) -> SystemPath:
+        set_asdf_paths()
         set_pyenv_paths()
         return SystemPath.create(
             path=self.path_prepend,


### PR DESCRIPTION
### The issue

PEP 503 https://peps.python.org/pep-0503/

> The URL SHOULD include a hash in the form of a URL fragment with the following syntax: #<hashname>=<hashvalue>, where <hashname> is the lowercase name of the hash function (such as sha256) and <hashvalue> is the hex encoded digest.

### The fix

This should enable non pypi.org sources that are following PEP 503 to be able to leverage those package hashes without downloading the package.   This may also lead to a wider inclusion of package hashes in the lock file.

Note:  This branch is based on my fix-pyenv-asdf branch because I wanted to test it locally, and therefore should not be merged until that work is wrapped up first.


### The checklist

* [ ] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.
