### PR TITLE
Fix the version output

### DIFF
--- a/news/5838.bugfix.rst
+++ b/news/5838.bugfix.rst
@@ -1,0 +1,1 @@
+Fix the expected output of the ``version`` command.

--- a/pipenv/cli/command.py
+++ b/pipenv/cli/command.py
@@ -35,7 +35,7 @@ from pipenv.vendor.click import (
 )
 
 with console.capture() as capture:
-    console.print("[bold]pipenv[/bold]")
+    console.print("[bold]pipenv[/bold]", end="")
 
 prog_name = capture.get()
 


### PR DESCRIPTION
Before:
```
matteius@matteius-VirtualBox:~/pipenv$ pipenv --version
pipenv
, version 2023.8.19
```

After:
```
matteius@matteius-VirtualBox:~/pipenv$ pipenv --version
pipenv, version 2023.8.19
```


### The issue

We broke the benchmark run because unexpectedly the version output changed formats:. 
 https://github.com/lincolnloop/python-package-manager-shootout/actions/runs/5914571940/job/16040022277

### The checklist

* [X] Associated issue
* [ ] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.
