### PR TITLE
Patch for setup.py egg_info issue

### DIFF
--- a/news/5760.bugfix.rst
+++ b/news/5760.bugfix.rst
@@ -1,0 +1,1 @@
+Fix ``error: invalid command 'egg_info'`` edge case with requirementslib 3.0.0.  It exposed pipenv resolver sometimes was using a different python than expected.

--- a/pipenv/environment.py
+++ b/pipenv/environment.py
@@ -290,16 +290,9 @@ class Environment:
     @property
     def python(self) -> str:
         """Path to the environment python"""
-        if self._python is not None:
-            return self._python
-        if os.name == "nt" and not self.is_venv:
-            py = Path(self.prefix).joinpath("python").absolute().as_posix()
-        else:
-            py = Path(self.script_basedir).joinpath("python").absolute().as_posix()
-        if not py:
-            py = Path(sys.executable).as_posix()
-        self._python = py
-        return py
+        from pipenv.utils.virtualenv import ensure_python
+
+        return ensure_python(self.project)
 
     @cached_property
     def sys_path(self) -> List[str]:

--- a/pipenv/environment.py
+++ b/pipenv/environment.py
@@ -81,7 +81,6 @@ class Environment:
         if self.is_venv:
             self._base_paths = self.get_paths()
         self.sys_paths = get_paths()
-        os.environ["PIP_PYTHON_PATH"] = self.project.python
 
     def safe_import(self, name: str) -> ModuleType:
         """Helper utility for reimporting previously imported modules while inside the env"""

--- a/pipenv/environment.py
+++ b/pipenv/environment.py
@@ -81,6 +81,7 @@ class Environment:
         if self.is_venv:
             self._base_paths = self.get_paths()
         self.sys_paths = get_paths()
+        os.environ["PIP_PYTHON_PATH"] = self.project.python
 
     def safe_import(self, name: str) -> ModuleType:
         """Helper utility for reimporting previously imported modules while inside the env"""

--- a/pipenv/environment.py
+++ b/pipenv/environment.py
@@ -81,6 +81,7 @@ class Environment:
         if self.is_venv:
             self._base_paths = self.get_paths()
         self.sys_paths = get_paths()
+        os.environ["PIP_PYTHON_PATH"] = self.python
 
     def safe_import(self, name: str) -> ModuleType:
         """Helper utility for reimporting previously imported modules while inside the env"""

--- a/pipenv/environment.py
+++ b/pipenv/environment.py
@@ -81,7 +81,7 @@ class Environment:
         if self.is_venv:
             self._base_paths = self.get_paths()
         self.sys_paths = get_paths()
-        os.environ["PIP_PYTHON_PATH"] = self.python
+        os.environ["PIP_PYTHON_PATH"] = self.project.python
 
     def safe_import(self, name: str) -> ModuleType:
         """Helper utility for reimporting previously imported modules while inside the env"""
@@ -290,9 +290,16 @@ class Environment:
     @property
     def python(self) -> str:
         """Path to the environment python"""
-        from pipenv.utils.virtualenv import ensure_python
-
-        return ensure_python(self.project)
+        if self._python is not None:
+            return self._python
+        if os.name == "nt" and not self.is_venv:
+            py = Path(self.prefix).joinpath("python").absolute().as_posix()
+        else:
+            py = Path(self.script_basedir).joinpath("python").absolute().as_posix()
+        if not py:
+            py = Path(sys.executable).as_posix()
+        self._python = py
+        return py
 
     @cached_property
     def sys_path(self) -> List[str]:

--- a/pipenv/project.py
+++ b/pipenv/project.py
@@ -1158,6 +1158,13 @@ class Project:
                 result = str(result.path)
         return result
 
+    @property
+    def python(self) -> str:
+        """Path to the project python"""
+        from pipenv.utils.virtualenv import ensure_python
+
+        return ensure_python(self)
+
     def _which(self, command, location=None, allow_global=False):
         if not allow_global and location is None:
             if self.virtualenv_exists:

--- a/pipenv/project.py
+++ b/pipenv/project.py
@@ -1158,9 +1158,9 @@ class Project:
     @property
     def python(self) -> str:
         """Path to the project python"""
-        from pipenv.utils.virtualenv import ensure_python
+        from pipenv.utils.shell import project_python
 
-        return ensure_python(self)
+        return project_python(self)
 
     def _which(self, command, location=None, allow_global=False):
         if not allow_global and location is None:

--- a/pipenv/resolver.py
+++ b/pipenv/resolver.py
@@ -795,10 +795,6 @@ def _main(
     parse_only=False,
     category=None,
 ):
-    os.environ["PIPENV_REQUESTED_PYTHON_VERSION"] = ".".join(
-        [str(s) for s in sys.version_info[:3]]
-    )
-    os.environ["PIP_PYTHON_PATH"] = str(sys.executable)
     if parse_only:
         parse_packages(
             packages,

--- a/pipenv/utils/dependencies.py
+++ b/pipenv/utils/dependencies.py
@@ -62,6 +62,9 @@ class HackedPythonVersion:
         if self.python_path:
             os.environ["PIP_PYTHON_PATH"] = str(self.python_path)
 
+    def __exit__(self, *args):
+        pass
+
 
 def get_canonical_names(packages):
     """Canonicalize a list of packages and return a set of canonical names"""

--- a/pipenv/utils/dependencies.py
+++ b/pipenv/utils/dependencies.py
@@ -53,25 +53,14 @@ def get_pipfile_category_using_lockfile_section(category):
 
 
 class HackedPythonVersion:
-    """A Beautiful hack, which allows us to tell pip which version of Python we're using."""
+    """A hack, which allows us to tell resolver which version of Python we're using."""
 
-    def __init__(self, python_version, python_path):
-        self.python_version = python_version
+    def __init__(self, python_path):
         self.python_path = python_path
 
     def __enter__(self):
-        # Only inject when the value is valid
-        if self.python_version:
-            os.environ["PIPENV_REQUESTED_PYTHON_VERSION"] = str(self.python_version)
         if self.python_path:
             os.environ["PIP_PYTHON_PATH"] = str(self.python_path)
-
-    def __exit__(self, *args):
-        # Restore original Python version information.
-        try:
-            del os.environ["PIPENV_REQUESTED_PYTHON_VERSION"]
-        except KeyError:
-            pass
 
 
 def get_canonical_names(packages):

--- a/pipenv/utils/project.py
+++ b/pipenv/utils/project.py
@@ -1,3 +1,5 @@
+import os
+
 from pipenv import exceptions
 from pipenv.utils.dependencies import python_version
 from pipenv.utils.pipfile import ensure_pipfile
@@ -70,6 +72,7 @@ def ensure_project(
                         )
                     else:
                         raise exceptions.DeployException
+    os.environ["PIP_PYTHON_PATH"] = project.python
     # Ensure the Pipfile exists.
     ensure_pipfile(
         project,

--- a/pipenv/utils/project.py
+++ b/pipenv/utils/project.py
@@ -1,3 +1,5 @@
+import os
+
 from pipenv import exceptions
 from pipenv.utils.dependencies import python_version
 from pipenv.utils.pipfile import ensure_pipfile
@@ -77,3 +79,4 @@ def ensure_project(
         skip_requirements=skip_requirements,
         system=system,
     )
+    os.environ["PIP_PYTHON_PATH"] = project.python

--- a/pipenv/utils/project.py
+++ b/pipenv/utils/project.py
@@ -1,5 +1,3 @@
-import os
-
 from pipenv import exceptions
 from pipenv.utils.dependencies import python_version
 from pipenv.utils.pipfile import ensure_pipfile
@@ -72,7 +70,6 @@ def ensure_project(
                         )
                     else:
                         raise exceptions.DeployException
-    os.environ["PIP_PYTHON_PATH"] = project.python
     # Ensure the Pipfile exists.
     ensure_pipfile(
         project,

--- a/pipenv/utils/resolver.py
+++ b/pipenv/utils/resolver.py
@@ -1165,7 +1165,7 @@ def resolve_deps(
     req_dir = req_dir if req_dir else os.environ.get("req_dir", None)
     if not req_dir:
         req_dir = create_tracked_tempdir(prefix="pipenv-", suffix="-requirements")
-    with HackedPythonVersion(python_path=project.environment.python):
+    with HackedPythonVersion(python_path=project.python):
         try:
             results, hashes, markers_lookup, resolver, skipped = actually_resolve_deps(
                 deps,
@@ -1184,7 +1184,7 @@ def resolve_deps(
     # Second (last-resort) attempt:
     if results is None:
         with HackedPythonVersion(
-            python_path=project.environment.python,
+            python_path=project.python,
         ):
             try:
                 # Attempt to resolve again, with different Python version information,

--- a/pipenv/utils/resolver.py
+++ b/pipenv/utils/resolver.py
@@ -1155,10 +1155,8 @@ def resolve_deps(
     """
     index_lookup = {}
     markers_lookup = {}
-    python_path = which("python", allow_global=allow_global)
     if not os.environ.get("PIP_SRC"):
         os.environ["PIP_SRC"] = project.virtualenv_src_location
-    backup_python_path = sys.executable
     results = []
     resolver = None
     if not deps:
@@ -1167,7 +1165,7 @@ def resolve_deps(
     req_dir = req_dir if req_dir else os.environ.get("req_dir", None)
     if not req_dir:
         req_dir = create_tracked_tempdir(prefix="pipenv-", suffix="-requirements")
-    with HackedPythonVersion(python_version=python, python_path=python_path):
+    with HackedPythonVersion(python_path=project.environment.python):
         try:
             results, hashes, markers_lookup, resolver, skipped = actually_resolve_deps(
                 deps,
@@ -1186,8 +1184,7 @@ def resolve_deps(
     # Second (last-resort) attempt:
     if results is None:
         with HackedPythonVersion(
-            python_version=".".join([str(s) for s in sys.version_info[:3]]),
-            python_path=backup_python_path,
+            python_path=project.environment.python,
         ):
             try:
                 # Attempt to resolve again, with different Python version information,

--- a/pipenv/utils/virtualenv.py
+++ b/pipenv/utils/virtualenv.py
@@ -217,7 +217,7 @@ def cleanup_virtualenv(project, bare=True):
 
 def ensure_python(project, python=None):
     # Runtime import is necessary due to the possibility that the environments module may have been reloaded.
-    if project.s.PIPENV_PYTHON and python is False:
+    if project.s.PIPENV_PYTHON and not python:
         python = project.s.PIPENV_PYTHON
 
     def abort(msg=""):

--- a/pipenv/vendor/requirementslib/models/setup_info.py
+++ b/pipenv/vendor/requirementslib/models/setup_info.py
@@ -75,8 +75,9 @@ def pep517_subprocess_runner(cmd, cwd=None, extra_environ=None) -> None:
 
 class BuildEnv(envbuild.BuildEnvironment):
     def pip_install(self, reqs):
+        python = os.environ.get("PIP_PYTHON_PATH", sys.executable)
         cmd = [
-            sys.executable,
+            python,
             "-m",
             "pip",
             "install",

--- a/pipenv/vendor/requirementslib/models/setup_info.py
+++ b/pipenv/vendor/requirementslib/models/setup_info.py
@@ -1135,8 +1135,7 @@ def run_setup(script_path, egg_base=None):
         python = Path(os.environ.get("PIP_PYTHON_PATH", sys.executable))
         sp.run(
             [python, "setup.py"] + args,
-            stdout=sp.PIPE,
-            stderr=sp.PIPE,
+            capture_output=True,
         )
         dist = get_metadata(egg_base, metadata_type="egg")
     return dist

--- a/pipenv/vendor/requirementslib/models/setup_info.py
+++ b/pipenv/vendor/requirementslib/models/setup_info.py
@@ -1132,7 +1132,7 @@ def run_setup(script_path, egg_base=None):
         if egg_base:
             args += ["--egg-base", egg_base]
 
-        python = Path(os.environ.get("PIP_PYTHON_PATH", sys.executable))
+        python = os.environ.get("PIP_PYTHON_PATH", sys.executable)
         sp.run(
             [python, "setup.py"] + args,
             capture_output=True,

--- a/pipenv/vendor/requirementslib/models/setup_info.py
+++ b/pipenv/vendor/requirementslib/models/setup_info.py
@@ -58,11 +58,6 @@ from .utils import (
 
 CACHE_DIR = os.environ.get("PIPENV_CACHE_DIR", user_cache_dir("pipenv"))
 
-# The following are necessary for people who like to use "if __name__" conditionals
-# in their setup.py scripts
-_setup_stop_after = None
-_setup_distribution = None
-
 
 def pep517_subprocess_runner(cmd, cwd=None, extra_environ=None) -> None:
     """The default method of calling the wrapper subprocess."""
@@ -1142,29 +1137,15 @@ def run_setup(script_path, egg_base=None):
         sys.path.insert(0, target_cwd)
 
         save_argv = sys.argv.copy()
-        try:
-            global _setup_distribution, _setup_stop_after
-            _setup_stop_after = "run"
-            sys.argv[0] = script_name
-            sys.argv[1:] = args
-            with open(script_name, "rb") as f:
-                contents = f.read().replace(rb"\r\n", rb"\n")
-                exec(contents, g)
-        # We couldn't import everything needed to run setup
-        except Exception:
-            python = os.environ.get("PIP_PYTHON_PATH", sys.executable)
+        python = os.environ.get("PIP_PYTHON_PATH", sys.executable)
 
-            sp.run(
-                [python, "setup.py"] + args,
-                cwd=target_cwd,
-                stdout=sp.PIPE,
-                stderr=sp.PIPE,
-            )
-        finally:
-            _setup_stop_after = None
-            sys.argv = save_argv
-            _setup_distribution = get_metadata(egg_base, metadata_type="egg")
-        dist = _setup_distribution
+        sp.run(
+            [python, "setup.py"] + args,
+            cwd=target_cwd,
+            stdout=sp.PIPE,
+            stderr=sp.PIPE,
+        )
+        dist = get_metadata(egg_base, metadata_type="egg")
     return dist
 
 

--- a/pipenv/vendor/requirementslib/models/setup_info.py
+++ b/pipenv/vendor/requirementslib/models/setup_info.py
@@ -1120,6 +1120,7 @@ def run_setup(script_path, egg_base=None):
     :return: The metadata dictionary
     :rtype: Dict[Any, Any]
     """
+    from pathlib import Path
 
     if not os.path.exists(script_path):
         raise FileNotFoundError(script_path)
@@ -1127,21 +1128,13 @@ def run_setup(script_path, egg_base=None):
     if egg_base is None:
         egg_base = os.path.join(target_cwd, "reqlib-metadata")
     with temp_path(), cd(target_cwd):
-        # This is for you, Hynek
-        # see https://github.com/hynek/environ_config/blob/69b1c8a/setup.py
         args = ["egg_info"]
         if egg_base:
             args += ["--egg-base", egg_base]
-        script_name = os.path.basename(script_path)
-        g = {"__file__": script_name, "__name__": "__main__"}
-        sys.path.insert(0, target_cwd)
 
-        save_argv = sys.argv.copy()
-        python = os.environ.get("PIP_PYTHON_PATH", sys.executable)
-
+        python = Path(os.environ.get("PIP_PYTHON_PATH", sys.executable))
         sp.run(
             [python, "setup.py"] + args,
-            cwd=target_cwd,
             stdout=sp.PIPE,
             stderr=sp.PIPE,
         )


### PR DESCRIPTION
It was discovered that requirementslib uses the sys.executable python rather than the pipenv environment python.  Which as @oz123 reminded me should be the same, but due to some weird code paths, it wasn't always the same in my testing when the resolver got invoked as subprocess.

### The issue

Fixes #5753 

### The fix

I don't love the use of the environment variable, but I figured out this was the original intention of how the pipenv <--> requirements lib interface and at some point it got hard-coded to sys.executable in the resolver code which was getting invoked with a different python version at points.

This fixes the problem by ensuring that the correct python of the pipenv environment is being used.

### The checklist

* [X] Associated issue
* [ ] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

