### PR TITLE
Fixes issue I've been having running pipenv as an editable install on windows.

### DIFF
--- a/pipenv/__init__.py
+++ b/pipenv/__init__.py
@@ -1,9 +1,26 @@
+import importlib.util
 import os
+import sys
 import warnings
 
+
+def _ensure_modules():
+    spec = importlib.util.spec_from_file_location(
+        "typing_extensions",
+        location=os.path.join(
+            os.path.dirname(__file__), "patched", "pip", "_vendor", "typing_extensions.py"
+        ),
+    )
+    typing_extensions = importlib.util.module_from_spec(spec)
+    sys.modules["typing_extensions"] = typing_extensions
+    spec.loader.exec_module(typing_extensions)
+
+
+_ensure_modules()
+
 from pipenv.__version__ import __version__  # noqa
-from pipenv.cli import cli
-from pipenv.patched.pip._vendor.urllib3.exceptions import DependencyWarning
+from pipenv.cli import cli  # noqa
+from pipenv.patched.pip._vendor.urllib3.exceptions import DependencyWarning  # noqa
 
 warnings.filterwarnings("ignore", category=DependencyWarning)
 warnings.filterwarnings("ignore", category=ResourceWarning)

--- a/pipenv/resolver.py
+++ b/pipenv/resolver.py
@@ -9,6 +9,15 @@ os.environ["PIP_PYTHON_PATH"] = str(sys.executable)
 
 def _ensure_modules():
     spec = importlib.util.spec_from_file_location(
+        "typing_extensions",
+        location=os.path.join(
+            os.path.dirname(__file__), "patched", "pip", "_vendor", "typing_extensions.py"
+        ),
+    )
+    typing_extensions = importlib.util.module_from_spec(spec)
+    sys.modules["typing_extensions"] = typing_extensions
+    spec.loader.exec_module(typing_extensions)
+    spec = importlib.util.spec_from_file_location(
         "pipenv", location=os.path.join(os.path.dirname(__file__), "__init__.py")
     )
     pipenv = importlib.util.module_from_spec(spec)


### PR DESCRIPTION
### The issue

Ever since upgrading to pydantic in pipenv, I've had issues running it on windows when its an editable install.   I am not convinced its not an environment issue but I searched far and wide and continued to get:

```
[pipenv.exceptions.InstallError]: Traceback (most recent call last):
[pipenv.exceptions.InstallError]:   File "C:\Users\matte\Projects\pipenv\pipenv\patched\pip\__pip-runner__.py", line 50, in <module>
[pipenv.exceptions.InstallError]:     runpy.run_module("pip", run_name="__main__", alter_sys=True)
[pipenv.exceptions.InstallError]:   File "<frozen runpy>", line 226, in run_module
[pipenv.exceptions.InstallError]:   File "<frozen runpy>", line 98, in _run_module_code
[pipenv.exceptions.InstallError]:   File "<frozen runpy>", line 88, in _run_code
[pipenv.exceptions.InstallError]:   File "C:\Users\matte\Projects\pipenv\pipenv\patched\pip\__main__.py", line 35, in <module>
[pipenv.exceptions.InstallError]:     spec.loader.exec_module(pipenv)
[pipenv.exceptions.InstallError]:   File "<frozen importlib._bootstrap_external>", line 940, in exec_module
[pipenv.exceptions.InstallError]:   File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
[pipenv.exceptions.InstallError]:   File "C:\Users\matte\Projects\pipenv\pipenv\__init__.py", line 5, in <module>
[pipenv.exceptions.InstallError]:     from pipenv.cli import cli
[pipenv.exceptions.InstallError]:   File "C:\Users\matte\Projects\pipenv\pipenv\cli\__init__.py", line 1, in <module>
[pipenv.exceptions.InstallError]:     from .command import cli  # noqa
[pipenv.exceptions.InstallError]:     ^^^^^^^^^^^^^^^^^^^^^^^^
[pipenv.exceptions.InstallError]:   File "C:\Users\matte\Projects\pipenv\pipenv\cli\command.py", line 4, in <module>
[pipenv.exceptions.InstallError]:     from pipenv import environments
[pipenv.exceptions.InstallError]:   File "C:\Users\matte\Projects\pipenv\pipenv\environments.py", line 8, in <module>
[pipenv.exceptions.InstallError]:     from pipenv.utils.shell import env_to_bool, is_env_truthy, isatty
[pipenv.exceptions.InstallError]:   File "C:\Users\matte\Projects\pipenv\pipenv\utils\shell.py", line 15, in <module>
[pipenv.exceptions.InstallError]:     from pipenv.vendor.pythonfinder.utils import ensure_path
[pipenv.exceptions.InstallError]:   File "C:\Users\matte\Projects\pipenv\pipenv\vendor\pythonfinder\__init__.py", line 4, in <module>
[pipenv.exceptions.InstallError]:     from .models import SystemPath
[pipenv.exceptions.InstallError]:   File "C:\Users\matte\Projects\pipenv\pipenv\vendor\pythonfinder\models\__init__.py", line 3, in <module>
[pipenv.exceptions.InstallError]:     from .path import SystemPath
[pipenv.exceptions.InstallError]:   File "C:\Users\matte\Projects\pipenv\pipenv\vendor\pythonfinder\models\path.py", line 23, in <module>
[pipenv.exceptions.InstallError]:     from pipenv.vendor.pydantic import Field, root_validator
[pipenv.exceptions.InstallError]:   File "pydantic\__init__.py", line 2, in init pydantic.__init__
[pipenv.exceptions.InstallError]:
[pipenv.exceptions.InstallError]:   File "pydantic\dataclasses.py", line 41, in init pydantic.dataclasses
[pipenv.exceptions.InstallError]:     # +=========+=========================================+
```

### The fix

Make sure typing_extensions from the pip vendor is available in both the resolver and the main pipenv process.

