### PR TITLE
Fix pyenv version not installed edge case

### DIFF
--- a/pipenv/vendor/pythonfinder/__init__.py
+++ b/pipenv/vendor/pythonfinder/__init__.py
@@ -4,7 +4,7 @@ from .exceptions import InvalidPythonVersion
 from .models import SystemPath
 from .pythonfinder import Finder
 
-__version__ = "2.0.2"
+__version__ = "2.0.3"
 
 
 __all__ = ["Finder", "SystemPath", "InvalidPythonVersion"]

--- a/pipenv/vendor/pythonfinder/models/path.py
+++ b/pipenv/vendor/pythonfinder/models/path.py
@@ -462,14 +462,14 @@ class SystemPath(FinderBaseModel):
                 found_version = sub_finder(path)
                 if found_version:
                     return found_version
-            if alternate_sub_finder:
+            if name and not (minor or patch or pre or dev or arch or major):
                 for path in paths:
                     found_version = alternate_sub_finder(path)
                     if found_version:
                         return found_version
 
         ver = next(iter(self.get_pythons(sub_finder)), None)
-        if not ver and alternate_sub_finder is not None:
+        if not ver and name and not (minor or patch or pre or dev or arch or major):
             ver = next(iter(self.get_pythons(alternate_sub_finder)), None)
 
         if ver:

--- a/pipenv/vendor/vendor.txt
+++ b/pipenv/vendor/vendor.txt
@@ -12,7 +12,7 @@ plette[validation]==0.4.4
 ptyprocess==0.7.0
 pydantic==1.10.7
 python-dotenv==1.0.0
-pythonfinder==2.0.2
+pythonfinder==2.0.3
 requirementslib==2.3.0
 ruamel.yaml==0.17.21
 shellingham==1.5.0.post1


### PR DESCRIPTION
### The issue

Vendor in pythonfinder 2.0.3 to fix regression finding a specific python version should it not be installed.