### PR TITLE
Attempt to fix the local/editable file installs

### DIFF
--- a/pipenv/project.py
+++ b/pipenv/project.py
@@ -333,7 +333,8 @@ class Project:
                 )
             return None
 
-    def get_file_hash(self, session, link):
+    @staticmethod
+    def get_file_hash(session, link):
         h = hashlib.new(FAVORITE_HASH)
         err.print(f"Downloading file {link.filename} to obtain hash...")
         with open_file(link.url, session) as fp:
@@ -1126,7 +1127,7 @@ class Project:
         if extras:
             entry["extras"] = list(extras)
         if path_specifier:
-            entry["file"] = unquote(path_specifier)
+            entry["file"] = unquote(str(path_specifier))
         elif vcs_specifier:
             for vcs in VCS_LIST:
                 if vcs in package.link.scheme:

--- a/pipenv/utils/funktools.py
+++ b/pipenv/utils/funktools.py
@@ -9,7 +9,7 @@ import subprocess
 import time
 import warnings
 from functools import partial
-from itertools import count, islice, tee
+from itertools import count, islice
 from typing import Any, Iterable
 
 DIRECTORY_CLEANUP_TIMEOUT = 1.0
@@ -62,19 +62,13 @@ def unnest(elem: Iterable) -> Any:
     """
 
     if isinstance(elem, Iterable) and not isinstance(elem, str):
-        elem, target = tee(elem, 2)
-    else:
-        target = elem
-    if not target or not _is_iterable(target):
-        yield target
-    else:
-        for el in target:
+        for el in elem:
             if isinstance(el, Iterable) and not isinstance(el, str):
-                el, el_copy = tee(el, 2)
-                for sub in unnest(el_copy):
-                    yield sub
+                yield from unnest(el)
             else:
                 yield el
+    else:
+        yield elem
 
 
 def dedup(iterable: Iterable) -> Iterable:

--- a/tests/integration/test_install_uri.py
+++ b/tests/integration/test_install_uri.py
@@ -187,7 +187,7 @@ def test_install_local_vcs_not_in_lockfile(pipenv_instance_pypi):
 def test_get_vcs_refs(pipenv_instance_private_pypi):
     with pipenv_instance_private_pypi() as p:
         c = p.pipenv(
-            "install -e git+https://github.com/benjaminp/six.git@1.9.0"
+            "install -e git+https://github.com/benjaminp/six.git@1.9.0#egg=six"
         )
         assert c.returncode == 0
         assert "six" in p.pipfile["packages"]


### PR DESCRIPTION
Attempt to fix the local/editable file installs which broke when we refactored away from requirementslib.

### The issue

Fixes (??) Issue #5858

### The fix

How does this pull request fix your problem? Did you consider any alternatives? Why is this the *best* solution, in your opinion?


### The checklist

* [ ] Associated issue
* [ ] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

<!--
### If this is a patch to the `vendor` directory...

Please try to refrain from submitting patches directly to `vendor` or `patched`, but raise your issue to the upstream project instead, and inform Pipenv to upgrade when the upstream project accepts the fix.

A pull request to upgrade vendor packages is strongly discouraged, unless there is a very good reason (e.g. you need to test Pipenv’s integration to a new vendor feature). Pipenv audits and performs vendor upgrades regularly, generally before a new release is about to drop.

If your patch is not or cannot be accepted by upstream, but is essential to Pipenv (make sure to discuss this with maintainers!), please remember to attach a patch file in `tasks/vendoring/patched`, so this divergence from upstream can be recorded and replayed afterwards.
-->
