### PR TITLE
pre-commit autoupdate 2023-08-25

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,13 +18,13 @@ repos:
     exclude: .patch
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.0.275
+  rev: v0.0.285
   hooks:
   - id: ruff
     args: [--fix, --exit-non-zero-on-fix]
 
 - repo: https://github.com/psf/black
-  rev: 23.3.0
+  rev: 23.7.0
   hooks:
   - id: black
 
@@ -53,6 +53,6 @@ repos:
     stages: [manual]
 
 - repo: https://github.com/abravalheri/validate-pyproject
-  rev: v0.13
+  rev: v0.14
   hooks:
   - id: validate-pyproject


### PR DESCRIPTION
% `pre-commit autoupdate`
```
[https://github.com/pre-commit/pre-commit-hooks] already up to date!
[https://github.com/astral-sh/ruff-pre-commit] updating v0.0.275 -> v0.0.285
[https://github.com/psf/black] updating 23.3.0 -> 23.7.0
[https://github.com/pre-commit/pygrep-hooks] already up to date!
[https://github.com/mgedmin/check-manifest] already up to date!
[https://github.com/abravalheri/validate-pyproject] updating v0.13 -> v0.14
```
% `pre-commit run --all-files`