### PR TITLE
Safer usage requests sessions and account for the verify_ssl requirements of each source.

### DIFF
--- a/pipenv/utils/resolver.py
+++ b/pipenv/utils/resolver.py
@@ -180,6 +180,7 @@ class Resolver:
         self._pip_command = None
         self._retry_attempts = 0
         self._hash_cache = None
+        self._sessions = {}
 
     def __repr__(self):
         return (
@@ -594,7 +595,7 @@ class Resolver:
                 session=self.session,
             )
             # It would be nice if `shims.get_package_finder` took an
-            # `ignore_compatibility` parameter, but that's some vendorered code
+            # `ignore_compatibility` parameter, but that's some vendored code
             # we'd rather avoid touching.
             index_lookup = self.prepare_index_lookup()
             ignore_compatibility_finder._ignore_compatibility = True
@@ -744,9 +745,19 @@ class Resolver:
             cleaned_checksums.add(checksum)
         return cleaned_checksums
 
-    def _get_hashes_from_pypi(self, ireq):
+    def _get_requests_session_for_source(self, source):
+        if self._sessions.get(source["name"]):
+            session = self._sessions[source["name"]]
+        else:
+            session = _get_requests_session(
+                self.project.s.PIPENV_MAX_RETRIES, source.get("verify_ssl", True)
+            )
+            self._sessions[source["name"]] = session
+        return session
+
+    def _get_hashes_from_pypi(self, ireq, source):
         pkg_url = f"https://pypi.org/pypi/{ireq.name}/json"
-        session = _get_requests_session(self.project.s.PIPENV_MAX_RETRIES)
+        session = self._get_requests_session_for_source(source)
         try:
             collected_hashes = set()
             # Grab the hashes from the new warehouse API.
@@ -776,7 +787,7 @@ class Resolver:
 
     def _get_hashes_from_remote_index_urls(self, ireq, source):
         pkg_url = f"{source['url']}/{ireq.name}/"
-        session = _get_requests_session(self.project.s.PIPENV_MAX_RETRIES)
+        session = self._get_requests_session_for_source(source)
         try:
             collected_hashes = set()
             # Grab the hashes from the new warehouse API.
@@ -828,7 +839,7 @@ class Resolver:
         source = sources[0] if len(sources) else None
         if source:
             if is_pypi_url(source["url"]):
-                hashes = self._get_hashes_from_pypi(ireq)
+                hashes = self._get_hashes_from_pypi(ireq, source)
                 if hashes:
                     return hashes
             else:


### PR DESCRIPTION
Thank you for contributing to Pipenv!


### The issue

Fixes #5724 

### The fix

The improvement to the pep 508 URLs for determining appropriate hash did not consider the verify_ssl requirements.   Also, it seemed odd to me that even though pipenv is multi-processing we had a global variable for the requests session state.   This made it hard to have different requests (some that verify ssl and some that do not).  Since the primary point of re-use of the requests session is in the Resolver, I made a patch there to have a separate requests session per source.

### The checklist

* [X] Associated issue
* [X] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.
