### PR TITLE
utils.toml: Handle tomlkit OutOfOrderTableProxy

### DIFF
--- a/news/5794.bugfix.rst
+++ b/news/5794.bugfix.rst
@@ -1,0 +1,1 @@
+Fix issue parsing some Pipfiles with separate packages.<pkg> sections (tomlkit OutOfOrderTableProxy)

--- a/pipenv/utils/toml.py
+++ b/pipenv/utils/toml.py
@@ -36,6 +36,8 @@ def convert_toml_outline_tables(parsed, project):
         result = section.copy()
         if isinstance(section, tomlkit.items.Table):
             body = section.value._body
+        elif isinstance(section, tomlkit.container.OutOfOrderTableProxy):
+            body = section._internal_container._body
         else:
             body = section._body
         for key, value in body:

--- a/tests/integration/test_install_basic.py
+++ b/tests/integration/test_install_basic.py
@@ -451,6 +451,39 @@ extras = ["socks"]
         assert 'colorama = "*"' in contents
 
 
+@pytest.mark.basic
+@pytest.mark.install
+def test_rewrite_outline_table_ooo(pipenv_instance_private_pypi):
+    with pipenv_instance_private_pypi() as p:
+        with open(p.pipfile_path, 'w') as f:
+            contents = """
+[[source]]
+url = "{}"
+verify_ssl = false
+name = "testindex"
+
+[packages]
+six = {}
+
+# Out-of-order
+[pipenv]
+allow_prereleases = false
+
+[packages.requests]
+version = "*"
+extras = ["socks"]
+            """.format(p.index_url, "{version = \"*\"}").strip()
+            f.write(contents)
+        c = p.pipenv("install colorama")
+        assert c.returncode == 0
+        with open(p.pipfile_path) as f:
+            contents = f.read()
+        assert "[packages.requests]" not in contents
+        assert 'six = {version = "*"}' in contents
+        assert 'requests = {version = "*"' in contents
+        assert 'colorama = "*"' in contents
+
+
 @pytest.mark.dev
 @pytest.mark.install
 def test_install_dev_use_default_constraints(pipenv_instance_private_pypi):


### PR DESCRIPTION
We get this when we have subtables that do not
directly follow their parent table.

Fixes: #5794

### The fix

I think this issue and the fix show that we're way too deep into the tomlkit internals. I think
in the long run it would be much better to try to use a higher level interface... But I really don't
have time to go that deep into the code to find out whether that is even feasible. So for now
the minimal fix.

### The checklist

* [X] Associated issue
* [x] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.
