### PR TITLE
Invoke the resolver in the same process as pipenv rather than utilzing subprocess.

### DIFF
--- a/news/5787.bugfix.rst
+++ b/news/5787.bugfix.rst
@@ -1,0 +1,1 @@
+Invoke the resolver in the same process as pipenv rather than utilizing subprocess.

--- a/pipenv/environment.py
+++ b/pipenv/environment.py
@@ -542,12 +542,7 @@ class Environment:
         :rtype: iterator
         """
 
-        pip_target_dir = os.environ.get("PIP_TARGET")
-        libdirs = (
-            [pip_target_dir]
-            if pip_target_dir
-            else self.base_paths["libdirs"].split(os.pathsep)
-        )
+        libdirs = self.base_paths["libdirs"].split(os.pathsep)
         dists = (pkg_resources.find_distributions(libdir) for libdir in libdirs)
         yield from itertools.chain.from_iterable(dists)
 

--- a/pipenv/patched/pip/_internal/req/constructors.py
+++ b/pipenv/patched/pip/_internal/req/constructors.py
@@ -95,13 +95,13 @@ def parse_editable(editable_req: str) -> Tuple[Optional[str], str, Set[str]]:
 
     link = Link(url)
 
-    # if not link.is_vcs:
-    #     backends = ", ".join(vcs.all_schemes)
-    #     raise InstallationError(
-    #         f"{editable_req} is not a valid editable requirement. "
-    #         f"It should either be a path to a local project or a VCS URL "
-    #         f"(beginning with {backends})."
-    #     )
+    if not link.is_vcs:
+        backends = ", ".join(vcs.all_schemes)
+        raise InstallationError(
+            f"{editable_req} is not a valid editable requirement. "
+            f"It should either be a path to a local project or a VCS URL "
+            f"(beginning with {backends})."
+        )
 
     package_name = link.egg_fragment
     if not package_name:

--- a/pipenv/resolver.py
+++ b/pipenv/resolver.py
@@ -140,11 +140,9 @@ class Entry:
         self._parents_in_pipfile = []
 
     @staticmethod
-    def make_requirement(name=None, entry=None, from_ireq=False):
+    def make_requirement(name=None, entry=None):
         from pipenv.vendor.requirementslib.models.requirements import Requirement
 
-        if from_ireq:
-            return Requirement.from_ireq(entry)
         return Requirement.from_pipfile(name, entry)
 
     @classmethod

--- a/pipenv/routines/graph.py
+++ b/pipenv/routines/graph.py
@@ -16,7 +16,7 @@ def do_graph(project, bare=False, json=False, json_tree=False, reverse=False):
 
     pipdeptree_path = os.path.dirname(pipdeptree.__file__.rstrip("cdo"))
     try:
-        python_path = project._which("python")
+        python_path = project.python()
     except AttributeError:
         click.echo(
             "{}: {}".format(

--- a/pipenv/utils/dependencies.py
+++ b/pipenv/utils/dependencies.py
@@ -121,8 +121,6 @@ def get_vcs_deps(project=None, dev=False, pypi_mirror=None, packages=None, reqs=
                         Requirement,
                     )
 
-                    # from distutils.sysconfig import get_python_lib
-                    # sys.path = [repo.checkout_directory, "", ".", get_python_lib(plat_specific=0)]
                     commit_hash = repo.commit_hash
                     name = requirement.normalized_name
                     lockfile[name] = requirement.pipfile_entry[1]

--- a/pipenv/utils/resolver.py
+++ b/pipenv/utils/resolver.py
@@ -280,7 +280,6 @@ class Resolver:
             project = Project()
         index, extra_index, trust_host, remainder = parse_indexes(line)
         line = " ".join(remainder)
-        req: Requirement = None
         try:
             req = Requirement.from_line(line)
         except ValueError:
@@ -1084,7 +1083,7 @@ def venv_resolve_deps(
                     project.s.is_verbose(),
                     allow_global,
                     req_dir,
-                    deps,
+                    packages=deps,
                     category=category,
                     constraints=constraints,
                 )

--- a/pipenv/utils/resolver.py
+++ b/pipenv/utils/resolver.py
@@ -674,7 +674,9 @@ class Resolver:
     def get_resolver(self, clear=False):
         from pipenv.patched.pip._internal.utils.temp_dir import TempDirectory
 
-        with global_tempdir_manager(), get_build_tracker() as build_tracker, TempDirectory() as directory:
+        with global_tempdir_manager(), get_build_tracker() as build_tracker, TempDirectory(
+            globally_managed=True
+        ) as directory:
             pip_options = self.pip_options
             finder = self.finder
             wheel_cache = WheelCache(pip_options.cache_dir)

--- a/pipenv/vendor/requirementslib/models/lockfile.py
+++ b/pipenv/vendor/requirementslib/models/lockfile.py
@@ -243,17 +243,6 @@ class Lockfile(ReqLibBaseModel):
             ]
         return []
 
-    def as_requirements(self, category: str, include_hashes: bool = False) -> List[str]:
-        lines = []
-        section = list(self.get_requirements(categories=[category]))
-        for req in section:
-            kwargs = {"include_hashes": include_hashes}
-            if req.editable:
-                kwargs["include_markers"] = False
-            r = req.as_line(**kwargs)
-            lines.append(r.strip())
-        return lines
-
     def write(self) -> None:
         self.projectfile.model = copy.deepcopy(self.lockfile)
         self.projectfile.write()

--- a/pipenv/vendor/requirementslib/models/setup_info.py
+++ b/pipenv/vendor/requirementslib/models/setup_info.py
@@ -11,17 +11,18 @@ import subprocess as sp
 import sys
 import time
 import warnings
-from collections.abc import Iterable, Mapping
 from contextlib import ExitStack
 from functools import lru_cache
 from itertools import count
 from os import scandir
 from pathlib import Path
-from typing import Any, AnyStr, Callable, Dict, Generator, List, Optional, Tuple, Union
+from typing import Any, AnyStr, Callable, Dict, Generator, List, Optional, Tuple, Union, Iterable, Mapping
 from urllib.parse import parse_qs, urlparse, urlunparse
 
 from pipenv.patched.pip._vendor.distlib.wheel import Wheel
 from pipenv.vendor.pep517 import envbuild, wrappers
+
+from pipenv.patched.pip._internal.models.wheel import Wheel
 from pipenv.patched.pip._internal.network.download import Downloader
 from pipenv.patched.pip._internal.operations.prepare import unpack_url
 from pipenv.patched.pip._internal.req.req_install import InstallRequirement
@@ -1119,8 +1120,6 @@ def run_setup(script_path, egg_base=None):
     :return: The metadata dictionary
     :rtype: Dict[Any, Any]
     """
-    from pathlib import Path
-
     if not os.path.exists(script_path):
         raise FileNotFoundError(script_path)
     target_cwd = os.path.dirname(os.path.abspath(script_path))
@@ -1131,9 +1130,8 @@ def run_setup(script_path, egg_base=None):
         if egg_base:
             args += ["--egg-base", egg_base]
 
-        python = os.environ.get("PIP_PYTHON_PATH", sys.executable)
         sp.run(
-            [python, "setup.py"] + args,
+            [sys.executable, "setup.py"] + args,
             capture_output=True,
         )
         dist = get_metadata(egg_base, metadata_type="egg")

--- a/pipenv/vendor/requirementslib/models/setup_info.py
+++ b/pipenv/vendor/requirementslib/models/setup_info.py
@@ -425,9 +425,7 @@ def rmtree(
     try:
         shutil.rmtree(directory, ignore_errors=ignore_errors, onerror=onerror)
     except (IOError, OSError, FileNotFoundError, PermissionError) as exc:  # noqa:B014
-        # Ignore removal failures where the file doesn't exist
-        if exc.errno != errno.ENOENT:
-            raise
+        pass
 
 
 def suppress_unparsable(func, *args, **kwargs):

--- a/pipenv/vendor/requirementslib/models/setup_info.py
+++ b/pipenv/vendor/requirementslib/models/setup_info.py
@@ -1386,12 +1386,6 @@ class SetupInfo(ReqLibBaseModel):
                     self.populate_metadata(dist)
                 self._ran_setup = True
 
-    @property
-    def pep517_config(self) -> Dict[str, Any]:
-        config = {}
-        config.setdefault("--global-option", [])
-        return config
-
     def build_wheel(self) -> str:
         need_delete = False
         if not self.pyproject.exists():
@@ -1422,7 +1416,6 @@ build-backend = "{1}"
         result = build_pep517(
             directory,
             self.extra_kwargs["build_dir"],
-            config_settings=self.pep517_config,
             dist_type="wheel",
         )
         if need_delete:
@@ -1454,7 +1447,6 @@ build-backend = "{1}"
         result = build_pep517(
             self.base_dir,
             self.extra_kwargs["build_dir"],
-            config_settings=self.pep517_config,
             dist_type="sdist",
         )
         if need_delete:

--- a/pipenv/vendor/requirementslib/models/vcs.py
+++ b/pipenv/vendor/requirementslib/models/vcs.py
@@ -3,10 +3,9 @@ import os
 import sys
 from typing import Any, Optional, Tuple
 
-from pipenv.patched.pip._internal.utils.temp_dir import global_tempdir_manager
 from pipenv.patched.pip._internal.vcs.versioncontrol import VcsSupport
 from pipenv.patched.pip._vendor.pyparsing.core import cached_property
-from pipenv.vendor.pydantic import BaseModel, Field
+from pipenv.vendor.pydantic import Field
 
 from .common import ReqLibBaseModel
 from .url import URI

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,10 +57,7 @@ norecursedirs = [
     "tests/pypi",
     "peeps",
 ]
-filterwarnings = [
-    "ignore::DeprecationWarning",
-    "ignore::PendingDeprecationWarning",
-]
+filterwarnings = []
 # These are not all the custom markers, but most of the ones with repeat uses
 # `pipenv run pytest --markers` will list all markers inlcuding these
 markers = [

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,7 +1,10 @@
+import errno
 import functools
 import json
 import logging
 import os
+import shutil
+from shutil import rmtree as _rmtree
 import sys
 import warnings
 from pathlib import Path
@@ -10,18 +13,16 @@ import subprocess
 
 import pytest
 import requests
-
 from pipenv.utils.processes import subprocess_run
 from pipenv.vendor import tomlkit
 from pipenv.vendor.requirementslib.utils import temp_environ
+from pipenv.vendor.requirementslib.models.setup_info import handle_remove_readonly
 
 log = logging.getLogger(__name__)
 warnings.simplefilter("default", category=ResourceWarning)
 
 
 HAS_WARNED_GITHUB = False
-
-DEFAULT_PRIVATE_PYPI_SERVER = "http://localhost:8080/simple"
 
 
 def try_internet(url="http://httpbin.org/ip", timeout=1.5):
@@ -281,26 +282,48 @@ class _PipenvInstance:
         return os.sep.join([self.path, 'Pipfile.lock'])
 
 
+# Windows python3.8 fails without this patch.  Additional details: https://bugs.python.org/issue42796
+def _rmtree_func(path, ignore_errors=True, onerror=None):
+    shutil_rmtree = _rmtree
+    if onerror is None:
+        onerror = handle_remove_readonly
+    try:
+        shutil_rmtree(path, ignore_errors=ignore_errors, onerror=onerror)
+    except (OSError, FileNotFoundError, PermissionError) as exc:
+        # Ignore removal failures where the file doesn't exist
+        if exc.errno != errno.ENOENT:
+            raise
+
 @pytest.fixture()
-def pipenv_instance_pypi(capfdbinary):
-    with temp_environ():
+def pipenv_instance_pypi(capfdbinary, monkeypatch):
+    with temp_environ(), monkeypatch.context() as m:
+        m.setattr(shutil, "rmtree", _rmtree_func)
+        original_umask = os.umask(0o007)
         os.environ["PIPENV_NOSPIN"] = "1"
         os.environ["CI"] = "1"
         os.environ["PIPENV_DONT_USE_PYENV"] = "1"
         warnings.simplefilter("ignore", category=ResourceWarning)
         warnings.filterwarnings("ignore", category=ResourceWarning, message="unclosed.*<ssl.SSLSocket.*>")
-        yield functools.partial(_PipenvInstance, capfd=capfdbinary, index_url="https://pypi.org/simple")
+        try:
+            yield functools.partial(_PipenvInstance, capfd=capfdbinary, index_url="https://pypi.org/simple")
+        finally:
+            os.umask(original_umask)
 
 
 @pytest.fixture()
-def pipenv_instance_private_pypi(capfdbinary):
-    with temp_environ():
+def pipenv_instance_private_pypi(capfdbinary, monkeypatch):
+    with temp_environ(), monkeypatch.context() as m:
+        m.setattr(shutil, "rmtree", _rmtree_func)
+        original_umask = os.umask(0o007)
         os.environ["PIPENV_NOSPIN"] = "1"
         os.environ["CI"] = "1"
         os.environ["PIPENV_DONT_USE_PYENV"] = "1"
         warnings.simplefilter("ignore", category=ResourceWarning)
         warnings.filterwarnings("ignore", category=ResourceWarning, message="unclosed.*<ssl.SSLSocket.*>")
-        yield functools.partial(_PipenvInstance, capfd=capfdbinary, index_url="http://localhost:8080/simple")
+        try:
+            yield functools.partial(_PipenvInstance, capfd=capfdbinary, index_url="http://localhost:8080/simple")
+        finally:
+            os.umask(original_umask)
 
 
 @pytest.fixture()

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -24,6 +24,8 @@ warnings.simplefilter("default", category=ResourceWarning)
 
 HAS_WARNED_GITHUB = False
 
+DEFAULT_PRIVATE_PYPI_SERVER = os.environ.get("PIPENV_PYPI_SERVER", "http://localhost:8080/simple")
+
 
 def try_internet(url="http://httpbin.org/ip", timeout=1.5):
     resp = requests.get(url, timeout=timeout)
@@ -321,7 +323,7 @@ def pipenv_instance_private_pypi(capfdbinary, monkeypatch):
         warnings.simplefilter("ignore", category=ResourceWarning)
         warnings.filterwarnings("ignore", category=ResourceWarning, message="unclosed.*<ssl.SSLSocket.*>")
         try:
-            yield functools.partial(_PipenvInstance, capfd=capfdbinary, index_url="http://localhost:8080/simple")
+            yield functools.partial(_PipenvInstance, capfd=capfdbinary, index_url=DEFAULT_PRIVATE_PYPI_SERVER)
         finally:
             os.umask(original_umask)
 

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -242,6 +242,7 @@ def test_install_parse_error(pipenv_instance_private_pypi):
         assert 'u/\\/p@r$34b13+pkg' not in p.pipfile['packages']
 
 
+@pytest.mark.skip(reason="This test clears the cache that other tests may be using.")
 @pytest.mark.cli
 def test_pipenv_clear(pipenv_instance_pypi):
     with pipenv_instance_pypi() as p:

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -94,11 +94,15 @@ def test_pipenv_graph(pipenv_instance_pypi):
 
 @pytest.mark.cli
 def test_pipenv_graph_reverse(pipenv_instance_private_pypi):
+    from pipenv.cli import cli
+    from click.testing import CliRunner  # not thread safe but graph is a tricky test
+
     with pipenv_instance_private_pypi() as p:
         c = p.pipenv('install tablib==0.13.0')
         assert c.returncode == 0
-        c = p.pipenv('graph --reverse')
-        assert c.returncode == 0
+        cli_runner = CliRunner(mix_stderr=False)
+        c = cli_runner.invoke(cli, "graph --reverse")
+        assert c.exit_code == 0
         output = c.stdout
 
         requests_dependency = [
@@ -169,7 +173,7 @@ def test_pipenv_check_check_lockfile_categories(pipenv_instance_pypi, category):
 
 @pytest.mark.cli
 def test_pipenv_clean(pipenv_instance_pypi):
-    with pipenv_instance_pypi(chdir=True) as p:
+    with pipenv_instance_pypi() as p:
         with open('setup.py', 'w') as f:
             f.write('from setuptools import setup; setup(name="empty")')
         c = p.pipenv('install -e .')
@@ -248,7 +252,7 @@ def test_pipenv_clear(pipenv_instance_pypi):
 
 @pytest.mark.outdated
 def test_pipenv_outdated_prerelease(pipenv_instance_pypi):
-    with pipenv_instance_pypi(chdir=True) as p:
+    with pipenv_instance_pypi() as p:
         with open(p.pipfile_path, "w") as f:
             contents = """
 [packages]

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -19,7 +19,7 @@ def test_pipenv_where(pipenv_instance_pypi):
 @pytest.mark.cli
 def test_pipenv_venv(pipenv_instance_pypi):
     with pipenv_instance_pypi() as p:
-        c = p.pipenv('--python python')
+        c = p.pipenv('install dataclasses-json')
         assert c.returncode == 0
         c = p.pipenv('--venv')
         assert c.returncode == 0

--- a/tests/integration/test_dot_venv.py
+++ b/tests/integration/test_dot_venv.py
@@ -51,7 +51,7 @@ def test_venv_in_project_disabled_ignores_venv(false_value, pipenv_instance_pypi
 @pytest.mark.parametrize("true_value", TRUE_VALUES)
 def test_venv_at_project_root(true_value, pipenv_instance_pypi):
     with temp_environ():
-        with pipenv_instance_pypi(chdir=True) as p:
+        with pipenv_instance_pypi() as p:
             os.environ['PIPENV_VENV_IN_PROJECT'] = true_value
             c = p.pipenv('install')
             assert c.returncode == 0
@@ -65,7 +65,7 @@ def test_venv_at_project_root(true_value, pipenv_instance_pypi):
 
 @pytest.mark.dotvenv
 def test_reuse_previous_venv(pipenv_instance_pypi):
-    with pipenv_instance_pypi(chdir=True) as p:
+    with pipenv_instance_pypi() as p:
         os.mkdir('.venv')
         c = p.pipenv('install dataclasses-json')
         assert c.returncode == 0
@@ -78,7 +78,7 @@ def test_venv_file(venv_name, pipenv_instance_pypi):
     """Tests virtualenv creation when a .venv file exists at the project root
     and contains a venv name.
     """
-    with pipenv_instance_pypi(chdir=True) as p:
+    with pipenv_instance_pypi() as p:
         file_path = os.path.join(p.path, '.venv')
         with open(file_path, 'w') as f:
             f.write(venv_name)
@@ -87,8 +87,6 @@ def test_venv_file(venv_name, pipenv_instance_pypi):
             prefix='pipenv-', suffix='temp_workon_home'
         ) as workon_home:
             os.environ['WORKON_HOME'] = workon_home
-            if 'PIPENV_VENV_IN_PROJECT' in os.environ:
-                del os.environ['PIPENV_VENV_IN_PROJECT']
 
             c = p.pipenv('install')
             assert c.returncode == 0
@@ -110,7 +108,7 @@ def test_venv_file(venv_name, pipenv_instance_pypi):
 def test_empty_venv_file(pipenv_instance_pypi):
     """Tests virtualenv creation when an empty .venv file exists at the project root
     """
-    with pipenv_instance_pypi(chdir=True) as p:
+    with pipenv_instance_pypi() as p:
         file_path = os.path.join(p.path, '.venv')
         with open(file_path, 'w'):
             pass
@@ -119,8 +117,6 @@ def test_empty_venv_file(pipenv_instance_pypi):
             prefix='pipenv-', suffix='temp_workon_home'
         ) as workon_home:
             os.environ['WORKON_HOME'] = workon_home
-            if 'PIPENV_VENV_IN_PROJECT' in os.environ:
-                del os.environ['PIPENV_VENV_IN_PROJECT']
 
             c = p.pipenv('install')
             assert c.returncode == 0
@@ -140,13 +136,10 @@ def test_empty_venv_file(pipenv_instance_pypi):
 def test_venv_in_project_default_when_venv_exists(pipenv_instance_pypi):
     """Tests virtualenv creation when a .venv file exists at the project root.
     """
-    with temp_environ(), pipenv_instance_pypi(chdir=True) as p:
+    with temp_environ(), pipenv_instance_pypi() as p:
         with TemporaryDirectory(
             prefix='pipenv-', suffix='-test_venv'
         ) as venv_path:
-            if 'PIPENV_VENV_IN_PROJECT' in os.environ:
-                del os.environ['PIPENV_VENV_IN_PROJECT']
-
             file_path = os.path.join(p.path, '.venv')
             with open(file_path, 'w') as f:
                 f.write(venv_path)
@@ -165,7 +158,7 @@ def test_venv_in_project_default_when_venv_exists(pipenv_instance_pypi):
 def test_venv_name_accepts_custom_name_environment_variable(pipenv_instance_pypi):
     """Tests that virtualenv reads PIPENV_CUSTOM_VENV_NAME and accepts it as a name
     """
-    with pipenv_instance_pypi(chdir=True, venv_in_project=False) as p:
+    with pipenv_instance_pypi() as p:
         test_name = "sensible_custom_venv_name"
         with temp_environ():
             os.environ['PIPENV_CUSTOM_VENV_NAME'] = test_name

--- a/tests/integration/test_import_requirements.py
+++ b/tests/integration/test_import_requirements.py
@@ -12,7 +12,7 @@ from pipenv.project import Project
 @pytest.mark.deploy
 @pytest.mark.system
 def test_auth_with_pw_redacted(pipenv_instance_pypi):
-    with pipenv_instance_pypi(chdir=True) as p:
+    with pipenv_instance_pypi() as p:
         p.pipenv("run shell")
         project = Project()
         requirements_file = tempfile.NamedTemporaryFile(mode="w+", delete=False)
@@ -27,7 +27,7 @@ def test_auth_with_pw_redacted(pipenv_instance_pypi):
 @pytest.mark.deploy
 @pytest.mark.system
 def test_auth_with_username_redacted(pipenv_instance_pypi):
-    with pipenv_instance_pypi(chdir=True) as p:
+    with pipenv_instance_pypi() as p:
         p.pipenv("run shell")
         project = Project()
         requirements_file = tempfile.NamedTemporaryFile(mode="w+", delete=False)
@@ -42,7 +42,7 @@ def test_auth_with_username_redacted(pipenv_instance_pypi):
 @pytest.mark.deploy
 @pytest.mark.system
 def test_auth_with_pw_are_variables_passed_to_pipfile(pipenv_instance_pypi):
-    with pipenv_instance_pypi(chdir=True) as p:
+    with pipenv_instance_pypi() as p:
         p.pipenv("run shell")
         project = Project()
         requirements_file = tempfile.NamedTemporaryFile(mode="w+", delete=False)
@@ -56,7 +56,7 @@ def test_auth_with_pw_are_variables_passed_to_pipfile(pipenv_instance_pypi):
 @pytest.mark.deploy
 @pytest.mark.system
 def test_auth_with_only_username_variable_passed_to_pipfile(pipenv_instance_pypi):
-    with pipenv_instance_pypi(chdir=True) as p:
+    with pipenv_instance_pypi() as p:
         p.pipenv("run shell")
         project = Project()
         requirements_file = tempfile.NamedTemporaryFile(mode="w+", delete=False)

--- a/tests/integration/test_install_basic.py
+++ b/tests/integration/test_install_basic.py
@@ -92,18 +92,18 @@ tablib = "*"
 
 @pytest.mark.basic
 @pytest.mark.install
-def test_install_with_version_req_default_operator(pipenv_instance_pypi):
+def test_install_with_version_req_default_operator(pipenv_instance_private_pypi):
     """Ensure that running `pipenv install` work when spec is package = "X.Y.Z". """
-    with pipenv_instance_pypi(chdir=True) as p:
+    with pipenv_instance_private_pypi(chdir=True) as p:
         with open(p.pipfile_path, "w") as f:
             contents = """
 [packages]
-fastapi = "0.95.0"
+six = "1.12.0"
             """.strip()
             f.write(contents)
         c = p.pipenv("install")
         assert c.returncode == 0
-        assert "fastapi" in p.pipfile["packages"]
+        assert "six" in p.pipfile["packages"]
 
 
 @pytest.mark.basic

--- a/tests/integration/test_install_basic.py
+++ b/tests/integration/test_install_basic.py
@@ -4,7 +4,6 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 
 import pytest
-from .conftest import DEFAULT_PRIVATE_PYPI_SERVER
 
 from pipenv.utils.processes import subprocess_run
 from pipenv.utils.shell import temp_environ
@@ -440,7 +439,7 @@ six = {}
 [packages.requests]
 version = "*"
 extras = ["socks"]
-            """.format(DEFAULT_PRIVATE_PYPI_SERVER, "{version = \"*\"}").strip()
+            """.format(p.index_url, "{version = \"*\"}").strip()
             f.write(contents)
         c = p.pipenv("install colorama")
         assert c.returncode == 0

--- a/tests/integration/test_install_basic.py
+++ b/tests/integration/test_install_basic.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 
 import pytest
+from .conftest import DEFAULT_PRIVATE_PYPI_SERVER
 
 from pipenv.utils.processes import subprocess_run
 from pipenv.utils.shell import temp_environ
@@ -22,11 +23,10 @@ def test_basic_install(pipenv_instance_private_pypi):
 @pytest.mark.basic
 @pytest.mark.install
 def test_mirror_install(pipenv_instance_pypi):
-    with temp_environ(), pipenv_instance_pypi(chdir=True) as p:
+    with temp_environ(), pipenv_instance_pypi() as p:
         mirror_url = "https://pypi.python.org/simple"
         assert "pypi.org" not in mirror_url
         # This should sufficiently demonstrate the mirror functionality
-        # since pypi.org is the default when PIPENV_TEST_INDEX is unset.
         c = p.pipenv(f"install dataclasses-json --pypi-mirror {mirror_url}")
         assert c.returncode == 0
         # Ensure the --pypi-mirror parameter hasn't altered the Pipfile or Pipfile.lock sources
@@ -43,9 +43,8 @@ def test_mirror_install(pipenv_instance_pypi):
 @pytest.mark.install
 @pytest.mark.needs_internet
 def test_bad_mirror_install(pipenv_instance_pypi):
-    with temp_environ(), pipenv_instance_pypi(chdir=True) as p:
+    with temp_environ(), pipenv_instance_pypi() as p:
         # This demonstrates that the mirror parameter is being used
-        os.environ.pop("PIPENV_TEST_INDEX", None)
         c = p.pipenv("install dataclasses-json --pypi-mirror https://pypi.example.org")
         assert c.returncode != 0
 
@@ -59,7 +58,7 @@ def test_basic_dev_install(pipenv_instance_pypi):
         assert "dataclasses-json" in p.pipfile["dev-packages"]
         assert "dataclasses-json" in p.lockfile["develop"]
 
-        c = p.pipenv("run python -c 'from dataclasses_json import dataclass_json'")
+        c = p.pipenv("""run python -c "from dataclasses_json import dataclass_json" """)
         assert c.returncode == 0
 
 
@@ -68,7 +67,7 @@ def test_basic_dev_install(pipenv_instance_pypi):
 @pytest.mark.install
 def test_install_without_dev(pipenv_instance_private_pypi):
     """Ensure that running `pipenv install` doesn't install dev packages"""
-    with pipenv_instance_private_pypi(chdir=True) as p:
+    with pipenv_instance_private_pypi() as p:
         with open(p.pipfile_path, "w") as f:
             contents = """
 [packages]
@@ -94,7 +93,7 @@ tablib = "*"
 @pytest.mark.install
 def test_install_with_version_req_default_operator(pipenv_instance_private_pypi):
     """Ensure that running `pipenv install` work when spec is package = "X.Y.Z". """
-    with pipenv_instance_private_pypi(chdir=True) as p:
+    with pipenv_instance_private_pypi() as p:
         with open(p.pipfile_path, "w") as f:
             contents = """
 [packages]
@@ -130,7 +129,7 @@ six = "*"
 @pytest.mark.extras
 @pytest.mark.install
 def test_extras_install(pipenv_instance_private_pypi):
-    with pipenv_instance_private_pypi(chdir=True) as p:
+    with pipenv_instance_private_pypi() as p:
         c = p.pipenv("install requests[socks]")
         assert c.returncode == 0
         assert "requests" in p.pipfile["packages"]
@@ -233,12 +232,12 @@ def test_bad_packages(pipenv_instance_private_pypi):
 @pytest.mark.requirements
 def test_requirements_to_pipfile(pipenv_instance_private_pypi):
 
-    with pipenv_instance_private_pypi(pipfile=False, chdir=True) as p:
+    with pipenv_instance_private_pypi(pipfile=False) as p:
 
         # Write a requirements file
         with open("requirements.txt", "w") as f:
             f.write(
-                f"-i {os.environ['PIPENV_TEST_INDEX']}\n"
+                f"-i {p.index_url}\n"
                 "requests[socks]==2.19.1\n"
             )
 
@@ -271,7 +270,7 @@ def test_skip_requirements_when_pipfile(pipenv_instance_private_pypi):
     1. We do `pipenv install [package]`
     2. A Pipfile already exists when we run `pipenv install`.
     """
-    with pipenv_instance_private_pypi(chdir=True) as p:
+    with pipenv_instance_private_pypi() as p:
         with open("requirements.txt", "w") as f:
             f.write("requests==2.18.1\n")
         c = p.pipenv("install six")
@@ -303,7 +302,7 @@ def test_clean_on_empty_venv(pipenv_instance_pypi):
 def test_install_does_not_extrapolate_environ(pipenv_instance_pypi):
     """Ensure environment variables are not expanded in lock file.
     """
-    with temp_environ(), pipenv_instance_pypi(chdir=True) as p:
+    with temp_environ(), pipenv_instance_pypi() as p:
         os.environ["PYPI_URL"] = p.pypi
 
         with open(p.pipfile_path, "w") as f:
@@ -346,7 +345,7 @@ def test_editable_no_args(pipenv_instance_pypi):
 def test_install_venv_project_directory(pipenv_instance_pypi):
     """Test the project functionality during virtualenv creation.
     """
-    with pipenv_instance_pypi(chdir=True) as p:
+    with pipenv_instance_pypi() as p:
         with temp_environ(), TemporaryDirectory(
             prefix="pipenv-", suffix="temp_workon_home"
         ) as workon_home:
@@ -367,7 +366,7 @@ def test_install_venv_project_directory(pipenv_instance_pypi):
 @pytest.mark.deploy
 @pytest.mark.system
 def test_system_and_deploy_work(pipenv_instance_private_pypi):
-    with pipenv_instance_private_pypi(chdir=True) as p:
+    with pipenv_instance_private_pypi() as p:
         c = p.pipenv("install urllib3")
         assert c.returncode == 0
         c = p.pipenv("--rm")
@@ -377,14 +376,13 @@ def test_system_and_deploy_work(pipenv_instance_private_pypi):
         c = p.pipenv("install --system --deploy")
         assert c.returncode == 0
 
+
 @pytest.mark.basic
 @pytest.mark.install
 def test_install_creates_pipfile(pipenv_instance_pypi):
-    with pipenv_instance_pypi(chdir=True) as p:
+    with pipenv_instance_pypi() as p:
         if os.path.isfile(p.pipfile_path):
             os.unlink(p.pipfile_path)
-        if "PIPENV_PIPFILE" in os.environ:
-            del os.environ["PIPENV_PIPFILE"]
         assert not os.path.isfile(p.pipfile_path)
         c = p.pipenv("install")
         assert c.returncode == 0
@@ -395,10 +393,10 @@ def test_install_creates_pipfile(pipenv_instance_pypi):
 
 @pytest.mark.basic
 @pytest.mark.install
-def test_create_pipfile_requires_python_full_version(pipenv_instance_pypi):
-    with pipenv_instance_pypi(chdir=True) as p:
-        python_version = str(sys.version_info.major) + "." + str(sys.version_info.minor)
-        python_full_version = python_version + "." + str(sys.version_info.micro)
+def test_create_pipfile_requires_python_full_version(pipenv_instance_private_pypi):
+    with pipenv_instance_private_pypi(pipfile=False) as p:
+        python_version = f"{sys.version_info.major}.{sys.version_info.minor}"
+        python_full_version = f"{python_version}.{sys.version_info.micro}"
         c = p.pipenv(f"--python {python_full_version}")
         assert c.returncode == 0
         assert p.pipfile["requires"] == {
@@ -410,7 +408,7 @@ def test_create_pipfile_requires_python_full_version(pipenv_instance_pypi):
 @pytest.mark.basic
 @pytest.mark.install
 def test_install_non_exist_dep(pipenv_instance_pypi):
-    with pipenv_instance_pypi(chdir=True) as p:
+    with pipenv_instance_pypi() as p:
         c = p.pipenv("install dateutil")
         assert c.returncode
         assert "dateutil" not in p.pipfile["packages"]
@@ -419,7 +417,7 @@ def test_install_non_exist_dep(pipenv_instance_pypi):
 @pytest.mark.basic
 @pytest.mark.install
 def test_install_package_with_dots(pipenv_instance_private_pypi):
-    with pipenv_instance_private_pypi(chdir=True) as p:
+    with pipenv_instance_private_pypi() as p:
         c = p.pipenv("install backports.html")
         assert c.returncode == 0
         assert "backports.html" in p.pipfile["packages"]
@@ -428,7 +426,7 @@ def test_install_package_with_dots(pipenv_instance_private_pypi):
 @pytest.mark.basic
 @pytest.mark.install
 def test_rewrite_outline_table(pipenv_instance_private_pypi):
-    with pipenv_instance_private_pypi(chdir=True) as p:
+    with pipenv_instance_private_pypi() as p:
         with open(p.pipfile_path, 'w') as f:
             contents = """
 [[source]]
@@ -442,7 +440,7 @@ six = {}
 [packages.requests]
 version = "*"
 extras = ["socks"]
-            """.format(os.environ['PIPENV_TEST_INDEX'], "{version = \"*\"}").strip()
+            """.format(DEFAULT_PRIVATE_PYPI_SERVER, "{version = \"*\"}").strip()
             f.write(contents)
         c = p.pipenv("install colorama")
         assert c.returncode == 0
@@ -459,7 +457,7 @@ extras = ["socks"]
 def test_install_dev_use_default_constraints(pipenv_instance_private_pypi):
     # See https://github.com/pypa/pipenv/issues/4371
     # See https://github.com/pypa/pipenv/issues/2987
-    with pipenv_instance_private_pypi(chdir=True) as p:
+    with pipenv_instance_private_pypi() as p:
 
         c = p.pipenv("install requests==2.14.0")
         assert c.returncode == 0
@@ -486,10 +484,10 @@ def test_install_dev_use_default_constraints(pipenv_instance_private_pypi):
 @pytest.mark.needs_internet
 def test_install_does_not_exclude_packaging(pipenv_instance_pypi):
     """Ensure that running `pipenv install` doesn't exclude packaging when its required. """
-    with pipenv_instance_pypi(chdir=True) as p:
+    with pipenv_instance_pypi() as p:
         c = p.pipenv("install dataclasses-json")
         assert c.returncode == 0
-        c = p.pipenv("run python -c 'from dataclasses_json import DataClassJsonMixin'")
+        c = p.pipenv("""run python -c "from dataclasses_json import DataClassJsonMixin" """)
         assert c.returncode == 0
 
 
@@ -497,7 +495,7 @@ def test_install_does_not_exclude_packaging(pipenv_instance_pypi):
 @pytest.mark.install
 @pytest.mark.needs_internet
 def test_install_will_supply_extra_pip_args(pipenv_instance_pypi):
-    with pipenv_instance_pypi(chdir=True) as p:
+    with pipenv_instance_pypi() as p:
         c = p.pipenv("""install dataclasses-json --extra-pip-args="--use-feature=truststore --proxy=test" """)
         assert c.returncode == 1
         assert "truststore feature" in c.stderr
@@ -508,7 +506,7 @@ def test_install_will_supply_extra_pip_args(pipenv_instance_pypi):
 @pytest.mark.needs_internet
 def test_install_tarball_is_actually_installed(pipenv_instance_pypi):
     """ Test case for Issue 5326"""
-    with pipenv_instance_pypi(chdir=True) as p:
+    with pipenv_instance_pypi() as p:
         with open(p.pipfile_path, "w") as f:
             contents = """
 [[source]]
@@ -524,5 +522,5 @@ dataclasses-json = {file = "https://files.pythonhosted.org/packages/85/94/1b3021
         assert c.returncode == 0
         c = p.pipenv("sync")
         assert c.returncode == 0
-        c = p.pipenv("run python -c 'from dataclasses_json import dataclass_json'")
+        c = p.pipenv("""run python -c "from dataclasses_json import dataclass_json" """)
         assert c.returncode == 0

--- a/tests/integration/test_install_categories.py
+++ b/tests/integration/test_install_categories.py
@@ -37,7 +37,7 @@ def test_multiple_category_install(pipenv_instance_private_pypi, categories):
 def test_multiple_category_install_proceeds_in_order_specified(pipenv_instance_private_pypi):
     """Ensure -e .[extras] installs.
     """
-    with pipenv_instance_private_pypi(chdir=True) as p:
+    with pipenv_instance_private_pypi() as p:
         #os.mkdir(os.path.join(p.path, "testpipenv"))
         setup_py = os.path.join(p.path, "setup.py")
         with open(setup_py, "w") as fh:

--- a/tests/integration/test_install_markers.py
+++ b/tests/integration/test_install_markers.py
@@ -3,7 +3,6 @@ import os
 import pytest
 from flaky import flaky
 
-from .conftest import DEFAULT_PRIVATE_PYPI_SERVER
 
 from pipenv.project import Project
 from pipenv.utils.shell import temp_environ
@@ -24,7 +23,7 @@ name = "testindex"
 fake_package = {}
 
 [dev-packages]
-            """.format(DEFAULT_PRIVATE_PYPI_SERVER, "{version = \"*\", markers=\"os_name=='splashwear'\", index=\"testindex\"}").strip()
+            """.format(p.index_url, "{version = \"*\", markers=\"os_name=='splashwear'\", index=\"testindex\"}").strip()
             f.write(contents)
 
         c = p.pipenv('install -v')

--- a/tests/integration/test_install_misc.py
+++ b/tests/integration/test_install_misc.py
@@ -1,4 +1,3 @@
-import os
 import pytest
 
 @pytest.mark.urls
@@ -6,7 +5,6 @@ import pytest
 @pytest.mark.install
 def test_install_uri_with_extras(pipenv_instance_private_pypi):
     file_uri = "http://localhost:8080/packages/plette/plette-0.2.2-py2.py3-none-any.whl"
-    index = os.environ['PIPENV_TEST_INDEX']
     with pipenv_instance_private_pypi() as p:
         with open(p.pipfile_path, 'w') as f:
             contents = """
@@ -17,7 +15,7 @@ name = "testindex"
 
 [packages]
 plette = {{file = "{file_uri}", extras = ["validation"]}}
-""".format(file_uri=file_uri, index=index)
+""".format(file_uri=file_uri, index=p.index_url)
             f.write(contents)
         c = p.pipenv("install")
         assert c.returncode == 0

--- a/tests/integration/test_install_twists.py
+++ b/tests/integration/test_install_twists.py
@@ -3,7 +3,6 @@ import shutil
 import sys
 
 import pytest
-from .conftest import DEFAULT_PRIVATE_PYPI_SERVER
 
 from pipenv.utils.shell import temp_environ
 
@@ -294,7 +293,7 @@ name = "pypi"
 
 [packages]
 six = {}
-            """.format(DEFAULT_PRIVATE_PYPI_SERVER, '{version = "*", index = "pypi"}').strip()
+            """.format(p.index_url, '{version = "*", index = "pypi"}').strip()
             f.write(contents)
         c = p.pipenv('install --skip-lock')
         assert c.returncode == 0

--- a/tests/integration/test_install_uri.py
+++ b/tests/integration/test_install_uri.py
@@ -10,11 +10,15 @@ from pipenv.utils.processes import subprocess_run
 @pytest.mark.install
 @pytest.mark.needs_internet
 def test_basic_vcs_install_with_env_var(pipenv_instance_pypi):
+    from pipenv.cli import cli
+    from click.testing import CliRunner  # not thread safe but macos and linux will expand the env var otherwise
+
     with pipenv_instance_pypi() as p:
         # edge case where normal package starts with VCS name shouldn't be flagged as vcs
         os.environ["GIT_HOST"] = "github.com"
-        c = p.pipenv("install git+https://${GIT_HOST}/benjaminp/six.git@1.11.0#egg=six gitdb2")
-        assert c.returncode == 0
+        cli_runner = CliRunner(mix_stderr=False)
+        c = cli_runner.invoke(cli, "install git+https://${GIT_HOST}/benjaminp/six.git@1.11.0#egg=six gitdb2")
+        assert c.exit_code == 0
         assert all(package in p.pipfile["packages"] for package in ["six", "gitdb2"])
         assert "git" in p.pipfile["packages"]["six"]
         assert p.lockfile["default"]["six"] == {

--- a/tests/integration/test_install_uri.py
+++ b/tests/integration/test_install_uri.py
@@ -10,7 +10,7 @@ from pipenv.utils.processes import subprocess_run
 @pytest.mark.install
 @pytest.mark.needs_internet
 def test_basic_vcs_install_with_env_var(pipenv_instance_pypi):
-    with pipenv_instance_pypi(chdir=True) as p:
+    with pipenv_instance_pypi() as p:
         # edge case where normal package starts with VCS name shouldn't be flagged as vcs
         os.environ["GIT_HOST"] = "github.com"
         c = p.pipenv("install git+https://${GIT_HOST}/benjaminp/six.git@1.11.0#egg=six gitdb2")
@@ -28,7 +28,7 @@ def test_basic_vcs_install_with_env_var(pipenv_instance_pypi):
 @pytest.mark.files
 @pytest.mark.needs_internet
 def test_urls_work(pipenv_instance_pypi):
-    with pipenv_instance_pypi(chdir=True) as p:
+    with pipenv_instance_pypi() as p:
         # the library this installs is "django-cms"
         url = "https://github.com/lidatong/dataclasses-json/archive/refs/tags/v0.5.7.zip"
         c = p.pipenv(
@@ -46,8 +46,8 @@ def test_urls_work(pipenv_instance_pypi):
 
 @pytest.mark.urls
 @pytest.mark.files
-def test_file_urls_work(pipenv_instance_pypi, pip_src_dir):
-    with pipenv_instance_pypi(chdir=True) as p:
+def test_file_urls_work(pipenv_instance_pypi):
+    with pipenv_instance_pypi() as p:
         whl = Path(__file__).parent.parent.joinpath(
             "pypi", "six", "six-1.11.0-py2.py3-none-any.whl"
         )
@@ -72,7 +72,7 @@ def test_file_urls_work(pipenv_instance_pypi, pip_src_dir):
 @pytest.mark.install
 @pytest.mark.needs_internet
 def test_editable_vcs_install(pipenv_instance_pypi):
-    with pipenv_instance_pypi(chdir=True) as p:
+    with pipenv_instance_pypi() as p:
         c = p.pipenv(
             "install -e git+https://github.com/lidatong/dataclasses-json.git#egg=dataclasses-json"
         )
@@ -85,7 +85,7 @@ def test_editable_vcs_install(pipenv_instance_pypi):
 @pytest.mark.install
 @pytest.mark.needs_internet
 def test_install_editable_git_tag(pipenv_instance_private_pypi):
-    with pipenv_instance_private_pypi(chdir=True) as p:
+    with pipenv_instance_private_pypi() as p:
         c = p.pipenv(
             "install -e git+https://github.com/benjaminp/six.git@1.11.0#egg=six"
         )
@@ -161,7 +161,7 @@ six = "*"
 @pytest.mark.install
 @pytest.mark.needs_internet
 def test_install_local_vcs_not_in_lockfile(pipenv_instance_pypi):
-    with pipenv_instance_pypi(chdir=True) as p:
+    with pipenv_instance_pypi() as p:
         # six_path = os.path.join(p.path, "six")
         six_path = p._pipfile.get_fixture_path("git/six/").as_posix()
         c = subprocess_run(["git", "clone", six_path, "./six"])
@@ -178,7 +178,7 @@ def test_install_local_vcs_not_in_lockfile(pipenv_instance_pypi):
 @pytest.mark.install
 @pytest.mark.needs_internet
 def test_get_vcs_refs(pipenv_instance_private_pypi):
-    with pipenv_instance_private_pypi(chdir=True) as p:
+    with pipenv_instance_private_pypi() as p:
         c = p.pipenv(
             "install -e git+https://github.com/benjaminp/six.git@1.9.0#egg=six"
         )
@@ -211,7 +211,7 @@ def test_vcs_entry_supersedes_non_vcs(pipenv_instance_pypi):
     in the lockfile -- due to not running pip install before locking and not locking
     the resolution graph of non-editable vcs dependencies.
     """
-    with pipenv_instance_pypi(chdir=True) as p:
+    with pipenv_instance_pypi() as p:
         jinja2_uri = p._pipfile.get_fixture_path("git/jinja2").as_uri()
         with open(p.pipfile_path, "w") as f:
             f.write(
@@ -244,7 +244,7 @@ Jinja2 = {{ref = "2.11.0", git = "{}"}}
 @pytest.mark.install
 @pytest.mark.needs_internet
 def test_vcs_can_use_markers(pipenv_instance_pypi):
-    with pipenv_instance_pypi(chdir=True) as p:
+    with pipenv_instance_pypi() as p:
         path = p._pipfile.get_fixture_path("git/six/.git")
         p._pipfile.install("six", {"git": f"{path.as_uri()}", "markers": "sys_platform == 'linux'"})
         assert "six" in p.pipfile["packages"]

--- a/tests/integration/test_lock.py
+++ b/tests/integration/test_lock.py
@@ -3,7 +3,6 @@ from pathlib import Path
 
 import pytest
 
-from .conftest import DEFAULT_PRIVATE_PYPI_SERVER
 
 from flaky import flaky
 from pipenv.utils.shell import temp_environ

--- a/tests/integration/test_pipenv.py
+++ b/tests/integration/test_pipenv.py
@@ -16,7 +16,7 @@ from pipenv.utils.shell import temp_environ
 @pytest.mark.deploy
 def test_deploy_works(pipenv_instance_pypi):
 
-    with pipenv_instance_pypi(chdir=True) as p:
+    with pipenv_instance_pypi() as p:
         with open(p.pipfile_path, 'w') as f:
             contents = """
 [packages]
@@ -65,7 +65,7 @@ def test_update_locks(pipenv_instance_private_pypi):
 @pytest.mark.project
 @pytest.mark.proper_names
 def test_proper_names_unmanaged_virtualenv(pipenv_instance_pypi):
-    with pipenv_instance_pypi(chdir=True):
+    with pipenv_instance_pypi():
         c = subprocess_run(['python', '-m', 'virtualenv', '.venv'])
         assert c.returncode == 0
         project = Project()
@@ -73,9 +73,9 @@ def test_proper_names_unmanaged_virtualenv(pipenv_instance_pypi):
 
 
 @pytest.mark.cli
-def test_directory_with_leading_dash(raw_venv, pipenv_instance_pypi):
+def test_directory_with_leading_dash(pipenv_instance_pypi):
     with temp_environ():
-        with pipenv_instance_pypi(chdir=True, venv_in_project=False, name="-project-with-dash") as p:
+        with pipenv_instance_pypi() as p:
             c = p.pipenv('run pip freeze')
             assert c.returncode == 0
             c = p.pipenv('--venv')

--- a/tests/integration/test_project.py
+++ b/tests/integration/test_project.py
@@ -3,8 +3,6 @@ import os
 
 import pytest
 
-from .conftest import DEFAULT_PRIVATE_PYPI_SERVER
-
 from pipenv.project import Project
 from pipenv.utils.shell import temp_environ
 from pipenv.vendor.plette import Pipfile
@@ -56,7 +54,7 @@ pytz = "*"
 six = {{version = "*", index = "pypi"}}
 
 [dev-packages]
-            """.format(DEFAULT_PRIVATE_PYPI_SERVER).strip()
+            """.format(p.index_url).strip()
             f.write(contents)
 
         if lock_first:
@@ -66,7 +64,7 @@ six = {{version = "*", index = "pypi"}}
         project = Project()
         sources = [
             ['pypi', 'https://pypi.org/simple'],
-            ['testindex', DEFAULT_PRIVATE_PYPI_SERVER]
+            ['testindex', p.index_url]
         ]
         for src in sources:
             name, url = src
@@ -141,31 +139,10 @@ pytz = "*"
 six = {{version = "*", index = "pypi"}}
 
 [dev-packages]
-            """.format(DEFAULT_PRIVATE_PYPI_SERVER).strip()
+            """.format(p.index_url).strip()
             f.write(contents)
         c = p.pipenv('install')
         assert c.returncode == 0
-
-
-@pytest.mark.project
-@pytest.mark.virtualenv
-def test_run_in_virtualenv(pipenv_instance_pypi):
-    with pipenv_instance_pypi() as p:
-        c = p.pipenv("run pip freeze")
-        assert c.returncode == 0, (c.stdout, c.stderr)
-
-        c = p.pipenv(f"run pip install -i {p.index_url} click")
-        assert c.returncode == 0, (c.stdout, c.stderr)
-
-        c = p.pipenv("install six")
-        assert c.returncode == 0, (c.stdout, c.stderr)
-
-        c = p.pipenv("run python -c 'import click;print(click.__file__)'")
-        assert c.returncode == 0, (c.stdout, c.stderr)
-
-        c = p.pipenv("clean --dry-run")
-        assert c.returncode == 0, (c.stdout, c.stderr)
-        assert "click" in c.stdout, c.stdout
 
 
 @pytest.mark.project

--- a/tests/integration/test_requirements.py
+++ b/tests/integration/test_requirements.py
@@ -7,7 +7,7 @@ from pipenv.routines.requirements import requirements_from_deps
 
 @pytest.mark.requirements
 def test_requirements_generates_requirements_from_lockfile(pipenv_instance_pypi):
-    with pipenv_instance_pypi(chdir=True) as p:
+    with pipenv_instance_pypi() as p:
         packages = ('requests', '2.14.0')
         dev_packages = ('flask', '0.12.2')
         with open(p.pipfile_path, 'w') as f:
@@ -44,7 +44,7 @@ def test_requirements_generates_requirements_from_lockfile(pipenv_instance_pypi)
 
 @pytest.mark.requirements
 def test_requirements_generates_requirements_from_lockfile_multiple_sources(pipenv_instance_private_pypi):
-    with pipenv_instance_private_pypi(chdir=True) as p:
+    with pipenv_instance_private_pypi() as p:
         packages = ('six', '1.12.0')
         dev_packages = ('itsdangerous', '1.1.0')
         with open(p.pipfile_path, 'w') as f:
@@ -74,7 +74,7 @@ def test_requirements_generates_requirements_from_lockfile_multiple_sources(pipe
 
 @pytest.mark.requirements
 def test_requirements_generates_requirements_from_lockfile_from_categories(pipenv_instance_private_pypi):
-    with pipenv_instance_private_pypi(chdir=True) as p:
+    with pipenv_instance_private_pypi() as p:
         packages = ('six', '1.12.0')
         dev_packages = ('itsdangerous', '1.1.0')
         test_packages = ('pytest', '7.1.3')
@@ -129,7 +129,7 @@ def test_requirements_with_git_requirements(pipenv_instance_pypi):
         "develop": {}
     }
 
-    with pipenv_instance_pypi(chdir=True) as p:
+    with pipenv_instance_pypi() as p:
         with open(p.lockfile_path, 'w') as f:
             json.dump(lockfile, f)
 
@@ -157,7 +157,7 @@ def test_requirements_markers_get_included(pipenv_instance_pypi):
         "develop": {}
     }
 
-    with pipenv_instance_pypi(chdir=True) as p:
+    with pipenv_instance_pypi() as p:
         with open(p.lockfile_path, 'w') as f:
             json.dump(lockfile, f)
 
@@ -184,7 +184,7 @@ def test_requirements_markers_get_excluded(pipenv_instance_pypi):
         "develop": {}
     }
 
-    with pipenv_instance_pypi(chdir=True) as p:
+    with pipenv_instance_pypi() as p:
         with open(p.lockfile_path, 'w') as f:
             json.dump(lockfile, f)
 
@@ -213,7 +213,7 @@ def test_requirements_hashes_get_included(pipenv_instance_pypi):
         "develop": {}
     }
 
-    with pipenv_instance_pypi(chdir=True) as p:
+    with pipenv_instance_pypi() as p:
         with open(p.lockfile_path, 'w') as f:
             json.dump(lockfile, f)
 
@@ -238,7 +238,7 @@ def test_requirements_generates_requirements_from_lockfile_without_env_var_expan
         "default": {},
     }
 
-    with pipenv_instance_pypi(chdir=True) as p:
+    with pipenv_instance_pypi() as p:
         with open(p.lockfile_path, "w") as f:
             json.dump(lockfile, f)
 

--- a/tests/integration/test_run.py
+++ b/tests/integration/test_run.py
@@ -9,7 +9,7 @@ from pipenv.utils.shell import subprocess_run, temp_environ
 @pytest.mark.run
 @pytest.mark.dotenv
 def test_env(pipenv_instance_pypi):
-    with pipenv_instance_pypi(pipfile=False, chdir=True) as p:
+    with pipenv_instance_pypi(pipfile=False, ) as p:
         with open(os.path.join(p.path, ".env"), "w") as f:
             f.write("HELLO=WORLD")
         c = subprocess_run(['pipenv', 'run', 'python', '-c', "import os; print(os.environ['HELLO'])"], env=p.env)
@@ -19,7 +19,7 @@ def test_env(pipenv_instance_pypi):
 
 @pytest.mark.run
 def test_scripts(pipenv_instance_pypi):
-    with pipenv_instance_pypi(chdir=True) as p:
+    with pipenv_instance_pypi() as p:
         with open(p.pipfile_path, 'w') as f:
             f.write(r"""
 [scripts]
@@ -65,7 +65,7 @@ multicommand = "bash -c \"cd docs && make html\""
 
 @pytest.mark.run
 def test_scripts_with_package_functions(pipenv_instance_pypi):
-    with pipenv_instance_pypi(chdir=True) as p:
+    with pipenv_instance_pypi() as p:
         p.pipenv('install')
         pkg_path = os.path.join(p.path, "pkg")
         os.makedirs(pkg_path, exist_ok=True)
@@ -96,7 +96,7 @@ argfunc = {call = "pkg.mod:arg_func('abc', 123)"}
 @pytest.mark.run
 @pytest.mark.skip_windows
 def test_run_with_usr_env_shebang(pipenv_instance_pypi):
-    with pipenv_instance_pypi(chdir=True) as p:
+    with pipenv_instance_pypi() as p:
         p.pipenv('install')
         script_path = os.path.join(p.path, "test_script")
         with open(script_path, "w") as f:
@@ -135,7 +135,7 @@ hello = "echo $HELLO_VAR"
         else:
             c = p.pipenv('run hello')
         assert c.returncode == 0
-        assert 'WORLD\n' in c.stdout
+        assert 'WORLD' in c.stdout
 
 
 @pytest.mark.run
@@ -144,8 +144,8 @@ def test_pipenv_run_pip_freeze_has_expected_output(quiet, pipenv_instance_pypi):
     with pipenv_instance_pypi() as p:
         with open(p.pipfile_path, 'w') as f:
             contents = """
-    [packages]
-    requests = "==2.14.0"
+[packages]
+requests = "==2.14.0"
                 """.strip()
             f.write(contents)
         c = p.pipenv('install')
@@ -156,4 +156,4 @@ def test_pipenv_run_pip_freeze_has_expected_output(quiet, pipenv_instance_pypi):
         else:
             c = p.pipenv('run pip freeze')
         assert c.returncode == 0
-        assert 'requests==2.14.0\n' == c.stdout
+        assert 'requests==2.14.0' in c.stdout

--- a/tests/integration/test_sync.py
+++ b/tests/integration/test_sync.py
@@ -1,7 +1,5 @@
 import pytest
 
-from .conftest import DEFAULT_PRIVATE_PYPI_SERVER
-
 from pipenv.utils.shell import temp_environ
 
 
@@ -23,7 +21,7 @@ def test_sync_error_without_lockfile(pipenv_instance_pypi):
 @pytest.mark.lock
 def test_mirror_lock_sync(pipenv_instance_private_pypi):
     with temp_environ(), pipenv_instance_private_pypi() as p:
-        mirror_url = DEFAULT_PRIVATE_PYPI_SERVER
+        mirror_url = p.index_url
         assert 'pypi.org' not in mirror_url
         with open(p.pipfile_path, 'w') as f:
             f.write("""

--- a/tests/integration/test_uninstall.py
+++ b/tests/integration/test_uninstall.py
@@ -1,8 +1,5 @@
-import os
-
 import pytest
 
-from .conftest import DEFAULT_PRIVATE_PYPI_SERVER
 
 from pipenv.utils.shell import temp_environ
 
@@ -57,7 +54,7 @@ def test_uninstall_django(pipenv_instance_private_pypi):
 def test_mirror_uninstall(pipenv_instance_pypi):
     with temp_environ(), pipenv_instance_pypi() as p:
 
-        mirror_url = DEFAULT_PRIVATE_PYPI_SERVER
+        mirror_url = p.index_url
         assert "pypi.org" not in mirror_url
 
         c = p.pipenv(f"install Django --pypi-mirror {mirror_url}")

--- a/tests/integration/test_uninstall.py
+++ b/tests/integration/test_uninstall.py
@@ -1,5 +1,6 @@
 import pytest
 
+from .conftest import DEFAULT_PRIVATE_PYPI_SERVER
 
 from pipenv.utils.shell import temp_environ
 
@@ -54,7 +55,7 @@ def test_uninstall_django(pipenv_instance_private_pypi):
 def test_mirror_uninstall(pipenv_instance_pypi):
     with temp_environ(), pipenv_instance_pypi() as p:
 
-        mirror_url = p.index_url
+        mirror_url = DEFAULT_PRIVATE_PYPI_SERVER
         assert "pypi.org" not in mirror_url
 
         c = p.pipenv(f"install Django --pypi-mirror {mirror_url}")

--- a/tests/integration/test_update.py
+++ b/tests/integration/test_update.py
@@ -8,5 +8,4 @@ def test_update_outdated_with_outdated_package(pipenv_instance_private_pypi, cmd
         package_name = "six"
         p.pipenv(f"install {cmd_option} {package_name}==1.11")
         c = p.pipenv("update --outdated")
-        assert isinstance(c.exception, SystemExit)
-        assert f"Package '{package_name}' out-of-date:" in c.stdout_bytes.decode("utf-8")
+        assert f"Package '{package_name}' out-of-date:" in c.stdout

--- a/tests/integration/test_windows.py
+++ b/tests/integration/test_windows.py
@@ -13,7 +13,7 @@ pytestmark = pytest.mark.skipif(os.name != 'nt', reason="only relevant on window
 def test_case_changes_windows(pipenv_instance_pypi):
     """Test project matching for case changes on Windows.
     """
-    with pipenv_instance_pypi(chdir=True) as p:
+    with pipenv_instance_pypi() as p:
         c = p.pipenv('install pytz')
         assert c.returncode == 0
 
@@ -47,7 +47,7 @@ def test_local_path_windows(pipenv_instance_pypi):
         whl = whl.resolve()
     except OSError:
         whl = whl.absolute()
-    with pipenv_instance_pypi(chdir=True) as p:
+    with pipenv_instance_pypi() as p:
         c = p.pipenv(f'install "{whl}"')
         assert c.returncode == 0
 
@@ -63,14 +63,14 @@ def test_local_path_windows_forward_slash(pipenv_instance_pypi):
         whl = whl.resolve()
     except OSError:
         whl = whl.absolute()
-    with pipenv_instance_pypi(chdir=True) as p:
+    with pipenv_instance_pypi() as p:
         c = p.pipenv(f'install "{whl.as_posix()}"')
         assert c.returncode == 0
 
 
 @pytest.mark.cli
 def test_pipenv_clean_windows(pipenv_instance_pypi):
-    with pipenv_instance_pypi(chdir=True) as p:
+    with pipenv_instance_pypi() as p:
         c = p.pipenv('install dataclasses-json')
         assert c.returncode == 0
         c = p.pipenv(f'run pip install -i {p.index_url} click')

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -72,8 +72,8 @@ def test_convert_deps_to_pip(deps, expected):
 @pytest.mark.utils
 @pytest.mark.needs_internet
 def test_convert_deps_to_pip_star_specifier():
-    deps = {"six": "*"}
-    expected = "six"
+    deps = {"uvicorn": "*"}
+    expected = "uvicorn"
     assert dependencies.convert_deps_to_pip(deps) == [expected]
 
 


### PR DESCRIPTION
* Invoke the resolver in the same process as pipenv rather than utilizing subprocess.
* Restore accidentally commented out part of pip validations.
* Make a test case faster (fastapi is actually got a lot of dependencies).
* Spend several hours trying  to track down why the tests have random failures in parallelism:
** Completely trim down the conftest.py and remove uneeded arguments
** try to ensure the directory is totally unique for the test
** Realize that click's CliRunner is actually to blame and even says in the docs that its not thread safe.
** Convert away from using CliRunner (mostly) for some reason the `graph --reverse` test is a special beast with unicode characters and a sub-process in a sub-process, so just use CliRunner there only.
* Made a few edits to requirementslib but trying to keep that minimal as I intend to do more work there in other PRs.

### The issue

In thinking more about the issue that arose with the resolver using a different python version, and modules maybe being out of scope, I began to wonder why we were kicking it off as a subprocess.   This reduces the number of files we have to write and read back in as well as eliminate the sub-process that we simply were waiting for anyway.

### The checklist
* [X] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.
