### PR TITLE
Fix for issue #5748

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -14,7 +14,7 @@ To explicitly disable a boolean option, assign to it a false value (i.e. `"0"`).
 
 ```{eval-rst}
 .. autoclass:: pipenv.environments.Setting
-:members:
+    :members:
 ```
 
 Also note that `pip` supports additional [environment variables](https://pip.pypa.io/en/stable/user_guide/#environment-variables), if you need additional customization.

--- a/news/missing_env_var_desc.doc.rst
+++ b/news/missing_env_var_desc.doc.rst
@@ -1,0 +1,1 @@
+Add missing environment variable descriptions back to documentation


### PR DESCRIPTION
### The issue

https://github.com/pypa/pipenv/issues/5748

### The fix

Adds missing tab due to a typo when docs were refactored

### The checklist

* [x] Associated issue
* [x] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

<!--
### If this is a patch to the `vendor` directory...

Please try to refrain from submitting patches directly to `vendor` or `patched`, but raise your issue to the upstream project instead, and inform Pipenv to upgrade when the upstream project accepts the fix.

A pull request to upgrade vendor packages is strongly discouraged, unless there is a very good reason (e.g. you need to test Pipenv’s integration to a new vendor feature). Pipenv audits and performs vendor upgrades regularly, generally before a new release is about to drop.

If your patch is not or cannot be accepted by upstream, but is essential to Pipenv (make sure to discuss this with maintainers!), please remember to attach a patch file in `tasks/vendoring/patched`, so this divergence from upstream can be recorded and replayed afterwards.
-->
