### PR TITLE
Pep 503 hashed urls

### DIFF
--- a/news/5701.feature.rst
+++ b/news/5701.feature.rst
@@ -1,0 +1,1 @@
+Resolver performance: package sources following PEP 503 will leverage package hashes from the URL fragment, without downloading the package.


### PR DESCRIPTION
### The issue

PEP 503 https://peps.python.org/pep-0503/

> The URL SHOULD include a hash in the form of a URL fragment with the following syntax: #<hashname>=<hashvalue>, where <hashname> is the lowercase name of the hash function (such as sha256) and <hashvalue> is the hex encoded digest.

### The fix

This should enable non pypi.org sources that are following PEP 503 to be able to leverage those package hashes without downloading the package.   This may also lead to a wider inclusion of package hashes in the lock file.

Replacement PR for: https://github.com/pypa/pipenv/pull/5688


### The checklist

* [ ] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.