### PR TITLE
Try to match if the part after @ is a valid ref (reject treating URL parts as refs).

### DIFF
--- a/news/5849.bugfix.rst
+++ b/news/5849.bugfix.rst
@@ -1,0 +1,1 @@
+More gracefully handle @ symbols in vcs URLs to address recent regression with vcs URLs.

--- a/pipenv/utils/dependencies.py
+++ b/pipenv/utils/dependencies.py
@@ -981,8 +981,9 @@ def install_req_from_pipfile(name, pipfile):
             "ssh://" not in vcs_url and "@" in vcs_url
         ):
             vcs_url_parts = vcs_url.rsplit("@", 1)
-            vcs_url = vcs_url_parts[0]
-            fallback_ref = vcs_url_parts[1]
+            if re.match(r"^[\w\.]+$", vcs_url_parts[1]):
+                vcs_url = vcs_url_parts[0]
+                fallback_ref = vcs_url_parts[1]
         req_str = f"{vcs_url}@{_pipfile.get('ref', fallback_ref)}{extras_str}"
         if not req_str.startswith(f"{vcs}+"):
             req_str = f"{vcs}+{req_str}"

--- a/pipenv/utils/requirements.py
+++ b/pipenv/utils/requirements.py
@@ -160,9 +160,11 @@ def requirement_from_lockfile(
                 "ssh://" not in url and "@" in url
             ):
                 url_parts = url.rsplit("@", 1)
-                url = url_parts[0]
-                if not ref:
-                    ref = url_parts[1]
+                # Check if the second part matches the criteria to be a ref (vcs URLs would likely have a /)
+                if re.match(r"^[\w\.]+$", url_parts[1]):
+                    url = url_parts[0]
+                    if not ref:
+                        ref = url_parts[1]
 
             extras = (
                 "[{}]".format(",".join(package_info.get("extras", [])))


### PR DESCRIPTION
Try fixing the other part of #5849 

### The issue

Sometimes VCS urls have an @ symbol for netloc auth component, try to differentiate if its a valid ref.

### The checklist

* [X] Associated issue
* [ ] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.
