### PR TITLE
Do not include @ when no ref is specified

### DIFF
--- a/news/5843.bugfix.rst
+++ b/news/5843.bugfix.rst
@@ -1,0 +1,1 @@
+Fix some edge cases around vcs dependencies without a ref, and older Pipfile/lockfile formats.

--- a/pipenv/utils/dependencies.py
+++ b/pipenv/utils/dependencies.py
@@ -969,8 +969,13 @@ def install_req_from_pipfile(name, pipfile):
     vcs = next(iter([vcs for vcs in VCS_LIST if vcs in _pipfile]), None)
 
     if vcs:
-        _pipfile["vcs"] = vcs
-        req_str = f"{_pipfile[vcs]}{_pipfile.get('ref', '')}{extras_str}"
+        vcs_url = _pipfile[vcs]
+        fallback_ref = ""
+        if "@" in vcs_url:
+            vcs_url_parts = vcs_url.rsplit("@", 1)
+            vcs_url = vcs_url_parts[0]
+            fallback_ref = vcs_url_parts[1]
+        req_str = f"{vcs_url}{_pipfile.get('ref', fallback_ref)}{extras_str}"
         if not req_str.startswith(f"{vcs}+"):
             req_str = f"{vcs}+{req_str}"
         if f"{vcs}+file://" in req_str:

--- a/pipenv/utils/dependencies.py
+++ b/pipenv/utils/dependencies.py
@@ -959,14 +959,19 @@ def expansive_install_req_from_line(
 
 def install_req_from_pipfile(name, pipfile):
     _pipfile = {}
+    vcs = None
     if hasattr(pipfile, "keys"):
         _pipfile = dict(pipfile).copy()
+    else:
+        vcs = next(iter([vcs for vcs in VCS_LIST if pipfile.startswith(f"{vcs}+")]), None)
+        _pipfile[vcs] = pipfile
 
     extras = _pipfile.get("extras", [])
     extras_str = ""
     if extras:
         extras_str = f"[{','.join(extras)}]"
-    vcs = next(iter([vcs for vcs in VCS_LIST if vcs in _pipfile]), None)
+    if not vcs:
+        vcs = next(iter([vcs for vcs in VCS_LIST if vcs in _pipfile]), None)
 
     if vcs:
         vcs_url = _pipfile[vcs]

--- a/pipenv/utils/dependencies.py
+++ b/pipenv/utils/dependencies.py
@@ -964,7 +964,8 @@ def install_req_from_pipfile(name, pipfile):
         _pipfile = dict(pipfile).copy()
     else:
         vcs = next(iter([vcs for vcs in VCS_LIST if pipfile.startswith(f"{vcs}+")]), None)
-        _pipfile[vcs] = pipfile
+        if vcs is not None:
+            _pipfile[vcs] = pipfile
 
     extras = _pipfile.get("extras", [])
     extras_str = ""

--- a/pipenv/utils/requirements.py
+++ b/pipenv/utils/requirements.py
@@ -163,7 +163,7 @@ def requirement_from_lockfile(
             )
             include_vcs = "" if f"{vcs}+" in url else f"{vcs}+"
             egg_fragment = "" if "#egg=" in url else f"#egg={package_name}"
-            ref_str = "" if f"@{ref}" in url else f"@{ref}"
+            ref_str = "" if not ref or f"@{ref}" in url else f"@{ref}"
             if is_editable_path(url) or "file://" in url:
                 pip_line = f"-e {include_vcs}{url}{ref_str}{egg_fragment}{extras}"
             else:

--- a/pipenv/utils/requirements.py
+++ b/pipenv/utils/requirements.py
@@ -156,6 +156,12 @@ def requirement_from_lockfile(
         if vcs in package_info:
             url = package_info[vcs]
             ref = package_info.get("ref", "")
+            if "@" in url:
+                url_parts = url.rsplit("@", 1)
+                url = url_parts[0]
+                if not ref:
+                    ref = url_parts[1]
+
             extras = (
                 "[{}]".format(",".join(package_info.get("extras", [])))
                 if "extras" in package_info


### PR DESCRIPTION
Solves some edge cases:
* vcs sub-requirement has no ref
* old Pipfile or Pipfile.lock that contains a ref in the vcs url.

### The issue

Fixes #5843 
Fixes #5846


### The checklist

* [X] Associated issue
* [ ] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.
