### PR TITLE
requirements command improvements, fixes issue 5755.

### DIFF
--- a/news/5755.bugfix.rst
+++ b/news/5755.bugfix.rst
@@ -1,0 +1,1 @@
+Fix regression in ``requirements`` command that was causing package installs after upgrade to ``requirementslib==3.0.0``.

--- a/pipenv/routines/requirements.py
+++ b/pipenv/routines/requirements.py
@@ -1,0 +1,79 @@
+import re
+import sys
+
+from pipenv.utils.dependencies import get_lockfile_section_using_pipfile_category
+from pipenv.vendor import click
+
+
+def requirements_from_deps(deps, include_hashes=True, include_markers=True):
+    pip_packages = []
+
+    for package_name, package_info in deps.items():
+        # Handling git repositories
+        if "git" in package_info:
+            git = package_info["git"].replace("ssh://", "https://")
+            ref = package_info.get("ref", "")
+            editable = "--editable " if package_info.get("editable", False) else ""
+            extras = (
+                "[{}]".format(",".join(package_info.get("extras", [])))
+                if "extras" in package_info
+                else ""
+            )
+            pip_package = f'"{package_name}{extras} @ {editable}git+{git}@{ref}"'
+        else:
+            # Handling packages with hashes and markers
+            version = package_info.get("version", "").replace("==", "")
+            hashes = (
+                " --hash={}".format(" --hash=".join(package_info["hashes"]))
+                if include_hashes and "hashes" in package_info
+                else ""
+            )
+            markers = (
+                "; {}".format(package_info["markers"])
+                if include_markers and "markers" in package_info
+                else ""
+            )
+            pip_package = f"{package_name}=={version}{hashes}{markers}"
+
+        # Append to the list
+        pip_packages.append(pip_package)
+
+    # pip_packages contains the pip-installable lines
+    return pip_packages
+
+
+def generate_requirements(
+    project,
+    dev=False,
+    dev_only=False,
+    include_hashes=False,
+    include_markers=True,
+    categories="",
+):
+    lockfile = project.load_lockfile(expand_env_vars=False)
+
+    for i, package_index in enumerate(lockfile["_meta"]["sources"]):
+        prefix = "-i" if i == 0 else "--extra-index-url"
+        click.echo(" ".join([prefix, package_index["url"]]))
+
+    deps = {}
+    categories_list = re.split(r", *| ", categories) if categories else []
+
+    if categories_list:
+        for category in categories_list:
+            category = get_lockfile_section_using_pipfile_category(category.strip())
+            deps.update(lockfile.get(category, {}))
+    else:
+        if dev or dev_only:
+            deps.update(lockfile["develop"])
+        if not dev_only:
+            deps.update(lockfile["default"])
+
+    pip_installable_lines = requirements_from_deps(
+        deps, include_hashes=include_hashes, include_markers=include_markers
+    )
+
+    for line in pip_installable_lines:
+        click.echo(line)
+
+    sys.exit(0)

--- a/pipenv/routines/requirements.py
+++ b/pipenv/routines/requirements.py
@@ -13,13 +13,12 @@ def requirements_from_deps(deps, include_hashes=True, include_markers=True):
         if "git" in package_info:
             git = package_info["git"].replace("ssh://", "https://")
             ref = package_info.get("ref", "")
-            editable = "--editable " if package_info.get("editable", False) else ""
             extras = (
                 "[{}]".format(",".join(package_info.get("extras", [])))
                 if "extras" in package_info
                 else ""
             )
-            pip_package = f'"{package_name}{extras} @ {editable}git+{git}@{ref}"'
+            pip_package = f'"{package_name}{extras} @ git+{git}@{ref}"'
         else:
             # Handling packages with hashes and markers
             version = package_info.get("version", "").replace("==", "")

--- a/pipenv/routines/requirements.py
+++ b/pipenv/routines/requirements.py
@@ -28,7 +28,7 @@ def requirements_from_deps(deps, include_hashes=True, include_markers=True):
                 else ""
             )
             markers = (
-                " ; {}".format(package_info["markers"])
+                "; {}".format(package_info["markers"])
                 if include_markers and "markers" in package_info
                 else ""
             )

--- a/pipenv/routines/requirements.py
+++ b/pipenv/routines/requirements.py
@@ -28,7 +28,7 @@ def requirements_from_deps(deps, include_hashes=True, include_markers=True):
                 else ""
             )
             markers = (
-                "; {}".format(package_info["markers"])
+                " ; {}".format(package_info["markers"])
                 if include_markers and "markers" in package_info
                 else ""
             )

--- a/pipenv/routines/requirements.py
+++ b/pipenv/routines/requirements.py
@@ -11,14 +11,14 @@ def requirements_from_deps(deps, include_hashes=True, include_markers=True):
     for package_name, package_info in deps.items():
         # Handling git repositories
         if "git" in package_info:
-            git = package_info["git"].replace("ssh://", "https://")
+            git = package_info["git"]
             ref = package_info.get("ref", "")
             extras = (
                 "[{}]".format(",".join(package_info.get("extras", [])))
                 if "extras" in package_info
                 else ""
             )
-            pip_package = f'"{package_name}{extras} @ git+{git}@{ref}"'
+            pip_package = f"{package_name}{extras} @ git+{git}@{ref}"
         else:
             # Handling packages with hashes and markers
             version = package_info.get("version", "").replace("==", "")

--- a/tests/integration/test_requirements.py
+++ b/tests/integration/test_requirements.py
@@ -163,7 +163,7 @@ def test_requirements_markers_get_included(pipenv_instance_pypi):
 
         c = p.pipenv('requirements')
         assert c.returncode == 0
-        assert f'{package}{version} ; {markers}' in c.stdout
+        assert f'{package}{version}; {markers}' in c.stdout
 
 
 @pytest.mark.requirements


### PR DESCRIPTION
Fixes #5755 

### The issue

The requirements command should have it all it needs from the lock file, but its re-using a requirementslib method that installs the requirements, which was a regression for the requirements command when we released requirementslib==3.0.0

### The fix

Provide our own method and relocate the requirements command logic to the routines module.


### The checklist

* [X] Associated issue
* [X] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.
