### PR TITLE
Ensure version contains an operator when defined

### DIFF
--- a/news/5765.bugfix
+++ b/news/5765.bugfix
@@ -1,0 +1,1 @@
+Fixes regression on Pipfile requirements syntax. Ensure default operator is provided to requirement lib to avoid crash.

--- a/news/5765.bugfix
+++ b/news/5765.bugfix
@@ -1,1 +1,0 @@
-Fixes regression on Pipfile requirements syntax. Ensure default operator is provided to requirement lib to avoid crash.

--- a/news/5765.bugfix.rst
+++ b/news/5765.bugfix.rst
@@ -1,0 +1,1 @@
+Fixes regression on Pipfile requirements syntax. Ensure default operator is provided to requirement lib to avoid crash.

--- a/pipenv/vendor/requirementslib/models/requirements.py
+++ b/pipenv/vendor/requirementslib/models/requirements.py
@@ -34,7 +34,7 @@ from pipenv.patched.pip._internal.req.constructors import (
 from pipenv.patched.pip._internal.req.req_install import InstallRequirement
 from pipenv.patched.pip._internal.utils.temp_dir import global_tempdir_manager
 from pipenv.patched.pip._internal.utils.urls import path_to_url, url_to_path
-from pipenv.patched.pip._vendor.distlib.util import cached_property
+from pipenv.patched.pip._vendor.distlib.util import cached_property, COMPARE_OP
 from pipenv.patched.pip._vendor.packaging.markers import Marker
 from pipenv.patched.pip._vendor.packaging.requirements import Requirement as PackagingRequirement
 from pipenv.patched.pip._vendor.packaging.specifiers import (
@@ -2544,6 +2544,10 @@ class Requirement(ReqLibBaseModel):
         if hasattr(pipfile, "keys"):
             _pipfile = dict(pipfile).copy()
         _pipfile["version"] = get_version(pipfile)
+
+        # We ensure version contains an operator. Default to equals (==)
+        if _pipfile["version"] and COMPARE_OP.match(_pipfile["version"]) is None:
+            _pipfile["version"] = "=={}".format(_pipfile["version"])
         vcs = next(iter([vcs for vcs in VCS_LIST if vcs in _pipfile]), None)
         if vcs:
             _pipfile["vcs"] = vcs

--- a/tests/integration/test_install_basic.py
+++ b/tests/integration/test_install_basic.py
@@ -92,6 +92,22 @@ tablib = "*"
 
 @pytest.mark.basic
 @pytest.mark.install
+def test_install_with_version_req_default_operator(pipenv_instance_pypi):
+    """Ensure that running `pipenv install` work when spec is package = "X.Y.Z". """
+    with pipenv_instance_pypi(chdir=True) as p:
+        with open(p.pipfile_path, "w") as f:
+            contents = """
+[packages]
+fastapi = "0.95.0"
+            """.strip()
+            f.write(contents)
+        c = p.pipenv("install")
+        assert c.returncode == 0
+        assert "fastapi" in p.pipfile["packages"]
+
+
+@pytest.mark.basic
+@pytest.mark.install
 def test_install_without_dev_section(pipenv_instance_pypi):
     with pipenv_instance_pypi() as p:
         with open(p.pipfile_path, "w") as f:


### PR DESCRIPTION
Try to fix #5764 

Maybe not the best as it simply revert one line to avoid the crash. I've added a test to validate the fix

I believe there might be a better fix by concatenating a "default operator" to `_pipfile["version"]` before calling the specifier constructor. I am just not sure of the intent of the whole function and which function should add this default operator. 
`Requirement.parse`  function ? 

You have probably more knowledge on this to see if a default operator make sense. At least, we have a base to fix

@matteius Let me know
