### PR TITLE
Update install.py

### DIFF
--- a/pipenv/routines/install.py
+++ b/pipenv/routines/install.py
@@ -147,7 +147,7 @@ def do_install(
             traceback = e
         finally:
             if error and traceback:
-                console.print(error, sytle="red")
+                console.print(error, style="red")
                 err.print(str(traceback), style="yellow")
                 sys.exit(1)
 


### PR DESCRIPTION
### The issue
Suspect there is a typo in install.py where a typo has made `style` into `sytle`

>  File "/Users/mathias/Library/Python/3.9/lib/python/site-packages/pipenv/routines/install.py", line 148, in do_install
    console.print(error, sytle="red")
TypeError: print() got an unexpected keyword argument 'sytle'

### The fix

refactor


### The checklist

* [x] Associated issue
* [x] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.


