### PR TITLE
Revert change that caused the credentials in source url issue

### DIFF
--- a/news/5878.bugfix.rst
+++ b/news/5878.bugfix.rst
@@ -1,0 +1,1 @@
+Revert change that caused the credentials in source url issue.

--- a/pipenv/utils/resolver.py
+++ b/pipenv/utils/resolver.py
@@ -266,7 +266,7 @@ class Resolver:
         pip_args.extend(["--cache-dir", self.project.s.PIPENV_CACHE_DIR])
         return pip_args
 
-    @property
+    @cached_property
     def pip_args(self):
         use_pep517 = environments.get_from_env("USE_PEP517", prefix="PIP")
         build_isolation = environments.get_from_env("BUILD_ISOLATION", prefix="PIP")
@@ -298,7 +298,7 @@ class Resolver:
         )
         return default_constraint_filename
 
-    @cached_property
+    @property
     def pip_options(self):
         pip_options, _ = self.pip_command.parser.parse_args(self.pip_args)
         pip_options.cache_dir = self.project.s.PIPENV_CACHE_DIR

--- a/pipenv/utils/resolver.py
+++ b/pipenv/utils/resolver.py
@@ -266,7 +266,7 @@ class Resolver:
         pip_args.extend(["--cache-dir", self.project.s.PIPENV_CACHE_DIR])
         return pip_args
 
-    @property
+    @property  # cached_property breaks authenticated private indexes
     def pip_args(self):
         use_pep517 = environments.get_from_env("USE_PEP517", prefix="PIP")
         build_isolation = environments.get_from_env("BUILD_ISOLATION", prefix="PIP")
@@ -298,7 +298,7 @@ class Resolver:
         )
         return default_constraint_filename
 
-    @property
+    @property  # cached_property breaks authenticated private indexes
     def pip_options(self):
         pip_options, _ = self.pip_command.parser.parse_args(self.pip_args)
         pip_options.cache_dir = self.project.s.PIPENV_CACHE_DIR

--- a/pipenv/utils/resolver.py
+++ b/pipenv/utils/resolver.py
@@ -266,7 +266,7 @@ class Resolver:
         pip_args.extend(["--cache-dir", self.project.s.PIPENV_CACHE_DIR])
         return pip_args
 
-    @cached_property
+    @property
     def pip_args(self):
         use_pep517 = environments.get_from_env("USE_PEP517", prefix="PIP")
         build_isolation = environments.get_from_env("BUILD_ISOLATION", prefix="PIP")


### PR DESCRIPTION
Thank you for contributing to Pipenv!


### The issue

Fixes #5878 
Fixes #5880 

### The fix

Reverts the change that is believed to have caused this per https://github.com/pypa/pipenv/issues/5878#issuecomment-1695759815


### The checklist

* [X] Associated issue
* [X] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.
