### PR TITLE
Assorted local editable file file fixes

### DIFF
--- a/news/5885.bugfix.rst
+++ b/news/5885.bugfix.rst
@@ -1,1 +1,2 @@
 Do not treat named requirements as file installs just becacuse a match path exists; better handling of editable keyword for local file installs.
+Handle additional edge cases in the setup.py ast parser logic for trying to determine local install package name.

--- a/news/5885.bugfix.rst
+++ b/news/5885.bugfix.rst
@@ -1,0 +1,1 @@
+Do not treat named requirements as file installs just becacuse a match path exists; better handling of editable keyword for local file installs.

--- a/pipenv/project.py
+++ b/pipenv/project.py
@@ -1128,6 +1128,8 @@ class Project:
             entry["extras"] = list(extras)
         if path_specifier:
             entry["file"] = unquote(str(path_specifier))
+            if pip_line.startswith("-e"):
+                entry["editable"] = True
         elif vcs_specifier:
             for vcs in VCS_LIST:
                 if vcs in package.link.scheme:

--- a/pipenv/utils/constants.py
+++ b/pipenv/utils/constants.py
@@ -36,6 +36,8 @@ RELEVANT_PROJECT_FILES = (
     "pyproject.toml",
 )
 
+INSTALLABLE_EXTENSIONS = (".whl", ".zip", ".tar", ".tar.gz", ".tgz")
+
 
 def is_type_checking():
     try:

--- a/pipenv/utils/dependencies.py
+++ b/pipenv/utils/dependencies.py
@@ -364,16 +364,8 @@ def is_pinned_requirement(ireq):
 
 
 def is_editable_path(path):
-    not_editable = INSTALLABLE_EXTENSIONS
-    if os.path.isfile(path):
-        return False
     if os.path.isdir(path):
         return True
-    if os.path.splitext(path)[1] in not_editable:
-        return False
-    for ext in not_editable:
-        if path.endswith(ext):
-            return False
     return False
 
 

--- a/pipenv/utils/dependencies.py
+++ b/pipenv/utils/dependencies.py
@@ -888,19 +888,14 @@ def expansive_install_req_from_line(
         for logging purposes in case of an error.
     """
     name = name.strip("'")
-    editable = False
-    if name.startswith("-e "):
-        # Editable requirement
-        editable = True
+    if name.startswith("-e "):  # Editable requirements
         name = name.split("-e ")[1]
+        return install_req_from_editable(name, line_source)
     if has_name_with_extras(name):
         name = name.split(" @ ", 1)[1]
 
     if expand_env:
         name = expand_env_variables(name)
-
-    if editable or os.path.isdir(name):
-        return install_req_from_editable(name, line_source)
 
     vcs_part = name
     if "@ " in name:  # Check for new style vcs lines
@@ -919,7 +914,7 @@ def expansive_install_req_from_line(
                 constraint=constraint,
                 user_supplied=user_supplied,
             )
-    if urlparse(name).scheme in ("http", "https", "file") or os.path.isfile(name):
+    if urlparse(name).scheme in ("http", "https", "file"):
         parts = parse_req_from_line(name, line_source)
     else:
         # It's a requirement

--- a/pipenv/utils/dependencies.py
+++ b/pipenv/utils/dependencies.py
@@ -40,6 +40,7 @@ from pipenv.utils.requirementslib import (
 )
 
 from .constants import (
+    INSTALLABLE_EXTENSIONS,
     RELEVANT_PROJECT_FILES,
     REMOTE_SCHEMES,
     SCHEME_LIST,
@@ -363,7 +364,7 @@ def is_pinned_requirement(ireq):
 
 
 def is_editable_path(path):
-    not_editable = [".whl", ".zip", ".tar", ".tar.gz", ".tgz"]
+    not_editable = INSTALLABLE_EXTENSIONS
     if os.path.isfile(path):
         return False
     if os.path.isdir(path):
@@ -743,7 +744,9 @@ def determine_package_name(package: InstallRequirement):
             ".zip"
         ):
             req_name = find_package_name_from_zipfile(package.link.file_path)
-        elif package.link.file_path.endswith(".tar.gz"):
+        elif package.link.file_path.endswith(
+            ".tar.gz"
+        ) or package.link.file_path.endswith(".tar.bz2"):
             req_name = find_package_name_from_tarball(package.link.file_path)
         else:
             req_name = find_package_name_from_directory(package.link.file_path)
@@ -923,7 +926,9 @@ def expansive_install_req_from_line(
                 constraint=constraint,
                 user_supplied=user_supplied,
             )
-    if urlparse(name).scheme in ("http", "https", "file"):
+    if urlparse(name).scheme in ("http", "https", "file") or any(
+        name.endswith(s) for s in INSTALLABLE_EXTENSIONS
+    ):
         parts = parse_req_from_line(name, line_source)
     else:
         # It's a requirement

--- a/pipenv/utils/locking.py
+++ b/pipenv/utils/locking.py
@@ -91,12 +91,14 @@ def format_requirement_for_lockfile(
         entry["extras"] = sorted(req.extras)
     if isinstance(pipfile_entry, dict) and pipfile_entry.get("file"):
         entry["file"] = pipfile_entry["file"]
-        entry["editable"] = True
+        if pipfile_entry.get("editable"):
+            entry["editable"] = pipfile_entry.get("editable")
         entry.pop("version", None)
         entry.pop("index", None)
     elif isinstance(pipfile_entry, dict) and pipfile_entry.get("path"):
         entry["path"] = pipfile_entry["path"]
-        entry["editable"] = True
+        if pipfile_entry.get("editable"):
+            entry["editable"] = pipfile_entry.get("editable")
         entry.pop("version", None)
         entry.pop("index", None)
     return name, entry


### PR DESCRIPTION
### The issue

In the refactor away from requirementslib, I incorrectly made an assumption that if the install line is found as a relative file path that its intended as an local file install, but this broke for cases where the file or directory name matched the named package to be pulled from a package index.

### The fix

Editable installs will need to be specified by passing the editable: true or -e arg, and not inferred.

### The checklist

* [X] Associated issue
* [ ] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.
