### PR TITLE
This pre pip install path should no longer be neccessary when adding packages.

### DIFF
--- a/pipenv/project.py
+++ b/pipenv/project.py
@@ -967,6 +967,7 @@ class Project:
     def add_package_to_pipfile(self, package, dev=False, category=None):
         from .vendor.requirementslib import Requirement
 
+        newly_added = False
         # Read and append Pipfile.
         p = self.parsed_pipfile
         # Don't re-capitalize file URLs or VCSs.
@@ -982,9 +983,12 @@ class Project:
         normalized_name = pep423_name(req_name)
         if name and name != normalized_name:
             self.remove_package_from_pipfile(name, category=category)
+        if normalized_name not in p[category]:
+            newly_added = True
         p[category][normalized_name] = converted
         # Write Pipfile.
         self.write_toml(p)
+        return newly_added, category
 
     def src_name_from_url(self, index_url):
         name, _, tld_guess = urllib.parse.urlsplit(index_url).netloc.rpartition(".")

--- a/pipenv/routines/install.py
+++ b/pipenv/routines/install.py
@@ -13,10 +13,7 @@ from pipenv.utils.dependencies import convert_deps_to_pip, is_star
 from pipenv.utils.indexes import get_source_list
 from pipenv.utils.internet import download_file, is_valid_url
 from pipenv.utils.pip import (
-    format_pip_error,
-    format_pip_output,
     get_trusted_hosts,
-    pip_install,
     pip_install_deps,
 )
 from pipenv.utils.pipfile import ensure_pipfile
@@ -256,60 +253,7 @@ def do_install(
                         )
                     )
                     sys.exit(1)
-                st.console.print("Installing...")
-                try:
-                    st.update(f"Installing {pkg_requirement.name}...")
-                    if project.s.is_verbose():
-                        st.console.print(
-                            f"Installing package: {pkg_requirement.as_line(include_hashes=False)}"
-                        )
-                    c = pip_install(
-                        project,
-                        pkg_requirement,
-                        ignore_hashes=True,
-                        allow_global=system,
-                        selective_upgrade=selective_upgrade,
-                        no_deps=False,
-                        pre=pre,
-                        dev=dev,
-                        requirements_dir=requirements_directory,
-                        index=index_url,
-                        pypi_mirror=pypi_mirror,
-                        use_constraint=True,
-                        extra_pip_args=extra_pip_args,
-                    )
-                    if c.returncode:
-                        err.print(
-                            "{} An error occurred while installing {}!".format(
-                                click.style("Error: ", fg="red", bold=True),
-                                click.style(pkg_line, fg="green"),
-                            ),
-                        )
-                        err.print(f"Error text: {c.stdout}")
-                        err.print(click.style(format_pip_error(c.stderr), fg="cyan"))
-                        if project.s.is_verbose():
-                            err.print(click.style(format_pip_output(c.stdout), fg="cyan"))
-                        if "setup.py egg_info" in c.stderr:
-                            err.print(
-                                "This is likely caused by a bug in {}. "
-                                "Report this to its maintainers.".format(
-                                    click.style(pkg_requirement.name, fg="green")
-                                )
-                            )
-                        err.print(
-                            environments.PIPENV_SPINNER_FAIL_TEXT.format(
-                                "Installation Failed"
-                            )
-                        )
-                        sys.exit(1)
-                except (ValueError, RuntimeError) as e:
-                    err.print("{}: {}".format(click.style("WARNING", fg="red"), e))
-                    err.print(
-                        environments.PIPENV_SPINNER_FAIL_TEXT.format(
-                            "Installation Failed",
-                        )
-                    )
-                    sys.exit(1)
+                st.update(f"Installing {pkg_requirement.name}...")
                 # Warn if --editable wasn't passed.
                 if (
                     pkg_requirement.is_vcs

--- a/pipenv/utils/resolver.py
+++ b/pipenv/utils/resolver.py
@@ -929,7 +929,7 @@ def resolve(cmd, st, project):
         echo(out.strip(), err=True)
         if not is_verbose:
             echo(err, err=True)
-        sys.exit(returncode)
+        raise RuntimeError("Failed to lock Pipfile.lock!")
     if is_verbose:
         echo(out.strip(), err=True)
     return subprocess.CompletedProcess(c.args, returncode, out, err)

--- a/tests/integration/test_install_basic.py
+++ b/tests/integration/test_install_basic.py
@@ -482,7 +482,7 @@ def test_install_does_not_exclude_packaging(pipenv_instance_pypi):
 @pytest.mark.needs_internet
 def test_install_will_supply_extra_pip_args(pipenv_instance_pypi):
     with pipenv_instance_pypi(chdir=True) as p:
-        c = p.pipenv("""install dataclasses-json --extra-pip-args=""--use-feature=truststore --proxy=test""")
+        c = p.pipenv("""install dataclasses-json --extra-pip-args="--use-feature=truststore --proxy=test" """)
         assert c.returncode == 1
         assert "truststore feature" in c.stderr
 


### PR DESCRIPTION
### The issue

Intended as a performance optimization and to reduce code complexity -- there should not be a reason to pre `pip install` the new packages before resolving and batch installing them.


### The checklist

* [ ] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.
