### PR TITLE
Handle edge case where it is expected ssh:// urls to have at least one @ symbol

### DIFF
--- a/news/5846.bugfix.rst
+++ b/news/5846.bugfix.rst
@@ -1,0 +1,1 @@
+Fix regression with ``ssh://`` vcs URLs introduced in ``2023.8.21`` whereby ssh vcs URLs are expected to have at least one ``@`` symbol.

--- a/pipenv/utils/dependencies.py
+++ b/pipenv/utils/dependencies.py
@@ -977,7 +977,9 @@ def install_req_from_pipfile(name, pipfile):
     if vcs:
         vcs_url = _pipfile[vcs]
         fallback_ref = ""
-        if "@" in vcs_url:
+        if ("ssh://" in vcs_url and vcs_url.count("@") >= 2) or (
+            "ssh://" not in vcs_url and "@" in vcs_url
+        ):
             vcs_url_parts = vcs_url.rsplit("@", 1)
             vcs_url = vcs_url_parts[0]
             fallback_ref = vcs_url_parts[1]

--- a/pipenv/utils/requirements.py
+++ b/pipenv/utils/requirements.py
@@ -156,7 +156,9 @@ def requirement_from_lockfile(
         if vcs in package_info:
             url = package_info[vcs]
             ref = package_info.get("ref", "")
-            if "@" in url:
+            if ("ssh://" in url and url.count("@") >= 2) or (
+                "ssh://" not in url and "@" in url
+            ):
                 url_parts = url.rsplit("@", 1)
                 url = url_parts[0]
                 if not ref:


### PR DESCRIPTION
Handle edge case where it is expected ssh:// urls to have at least one @ symbol

### The issue

Fixes Issue #5849 

### The fix

I think ssh:// urls require at least one @ and so checking for 2 or more in this case should be sufficient.

### The checklist

* [X] Associated issue
* [X] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.
