### PR TITLE
Consider the PIP_CLIENT_CERT value when creating the requests session.

### DIFF
--- a/news/5746.bugfix.rst
+++ b/news/5746.bugfix.rst
@@ -1,0 +1,1 @@
+Patch ``_get_requests_session`` method to consider ``PIP_CLIENT_CERT`` value when present.

--- a/pipenv/utils/internet.py
+++ b/pipenv/utils/internet.py
@@ -1,3 +1,4 @@
+import os
 import re
 from urllib.parse import urlparse
 
@@ -8,7 +9,10 @@ from pipenv.patched.pip._vendor.urllib3 import util as urllib3_util
 
 def _get_requests_session(max_retries=1, verify_ssl=True):
     """Load requests lazily."""
+    pip_client_cert = os.environ.get("PIP_CLIENT_CERT")
     requests_session = requests.Session()
+    if pip_client_cert:
+        requests_session.cert = pip_client_cert
     adapter = HTTPAdapter(max_retries=max_retries)
     requests_session.mount("https://", adapter)
     if verify_ssl is False:


### PR DESCRIPTION
Fixes #5746 


### The issue

When we introduced the pep508 package index url checks for determining package hashes, it broke users that rely on client side certificates when locking.

### The fix

Consider how the users were supplying client side certs with `PIP_CLIENT_CERT` and pass it to the requests session as well.

### The checklist

* [X] Associated issue
* [X] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.
