### PR TITLE
Fix usage of format_help

### DIFF
--- a/news/5872.bugfix.rst
+++ b/news/5872.bugfix.rst
@@ -1,0 +1,1 @@
+Fix regression that caused printing non-printable ascii characters  when help was called.

--- a/pipenv/cli/command.py
+++ b/pipenv/cli/command.py
@@ -189,7 +189,7 @@ def cli(
     # Check this again before exiting for empty ``pipenv`` command.
     elif ctx.invoked_subcommand is None:
         # Display help to user, if no commands were passed.
-        console.print(format_help(ctx.get_help()))
+        print(format_help(ctx.get_help()))
 
 
 @cli.command(

--- a/pipenv/utils/funktools.py
+++ b/pipenv/utils/funktools.py
@@ -71,8 +71,7 @@ def unnest(elem: Iterable) -> Any:
         for el in target:
             if isinstance(el, Iterable) and not isinstance(el, str):
                 el, el_copy = tee(el, 2)
-                for sub in unnest(el_copy):
-                    yield sub
+                yield from unnest(el_copy)
             else:
                 yield el
 


### PR DESCRIPTION
Fix how format_help is used.
Because it uses `click.echo` color strings, one should not use `console.print`.

Fix #5869 
Fix #5850