### PR TITLE
Remove the sys path hacks (again) to fix edge cases with keyring

### DIFF
--- a/news/5719.bugfix.rst
+++ b/news/5719.bugfix.rst
@@ -1,0 +1,1 @@
+Remove the ``sys.path`` modifications and as a result fixes keyring support.

--- a/pipenv/__init__.py
+++ b/pipenv/__init__.py
@@ -1,27 +1,15 @@
-# |~~\'    |~~
-# |__/||~~\|--|/~\\  /
-# |   ||__/|__|   |\/
-#      |
-
 import os
-import sys
 import warnings
 
-from pipenv.__version__ import __version__  # noqa
+from pipenv.cli import cli
 from pipenv.patched.pip._vendor.urllib3.exceptions import DependencyWarning
 
 warnings.filterwarnings("ignore", category=DependencyWarning)
 warnings.filterwarnings("ignore", category=ResourceWarning)
 warnings.filterwarnings("ignore", category=UserWarning)
-PIPENV_ROOT = os.path.abspath(os.path.dirname(os.path.realpath(__file__)))
-PIPENV_VENDOR = os.sep.join([PIPENV_ROOT, "vendor"])
-PIP_VENDOR = os.sep.join([PIPENV_ROOT, "patched", "pip", "_vendor"])
 
 # Load patched pip instead of system pip
 os.environ["PIP_DISABLE_PIP_VERSION_CHECK"] = "1"
-sys.path.insert(0, PIPENV_ROOT)
-sys.path.insert(0, PIPENV_VENDOR)
-sys.path.insert(0, PIP_VENDOR)
 
 if os.name == "nt":
     from pipenv.vendor import colorama
@@ -30,8 +18,6 @@ if os.name == "nt":
     if not os.getenv("NO_COLOR") or no_color:
         colorama.just_fix_windows_console()
 
-from . import resolver  # noqa: F401,E402
-from .cli import cli  # noqa: E402
 
 if __name__ == "__main__":
     cli()

--- a/pipenv/cli/command.py
+++ b/pipenv/cli/command.py
@@ -668,6 +668,7 @@ def run_open(state, module, *args, **kwargs):
 @system_option
 @option("--bare", is_flag=True, default=False, help="Minimal output.")
 @sync_options
+@site_packages_option
 @pass_state
 @pass_context
 def sync(ctx, state, bare=False, user=False, unused=False, **kwargs):
@@ -687,6 +688,7 @@ def sync(ctx, state, bare=False, user=False, unused=False, **kwargs):
         system=state.system,
         extra_pip_args=state.installstate.extra_pip_args,
         categories=state.installstate.categories,
+        site_packages=state.site_packages,
     )
     if retcode:
         ctx.abort()

--- a/pipenv/routines/install.py
+++ b/pipenv/routines/install.py
@@ -354,6 +354,7 @@ def do_sync(
     deploy=False,
     extra_pip_args=None,
     categories=None,
+    site_packages=False,
 ):
     # The lock file needs to exist because sync won't write to it.
     if not project.lockfile_exists:
@@ -368,6 +369,7 @@ def do_sync(
         deploy=deploy,
         pypi_mirror=pypi_mirror,
         clear=clear,
+        site_packages=site_packages,
     )
 
     # Install everything.


### PR DESCRIPTION
### The issue

Fixes #5719 
Fixes #4706 

### The fix

When we added back the hack to the sys.path it broke the google keyring support, I verified this -- because the appropriate requests package module cannot be found (strangely).   My goal has bene to eliminate these path patchces for a while and there were a couple reasons I had to add them back recent which I think have since been resolved:
1.) pydantic was getting an import error on typing_extensions, but the latest vendor'd pydantic seems to have cleaner imports which got re-written to use the right vendor path.
2.) pipdeptree prior version was getting an error on `pipenv graph` but it seems like the new version of `pipdeptrees` may be immune.

I verified that removing this path allows the google keyring stuff to work again.

It still requires that keyring and keyrings.google-artifactregistry-auth be either installed in virtualenv or the virtualenv has access to the system-site-packages.

Additionally, this change allows the sync command to use the `--site-packages` flag as well, for which I know there is an issue request in our backlog for this.   You shouldn't have to relock to create a virtualenv that uses that flag.


### The checklist

* [X] Associated issue
* [ ] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

