### PR TITLE
Caching properties to deduplicate sources

### DIFF
--- a/pipenv/resolver.py
+++ b/pipenv/resolver.py
@@ -40,7 +40,6 @@ def get_parser():
         action="store",
         default=None,
     )
-    parser.add_argument("--debug", action="store_true", default=False)
     parser.add_argument("--system", action="store_true", default=False)
     parser.add_argument("--parse-only", action="store_true", default=False)
     parser.add_argument(

--- a/pipenv/utils/resolver.py
+++ b/pipenv/utils/resolver.py
@@ -266,7 +266,7 @@ class Resolver:
         pip_args.extend(["--cache-dir", self.project.s.PIPENV_CACHE_DIR])
         return pip_args
 
-    @property
+    @cached_property
     def pip_args(self):
         use_pep517 = environments.get_from_env("USE_PEP517", prefix="PIP")
         build_isolation = environments.get_from_env("BUILD_ISOLATION", prefix="PIP")
@@ -298,7 +298,7 @@ class Resolver:
         )
         return default_constraint_filename
 
-    @property
+    @cached_property
     def pip_options(self):
         pip_options, _ = self.pip_command.parser.parse_args(self.pip_args)
         pip_options.cache_dir = self.project.s.PIPENV_CACHE_DIR


### PR DESCRIPTION
Without caching, the Resolver duplicates the sources listed in the `Pipfile` multiple times (since the property re-adds them every time they're called) in the arguments sent to the `pip` parser.

Removing unused command-line option `--debug`

Thank you for contributing to Pipenv!


### The issue

While diagnosing another issue, I found through `print` debugging that the multiple calls to these properties, `pip_args` and `pip_options`, ended up duplicating the sources listed in the `Pipfile` multiple times for the `pip` parser.

Related to the resolver, the `--debug` command-line option for `pipenv-resolver` is unused.

### The fix

To fix this, I replaced `property` decorator with `cached_property`, which was already imported in the module. As best as I can tell, these properties (and a number of other ones) only need to be evaluated once instead of every single time they are called. Caching not only fixes this duplication but will also lead to faster, more efficient code.

If a debug option is later implemented, the command-line option can be added at that time.

### The checklist

* [ ] Associated issue
* [x] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.