### PR TITLE
Adjust the Fallback logic for obtaining the hashes from private indexes

### DIFF
--- a/news/5866.bugfix.rst
+++ b/news/5866.bugfix.rst
@@ -1,0 +1,1 @@
+Fix regression of hash collection when downloading package from private indexes when the hash is not found in the index href url fragment.

--- a/pipenv/project.py
+++ b/pipenv/project.py
@@ -12,7 +12,7 @@ import urllib.parse
 from json.decoder import JSONDecodeError
 from pathlib import Path
 from urllib import parse
-from urllib.parse import unquote
+from urllib.parse import unquote, urljoin
 
 from pipenv.utils.constants import VCS_LIST
 
@@ -315,8 +315,7 @@ class Project:
                     if params_dict.get(FAVORITE_HASH):
                         collected_hashes.add(params_dict[FAVORITE_HASH][0])
                     else:  # Fallback to downloading the file to obtain hash
-                        if source["url"] not in package_url:
-                            package_url = f"{source['url']}{package_url}"
+                        package_url = urljoin(source["url"], package_url)
                         link = Link(package_url)
                         collected_hashes.add(self.get_file_hash(session, link))
             return self.prepend_hash_types(collected_hashes, FAVORITE_HASH)

--- a/pipenv/project.py
+++ b/pipenv/project.py
@@ -240,7 +240,9 @@ class Project:
             session = self.sessions[source["name"]]
         else:
             session = get_requests_session(
-                self.s.PIPENV_MAX_RETRIES, source.get("verify_ssl", True)
+                self.s.PIPENV_MAX_RETRIES,
+                source.get("verify_ssl", True),
+                cache_dir=self.s.PIPENV_CACHE_DIR,
             )
             self.sessions[source["name"]] = session
         return session

--- a/pipenv/project.py
+++ b/pipenv/project.py
@@ -317,7 +317,9 @@ class Project:
                     else:  # Fallback to downloading the file to obtain hash
                         package_url = urljoin(source["url"], package_url)
                         link = Link(package_url)
-                        collected_hashes.add(self.get_file_hash(session, link))
+                        file_hash = self.get_file_hash(session, link)
+                        if file_hash:
+                            collected_hashes.add(file_hash)
             return self.prepend_hash_types(collected_hashes, FAVORITE_HASH)
         except (ValueError, KeyError, ConnectionError):
             if self.s.is_verbose():
@@ -333,6 +335,8 @@ class Project:
         h = hashlib.new(FAVORITE_HASH)
         err.print(f"Downloading file {link.filename} to obtain hash...")
         with open_file(link.url, session) as fp:
+            if fp is None:
+                return None
             for chunk in iter(lambda: fp.read(8096), b""):
                 h.update(chunk)
         return f"{h.name}:{h.hexdigest()}"

--- a/pipenv/utils/fileutils.py
+++ b/pipenv/utils/fileutils.py
@@ -13,6 +13,7 @@ from urllib.parse import quote, urlparse
 
 from pipenv.patched.pip._internal.vcs import RemoteNotFoundError
 from pipenv.patched.pip._vendor.requests import Session
+from pipenv.utils import err
 
 _T = TypeVar("_T")
 
@@ -131,7 +132,11 @@ def open_file(
         try:
             link = link.url_without_fragment
         except AttributeError:
-            raise ValueError(f"Cannot parse url from unknown type: {link!r}")
+            err.print(
+                f"Cannot parse url from unknown type: {link!r}; Skipping ...",
+                style="bold red",
+            )
+            return None
 
     if not is_valid_url(link) and os.path.exists(link):
         link = path_to_url(link)

--- a/pipenv/utils/fileutils.py
+++ b/pipenv/utils/fileutils.py
@@ -12,7 +12,8 @@ from urllib import parse as urllib_parse
 from urllib import request as urllib_request
 from urllib.parse import quote, urlparse
 
-from pipenv.patched.pip._vendor.requests import Session
+from pipenv.patched.pip._internal.locations import USER_CACHE_DIR
+from pipenv.patched.pip._internal.network.download import PipSession
 from pipenv.utils import err
 
 
@@ -114,12 +115,12 @@ def path_to_url(path):
 
 
 @contextmanager
-def open_file(link, session: Optional[Session] = None, stream: bool = True):
+def open_file(link, session: Optional[PipSession] = None, stream: bool = False):
     """Open local or remote file for reading.
 
     :param pipenv.patched.pip._internal.index.Link link: A link object from resolving dependencies with
         pip, or else a URL.
-    :param Optional[Session] session: A :class:`~requests.Session` instance
+    :param Optional[PipSession] session: A :class:`~PipSession` instance
     :param bool stream: Whether to stream the content if remote, default True
     :raises ValueError: If link points to a local directory.
     :return: a context manager to the opened file-like object
@@ -145,7 +146,7 @@ def open_file(link, session: Optional[Session] = None, stream: bool = True):
         # Remote URL
         headers = {"Accept-Encoding": "identity"}
         if not session:
-            session = Session()
+            session = PipSession(cache=USER_CACHE_DIR)
         resp = session.get(link, headers=headers, stream=stream)
         if resp.status_code != 200:
             err.print(f"HTTP error {resp.status_code} while getting {link}")

--- a/pipenv/utils/fileutils.py
+++ b/pipenv/utils/fileutils.py
@@ -117,7 +117,12 @@ def path_to_url(path):
 def open_file(link, session: Optional[Session] = None, stream: bool = True):
     """Open local or remote file for reading.
 
-    Other details...
+    :param pipenv.patched.pip._internal.index.Link link: A link object from resolving dependencies with
+        pip, or else a URL.
+    :param Optional[Session] session: A :class:`~requests.Session` instance
+    :param bool stream: Whether to stream the content if remote, default True
+    :raises ValueError: If link points to a local directory.
+    :return: a context manager to the opened file-like object
     """
     if not isinstance(link, str):
         try:

--- a/pipenv/utils/internet.py
+++ b/pipenv/utils/internet.py
@@ -3,19 +3,17 @@ import re
 from html.parser import HTMLParser
 from urllib.parse import urlparse
 
-from pipenv.patched.pip._vendor import requests
-from pipenv.patched.pip._vendor.requests.adapters import HTTPAdapter
+from pipenv.patched.pip._internal.locations import USER_CACHE_DIR
+from pipenv.patched.pip._internal.network.download import PipSession
 from pipenv.patched.pip._vendor.urllib3 import util as urllib3_util
 
 
-def get_requests_session(max_retries=1, verify_ssl=True):
+def get_requests_session(max_retries=1, verify_ssl=True, cache_dir=USER_CACHE_DIR):
     """Load requests lazily."""
     pip_client_cert = os.environ.get("PIP_CLIENT_CERT")
-    requests_session = requests.Session()
+    requests_session = PipSession(cache=cache_dir, retries=max_retries)
     if pip_client_cert:
         requests_session.cert = pip_client_cert
-    adapter = HTTPAdapter(max_retries=max_retries)
-    requests_session.mount("https://", adapter)
     if verify_ssl is False:
         requests_session.verify = False
     return requests_session

--- a/tasks/vendoring/__init__.py
+++ b/tasks/vendoring/__init__.py
@@ -795,4 +795,7 @@ def vendor_artifact(ctx, package, version=None):
         dest_file = dest_dir / dest_path
         with open(dest_file.as_posix(), "wb") as target_handle:
             with open_file(link) as fp:
+                if fp is None:
+                    print(f"Error downloading {link}")
+                    continue
                 shutil.copyfileobj(fp, target_handle)


### PR DESCRIPTION
The else Fallback here is not working right, for example if my source url is: url = "https://download.pytorch.org/whl/cu117" and the page contains url's like: /whl/cu117/torch-2.0.1%2Bcu117-cp310-cp310-linux_x86_64.whl So the url that gets generated is: https://download.pytorch.org/whl/cu117/whl/cu117/torch-2.0.1%2Bcu117-cp310-cp310-linux_x86_64.whl which is wrong because it repeats /whl/cu117/


### The issue

Fixes #5864
Fixes #5860
Maybe Fixes #5848

### The fix

Use urllib.parse urljoin which will intelligently handle this case:

```
Downloading file torch-2.0.1+cu117-cp310-cp310-linux_x86_64.whl to obtain
hash...
Downloading file torch-2.0.1+cu117-cp310-cp310-win_amd64.whl to obtain hash...
Downloading file torch-2.0.1+cu117-cp311-cp311-linux_x86_64.whl to obtain
hash...
Downloading file torch-2.0.1+cu117-cp311-cp311-win_amd64.whl to obtain hash...
Downloading file torch-2.0.1+cu117-cp38-cp38-linux_x86_64.whl to obtain hash...
Downloading file torch-2.0.1+cu117-cp38-cp38-win_amd64.whl to obtain hash...
Downloading file torch-2.0.1+cu117-cp39-cp39-linux_x86_64.whl to obtain hash...
Downloading file torch-2.0.1+cu117-cp39-cp39-win_amd64.whl to obtain hash...
```

Install:
```
Writing supplied requirement line to temporary file: 'torch==2.0.1+cu117 --hash=sha256:0a56cf5d99f1c7fa29c328a6737c5e5108fa71d8f021c074f4ff0de9e8969302
--hash=sha256:245d04e1541350dba11c7b76e343ca0071bbcb10f956a09b6bede3d68db9e759 --hash=sha256:60b21e8db98f7365758a5c218f5dc533d84f046ed0876b4540ba5ba7ef6797d4
--hash=sha256:a77ba4f4b13c8b6c2c863b84a98dde2ddf1feaad5f25700d41cf3236e11d2ee8 --hash=sha256:bb54b705185bea820e6ec6485a25761bc03f689e1a09a37d814d6ea8e276b5bd
--hash=sha256:bec39e6fe7232f399c6a5cda5785517fec759fc0852e0c31d71a39f7bf6b23b3 --hash=sha256:deed82674691238ff9471fb7dd13a6eafc0c394cb6cdb249b483b4855c00276f
--hash=sha256:e06deb28938e7468bdd79ad5a4cfda36e95113507a9144a367039b35ac73986c'
Install Phase: Standard Requirements
Preparing Installation of 'torch==2.0.1+cu117 --hash=sha256:0a56cf5d99f1c7fa29c328a6737c5e5108fa71d8f021c074f4ff0de9e8969302 --hash=sha256:245d04e1541350dba11c7b76e343ca0071bbcb10f956a09b6bede3d68db9e759
--hash=sha256:60b21e8db98f7365758a5c218f5dc533d84f046ed0876b4540ba5ba7ef6797d4 --hash=sha256:a77ba4f4b13c8b6c2c863b84a98dde2ddf1feaad5f25700d41cf3236e11d2ee8
--hash=sha256:bb54b705185bea820e6ec6485a25761bc03f689e1a09a37d814d6ea8e276b5bd --hash=sha256:bec39e6fe7232f399c6a5cda5785517fec759fc0852e0c31d71a39f7bf6b23b3
--hash=sha256:deed82674691238ff9471fb7dd13a6eafc0c394cb6cdb249b483b4855c00276f --hash=sha256:e06deb28938e7468bdd79ad5a4cfda36e95113507a9144a367039b35ac73986c'
$ C:/c/Users/matte/.virtualenvs/pytorch_new-7A-x71qg/Scripts/python.exe 'C:\Users\matte\Projects\pipenv\pipenv\patched\pip\__pip-runner__.py' install -i https://download.pytorch.org/whl/cu117 --no-input
--upgrade --no-deps -r 'c:\users\matte\appdata\local\temp\pipenv-6a7209oi-requirements\pipenv-8x7x43h8-hashed-reqs.txt'
Using source directory: 'C:\\c\\Users\\matte\\.virtualenvs\\pytorch_new-7A-x71qg\\src'
Looking in indexes: https://download.pytorch.org/whl/cu117

Collecting torch==2.0.1+cu117 (from -r c:\users\matte\appdata\local\temp\pipenv-6a7209oi-requirements\pipenv-8x7x43h8-hashed-reqs.txt (line 1))

  Using cached https://download.pytorch.org/whl/cu117/torch-2.0.1%2Bcu117-cp311-cp311-win_amd64.whl (2343.6 MB)

Installing collected packages: torch

Successfully installed torch-2.0.1+cu117
```

I've also added better error handling for this case to avoid capturing a hash if the response is not 200.   When I undo the fix, that looks like:
```
[  ==] Locking...Downloading file torch-2.0.1+cu117-cp310-cp310-linux_x86_64.whl to obtain hash...
[   =] Locking...HTTP error 403 while getting https://download.pytorch.org/whl/cu117/whl/cu117/torch-2.0.1%2Bcu117-cp310-cp310-linux_x86_64.whl
Downloading file torch-2.0.1+cu117-cp310-cp310-win_amd64.whl to obtain hash...
[  ==] Locking...HTTP error 403 while getting https://download.pytorch.org/whl/cu117/whl/cu117/torch-2.0.1%2Bcu117-cp310-cp310-win_amd64.whl
Downloading file torch-2.0.1+cu117-cp311-cp311-linux_x86_64.whl to obtain hash...
[==  ] Locking...HTTP error 403 while getting https://download.pytorch.org/whl/cu117/whl/cu117/torch-2.0.1%2Bcu117-cp311-cp311-linux_x86_64.whl
Downloading file torch-2.0.1+cu117-cp311-cp311-win_amd64.whl to obtain hash...
[=   ] Locking...HTTP error 403 while getting https://download.pytorch.org/whl/cu117/whl/cu117/torch-2.0.1%2Bcu117-cp311-cp311-win_amd64.whl
Downloading file torch-2.0.1+cu117-cp38-cp38-linux_x86_64.whl to obtain hash...
[ ===] Locking...HTTP error 403 while getting https://download.pytorch.org/whl/cu117/whl/cu117/torch-2.0.1%2Bcu117-cp38-cp38-linux_x86_64.whl
Downloading file torch-2.0.1+cu117-cp38-cp38-win_amd64.whl to obtain hash...
[   =] Locking...HTTP error 403 while getting https://download.pytorch.org/whl/cu117/whl/cu117/torch-2.0.1%2Bcu117-cp38-cp38-win_amd64.whl
Downloading file torch-2.0.1+cu117-cp39-cp39-linux_x86_64.whl to obtain hash...
[  ==] Locking...HTTP error 403 while getting https://download.pytorch.org/whl/cu117/whl/cu117/torch-2.0.1%2Bcu117-cp39-cp39-linux_x86_64.whl
Downloading file torch-2.0.1+cu117-cp39-cp39-win_amd64.whl to obtain hash...
[====] Locking...HTTP error 403 while getting https://download.pytorch.org/whl/cu117/whl/cu117/torch-2.0.1%2Bcu117-cp39-cp39-win_amd64.whl
[==  ] Locking...Downloading file torch-2.0.1+cu117-cp311-cp311-win_amd64.whl to obtain hash...
```

Latest Update is I got caching to work -- so if you download the expensive pytorch wheels in one lock phase, the subsequent lock phase is much faster!  🎉 
![image](https://github.com/pypa/pipenv/assets/479892/521feac0-3a22-4679-8599-695abdae73a5)


### The checklist

* [X] Associated issue
* [X] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.
