### PR TITLE
Fix extras not being included for pypi packages in requirements command

### DIFF
--- a/news/5784.bugfix.rst
+++ b/news/5784.bugfix.rst
@@ -1,0 +1,1 @@
+Fix regressions in the ``requirements`` command related to standard index extras and handling of local file requirements.

--- a/pipenv/routines/requirements.py
+++ b/pipenv/routines/requirements.py
@@ -20,8 +20,8 @@ def requirements_from_deps(deps, include_hashes=True, include_markers=True):
             )
             pip_package = f"{package_name}{extras} @ git+{git}@{ref}"
         # Handling file-sourced packages
-        elif "file" in package_info:
-            file = package_info["file"]
+        elif "file" in package_info or "path" in package_info:
+            file = package_info.get("file") or package_info.get("path")
             extras = (
                 "[{}]".format(",".join(package_info.get("extras", [])))
                 if "extras" in package_info

--- a/pipenv/routines/requirements.py
+++ b/pipenv/routines/requirements.py
@@ -20,7 +20,7 @@ def requirements_from_deps(deps, include_hashes=True, include_markers=True):
             )
             pip_package = f"{package_name}{extras} @ git+{git}@{ref}"
         else:
-            # Handling packages with hashes and markers
+            # Handling packages with hashes, markers and extras from PyPI
             version = package_info.get("version", "").replace("==", "")
             hashes = (
                 " --hash={}".format(" --hash=".join(package_info["hashes"]))
@@ -32,7 +32,12 @@ def requirements_from_deps(deps, include_hashes=True, include_markers=True):
                 if include_markers and "markers" in package_info
                 else ""
             )
-            pip_package = f"{package_name}=={version}{markers}{hashes}"
+            extras = (
+                "[{}]".format(",".join(package_info.get("extras", [])))
+                if "extras" in package_info
+                else ""
+            )
+            pip_package = f"{package_name}{extras}=={version}{markers}{hashes}"
 
         # Append to the list
         pip_packages.append(pip_package)

--- a/pipenv/routines/requirements.py
+++ b/pipenv/routines/requirements.py
@@ -19,8 +19,17 @@ def requirements_from_deps(deps, include_hashes=True, include_markers=True):
                 else ""
             )
             pip_package = f"{package_name}{extras} @ git+{git}@{ref}"
+        # Handling file-sourced packages
+        elif "file" in package_info:
+            file = package_info["file"]
+            extras = (
+                "[{}]".format(",".join(package_info.get("extras", [])))
+                if "extras" in package_info
+                else ""
+            )
+            pip_package = f"{file}{extras}"
         else:
-            # Handling packages with hashes, markers and extras from PyPI
+            # Handling packages from standard pypi like indexes
             version = package_info.get("version", "").replace("==", "")
             hashes = (
                 " --hash={}".format(" --hash=".join(package_info["hashes"]))

--- a/tests/integration/test_requirements.py
+++ b/tests/integration/test_requirements.py
@@ -262,39 +262,38 @@ def test_requirements_generates_requirements_from_lockfile_without_env_var_expan
             {
                 "django-storages": {
                     "version": "==1.12.3",
-                    "extras": ["azure"],
-                    "hashes": ["sha256:samplehash123"]
-                },
-                "package_from_git": {
-                    "git": "https://github.com/sample/repo.git",
-                    "ref": "123456",
-                    "extras": ["extra1"]
+                    "extras": ["azure"]
                 }
             },
             True,
             True,
-            [
-                "django-storages[azure]==1.12.3 --hash=sha256:samplehash123",
-                "package_from_git[extra1] @ git+https://github.com/sample/repo.git@123456"
-            ]
+            ["django-storages[azure]==1.12.3"]
         ),
         (
             {
-                "django-storages": {
-                    "version": "==1.12.3",
-                    "extras": ["azure"],
-                    "hashes": ["sha256:samplehash123"],
-                    "markers": "python_version >= '3.6'"
+                "evotum-cripto": {
+                    "file": "https://gitlab.com/eVotUM/Cripto-py/-/archive/develop/Cripto-py-develop.zip"
                 }
             },
             True,
             True,
-            [
-                "django-storages[azure]==1.12.3; python_version >= '3.6' --hash=sha256:samplehash123"
-            ]
+            ["https://gitlab.com/eVotUM/Cripto-py/-/archive/develop/Cripto-py-develop.zip"]
+        ),
+        (
+            {
+                "pyjwt": {
+                    "git": "https://github.com/jpadilla/pyjwt.git",
+                    "ref": "7665aa625506a11bae50b56d3e04413a3dc6fdf8",
+                    "extras": ["crypto"]
+                }
+            },
+            True,
+            True,
+            ["pyjwt[crypto] @ git+https://github.com/jpadilla/pyjwt.git@7665aa625506a11bae50b56d3e04413a3dc6fdf8"]
         )
     ]
 )
 def test_requirements_from_deps(deps, include_hashes, include_markers, expected):
     result = requirements_from_deps(deps, include_hashes, include_markers)
     assert result == expected
+


### PR DESCRIPTION
### The issue

Fixes #5783
Fixes #5780

### The fix

* Consider extras for pypi or private index packages.
* Consider file and path requirements.

### The checklist

* [X] Associated issue
* [X] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.
