### PR TITLE
Fix markers being included as None/null

### DIFF
--- a/news/5788.bugfix.rst
+++ b/news/5788.bugfix.rst
@@ -1,0 +1,1 @@
+Fix regression markers being included as None/null in requirements command.

--- a/pipenv/routines/requirements.py
+++ b/pipenv/routines/requirements.py
@@ -38,7 +38,9 @@ def requirements_from_deps(deps, include_hashes=True, include_markers=True):
             )
             markers = (
                 "; {}".format(package_info["markers"])
-                if include_markers and "markers" in package_info
+                if include_markers
+                and "markers" in package_info
+                and package_info["markers"]
                 else ""
             )
             extras = (


### PR DESCRIPTION
### The issue

Fixes #5786 

### The fix

use the empty string when the marker is None or null.

### The checklist

* [X] Associated issue
* [X] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.
