### PR TITLE
Only search the Pipenv default index when an alternative index is not specified.

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -27,7 +27,6 @@ The user can provide these additional parameters:
     --system — Install packages to the system site-packages rather than into your virtualenv.
     --deploy — Verifies the _meta hash of the lock file is up to date with the ``Pipfile``, aborts install if not.
     --ignore-pipfile — Install from the Pipfile.lock and completely ignore Pipfile information.
-    --skip-lock — Ignore the ``Pipfile.lock`` and install from the ``Pipfile``. In addition, do not write out a ``Pipfile.lock`` reflecting changes to the ``Pipfile``.  This is not recommended as you loose the security benefits of lock file hash verification.
 
 General Interface Note:
 ```{note}

--- a/news/5737.bugfix.rst
+++ b/news/5737.bugfix.rst
@@ -1,0 +1,1 @@
+Fixes resolver to only consider the default index for packages when a secondary index is not specified.  This brings the code into alignment with stated assumptions about index restricted packages behavior of ``pipenv``.

--- a/news/5737.removal.rst
+++ b/news/5737.removal.rst
@@ -1,0 +1,1 @@
+Deprecation of ``--skip-lock`` flag as it bypasses the security benefits of pipenv.  Plus it lacks proper deterministic support of installation from multiple package indexes.

--- a/pipenv/cli/options.py
+++ b/pipenv/cli/options.py
@@ -136,6 +136,15 @@ def skip_lock_option(f):
     def callback(ctx, param, value):
         state = ctx.ensure_object(State)
         state.installstate.skip_lock = value
+        if value:
+            click.secho(
+                "The flag --skip-lock has been deprecated for removal.  "
+                "Without running the lock resolver it is not possible to manage multiple package indexes.  "
+                "Additionally it bypasses the build consistency guarantees provided by maintaining a lock file.",
+                fg="yellow",
+                bold=True,
+                err=True,
+            )
         return value
 
     return option(

--- a/pipenv/exceptions.py
+++ b/pipenv/exceptions.py
@@ -365,11 +365,11 @@ class ResolutionFailure(PipenvException):
             "{}: Your dependencies could not be resolved. You likely have a "
             "mismatch in your sub-dependencies.\n  "
             "You can use {} to bypass this mechanism, then run "
-            "{} to inspect the situation.\n  "
+            "{} to inspect the versions actually installed in the virtualenv.\n  "
             "Hint: try {} if it is a pre-release dependency."
             "".format(
                 click.style("Warning", fg="red", bold=True),
-                click.style("$ pipenv install --skip-lock", fg="yellow"),
+                click.style("$ pipenv run pip install <requirement_name>", fg="yellow"),
                 click.style("$ pipenv graph", fg="yellow"),
                 click.style("$ pipenv lock --pre", fg="yellow"),
             ),

--- a/pipenv/patched/pip/_internal/models/search_scope.py
+++ b/pipenv/patched/pip/_internal/models/search_scope.py
@@ -136,4 +136,6 @@ class SearchScope:
         index_urls = self.index_urls
         if project_name in self.index_lookup:
             index_urls = [self.index_lookup[project_name]]
+        else:
+            index_urls = [self.index_urls[0]]
         return [mkurl_pypi_url(url) for url in index_urls]

--- a/pipenv/routines/outdated.py
+++ b/pipenv/routines/outdated.py
@@ -1,19 +1,16 @@
 import sys
+from collections import namedtuple
+from collections.abc import Mapping
 
+from pipenv.patched.pip._vendor.packaging.utils import canonicalize_name
 from pipenv.routines.lock import do_lock
 from pipenv.utils.dependencies import pep423_name
 from pipenv.vendor import click
+from pipenv.vendor.requirementslib.models.requirements import Requirement
+from pipenv.vendor.requirementslib.models.utils import get_version
 
 
 def do_outdated(project, pypi_mirror=None, pre=False, clear=False):
-    # TODO: Allow --skip-lock here?
-    from collections import namedtuple
-    from collections.abc import Mapping
-
-    from pipenv.patched.pip._vendor.packaging.utils import canonicalize_name
-    from pipenv.vendor.requirementslib.models.requirements import Requirement
-    from pipenv.vendor.requirementslib.models.utils import get_version
-
     packages = {}
     package_info = namedtuple("PackageInfo", ["name", "installed", "available"])
 

--- a/pipenv/utils/indexes.py
+++ b/pipenv/utils/indexes.py
@@ -72,7 +72,7 @@ def get_source_list(
     trusted_hosts: Optional[List[str]] = None,
     pypi_mirror: Optional[str] = None,
 ) -> List[TSource]:
-    sources: List[TSource] = []
+    sources = project.sources[:]
     if index:
         sources.append(get_project_index(project, index))
     if extra_indexes:
@@ -88,8 +88,6 @@ def get_source_list(
             if not sources or source["url"] != sources[0]["url"]:
                 sources.append(source)
 
-    if not sources:
-        sources = project.sources[:]
     if pypi_mirror:
         sources = [
             create_mirror_source(pypi_mirror, source["name"])

--- a/tasks/vendoring/patches/patched/pip_index_safety.patch
+++ b/tasks/vendoring/patches/patched/pip_index_safety.patch
@@ -36,7 +36,7 @@ index 0120610c..ead5227e 100644
          return link_collector
 
 diff --git a/pipenv/patched/pip/_internal/models/search_scope.py b/pipenv/patched/pip/_internal/models/search_scope.py
-index a64af738..0674ed07 100644
+index a64af738..76c44656 100644
 --- a/pipenv/patched/pip/_internal/models/search_scope.py
 +++ b/pipenv/patched/pip/_internal/models/search_scope.py
 @@ -3,7 +3,7 @@ import logging
@@ -94,4 +94,6 @@ index a64af738..0674ed07 100644
 +        index_urls = self.index_urls
 +        if project_name in self.index_lookup:
 +            index_urls = [self.index_lookup[project_name]]
++        else:
++            index_urls = [self.index_urls[0]]
 +        return [mkurl_pypi_url(url) for url in index_urls]

--- a/tests/integration/test_install_uri.py
+++ b/tests/integration/test_install_uri.py
@@ -132,8 +132,8 @@ six = "*"
 @pytest.mark.index
 @pytest.mark.install
 @pytest.mark.needs_internet
-def test_install_specifying_index_url(pipenv_instance_private_pypi):
-    with pipenv_instance_private_pypi() as p:
+def test_install_specifying_index_url(pipenv_instance_pypi):
+    with pipenv_instance_pypi() as p:
         with open(p.pipfile_path, "w") as f:
             contents = """
 [[source]]
@@ -146,8 +146,6 @@ six = "*"
 
 [dev-packages]
 
-[pipenv]
-install_search_all_sources = true
             """.strip()
             f.write(contents)
         c = p.pipenv("install pipenv-test-private-package --index https://test.pypi.org/simple")

--- a/tests/integration/test_lock.py
+++ b/tests/integration/test_lock.py
@@ -317,6 +317,7 @@ requests = {version = "*", extras = ["socks"]}
         assert "extra == 'socks'" not in c.stdout.strip()
 
 
+@pytest.mark.skip(reason="Skip lock does not support multiple indexes sources; flag is considered for deprecation.")
 @pytest.mark.index
 @pytest.mark.install  # private indexes need to be uncached for resolution
 @pytest.mark.skip_lock


### PR DESCRIPTION
### The issue

At some point pip changed behaviors of how it searches among the indexes to not always prefer pypi -- this difference caused inconsistency with the index restricted packages expectations.

Fixes #5736 

### The checklist

* [X] Associated issue
* [X] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.
