### PR TITLE
Add docker build, update docs for using docker images

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,5 @@
+ARG PYVERSION
+FROM docker.io/python:${PYVERSION}
+
+ARG VERSION
+RUN pip install pipenv=="${VERSION}"

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,0 +1,13 @@
+ifneq (,$(wildcard ./.env))
+    include .env
+	export
+endif
+
+
+docker-build:
+	echo $(PYVERSION) $(PIPENV)
+	docker build -t $(REGISTRY)/$(ORG)/$(IMG):$(TAG) --build-arg PYVERSION=$(PYVERSION) --build-arg VERSION=$(PIPENV) -f Dockerfile .
+
+
+docker-push:
+	docker push $(REGISTRY)/$(ORG)/$(IMG):$(TAG)

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,7 @@
+# Public docker images
+
+Build with:
+
+```
+$ make docker-build docker-push TAG=3.11-alpine-v2023-6-26 PYVERSION=3.11-alpine PIPENV=2023.6.26
+```

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -14,9 +14,8 @@ This results in a smaller image, which can still run your application.
 Here is an example `Dockerfile`, which you can use as a starting point for
 doing a multistage build for your application:
 
-    FROM docker.io/python:3.9 AS builder
+    FROM docker.io/oz123/pipenv:3.11-v2023-6-26 AS builder
 
-    RUN pip install --user pipenv
 
     # Tell pipenv to create venv in the current directory
     ENV PIPENV_VENV_IN_PROJECT=1
@@ -37,7 +36,7 @@ doing a multistage build for your application:
 
     RUN /usr/src/.venv/bin/python -c "import requests; print(requests.__version__)"
 
-    FROM docker.io/python:3.9 AS runtime
+    FROM docker.io/python:3.11 AS runtime
 
     RUN mkdir -v /usr/src/.venv
 


### PR DESCRIPTION
Publish docker images for CICD.

Added a subtle note in the docs. The changelog should definitely explain more how to use these images.
See news snippet that will follow.
