### PR TITLE
Handle windows paths better and utilize this utility for creating the virtualenv path.

### DIFF
--- a/pipenv/utils/shell.py
+++ b/pipenv/utils/shell.py
@@ -12,6 +12,7 @@ from functools import lru_cache
 from pathlib import Path
 
 from pipenv.vendor import click
+from pipenv.vendor.pythonfinder.utils import ensure_path
 from pipenv.vendor.requirementslib.fileutils import normalize_drive, normalize_path
 
 from .constants import FALSE_VALUES, SCHEME_LIST, TRUE_VALUES
@@ -190,6 +191,7 @@ def get_workon_home():
             )
     # Create directory if it does not already exist
     expanded_path = Path(os.path.expandvars(workon_home)).expanduser()
+    expanded_path = ensure_path(expanded_path)
     os.makedirs(expanded_path, exist_ok=True)
     return expanded_path
 

--- a/pipenv/vendor/pythonfinder/__init__.py
+++ b/pipenv/vendor/pythonfinder/__init__.py
@@ -4,7 +4,7 @@ from .exceptions import InvalidPythonVersion
 from .models import SystemPath
 from .pythonfinder import Finder
 
-__version__ = "2.0.1"
+__version__ = "2.0.2"
 
 
 __all__ = ["Finder", "SystemPath", "InvalidPythonVersion"]

--- a/pipenv/vendor/pythonfinder/environment.py
+++ b/pipenv/vendor/pythonfinder/environment.py
@@ -17,14 +17,27 @@ def is_type_checking():
     return TYPE_CHECKING
 
 
+def possibly_convert_to_windows_style_path(path):
+    if not isinstance(path, str):
+        path = str(path)
+    # Check if the path is in Unix-style (Git Bash)
+    if os.name == 'nt':
+        if path.startswith('/'):
+            drive, tail = re.match(r"^/([a-zA-Z])/(.*)", path).groups()
+            revised_path = drive.upper() + ":\\" + tail.replace('/', '\\')
+            return revised_path
+        elif path.startswith('\\'):
+            drive, tail = re.match(r"^\\([a-zA-Z])\\(.*)", path).groups()
+            revised_path = drive.upper() + ":\\" + tail.replace('\\', '\\')
+            return revised_path
+
+    return path
+
+
 PYENV_ROOT = os.path.expanduser(
     os.path.expandvars(os.environ.get("PYENV_ROOT", "~/.pyenv"))
 )
-# Check if the path is in Unix-style (Git Bash)
-if PYENV_ROOT.startswith('/') and os.name == 'nt':
-    # Convert to Windows-style path
-    drive, tail = re.match(r"^/([a-zA-Z])/(.*)", PYENV_ROOT).groups()
-    PYENV_ROOT = drive.upper() + ":\\" + tail.replace('/', '\\')
+PYENV_ROOT = possibly_convert_to_windows_style_path(PYENV_ROOT)
 PYENV_INSTALLED = shutil.which("pyenv") != None
 ASDF_DATA_DIR = os.path.expanduser(
     os.path.expandvars(os.environ.get("ASDF_DATA_DIR", "~/.asdf"))

--- a/pipenv/vendor/pythonfinder/models/path.py
+++ b/pipenv/vendor/pythonfinder/models/path.py
@@ -199,12 +199,13 @@ class SystemPath(FinderBaseModel):
         if self.check_for_asdf() and "asdf" not in self.finders:
             self._setup_asdf()
         venv = os.environ.get("VIRTUAL_ENV")
+        if venv:
+            venv = ensure_path(venv)
         if os.name == "nt":
             bin_dir = "Scripts"
         else:
             bin_dir = "bin"
         if venv and (self.system or self.global_search):
-            p = ensure_path(venv)
             path_order = [(p / bin_dir).as_posix(), *self.path_order]
             self.path_order = path_order
             self.paths[p] = self.get_path(p.joinpath(bin_dir))

--- a/pipenv/vendor/pythonfinder/models/path.py
+++ b/pipenv/vendor/pythonfinder/models/path.py
@@ -176,10 +176,7 @@ class SystemPath(FinderBaseModel):
         if self.global_search and "PATH" in os.environ:
             path_order = path_order + os.environ["PATH"].split(os.pathsep)
         path_order = list(dedup(path_order))
-        path_instances = [
-            ensure_path(p.strip('"'))
-            for p in path_order
-        ]
+        path_instances = [ensure_path(p.strip('"')) for p in path_order]
         self.paths.update(
             {
                 p.as_posix(): PathEntry.create(

--- a/pipenv/vendor/pythonfinder/models/path.py
+++ b/pipenv/vendor/pythonfinder/models/path.py
@@ -206,9 +206,9 @@ class SystemPath(FinderBaseModel):
         else:
             bin_dir = "bin"
         if venv and (self.system or self.global_search):
-            path_order = [(p / bin_dir).as_posix(), *self.path_order]
+            path_order = [(venv / bin_dir).as_posix(), *self.path_order]
             self.path_order = path_order
-            self.paths[p] = self.get_path(p.joinpath(bin_dir))
+            self.paths[venv] = self.get_path(venv.joinpath(bin_dir))
         if self.system:
             syspath = Path(sys.executable)
             syspath_bin = syspath.parent

--- a/pipenv/vendor/pythonfinder/utils.py
+++ b/pipenv/vendor/pythonfinder/utils.py
@@ -13,7 +13,7 @@ from typing import Any, Iterator
 
 from pipenv.patched.pip._vendor.packaging.version import InvalidVersion, Version
 
-from .environment import PYENV_ROOT
+from .environment import PYENV_ROOT, possibly_convert_to_windows_style_path
 from .exceptions import InvalidPythonVersion
 
 version_re_str = (
@@ -234,7 +234,7 @@ def ensure_path(path: Path | str) -> Path:
     :type path: str or :class:`~pathlib.Path`
     :return: A fully expanded Path object.
     """
-
+    path = possibly_convert_to_windows_style_path(path)
     if isinstance(path, Path):
         return path
     path = Path(os.path.expandvars(path))

--- a/pipenv/vendor/vendor.txt
+++ b/pipenv/vendor/vendor.txt
@@ -12,7 +12,7 @@ plette[validation]==0.4.4
 ptyprocess==0.7.0
 pydantic==1.10.7
 python-dotenv==1.0.0
-pythonfinder==2.0.1
+pythonfinder==2.0.2
 requirementslib==2.3.0
 ruamel.yaml==0.17.21
 shellingham==1.5.0.post1


### PR DESCRIPTION
### The issue

Windows was having issues creating new virtualenvs after this patch:  https://github.com/pypa/pipenv/pull/5686

There were two types of issues:
* sometimes the windows PATH may come from an env var in gitbash shell as \ instead of /
* It was sometimes double appending the drive and creating a new directory structure for the virtualenv home.

### The fix

Fix PATH edge case in `pythonfinder==2.0.2`

Declining on a news fragment since the issue was never published in a pipenv release.


### The checklist

* [X] Associated issue
* [ ] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.
