### PR TITLE
Apply patch for install_search_all_sources = True

### DIFF
--- a/news/5895.bugfix.rst
+++ b/news/5895.bugfix.rst
@@ -1,0 +1,1 @@
+Apply patch for install_search_all_sources = True functionality.

--- a/pipenv/patched/pip/_internal/models/search_scope.py
+++ b/pipenv/patched/pip/_internal/models/search_scope.py
@@ -20,7 +20,7 @@ class SearchScope:
     Encapsulates the locations that pip is configured to search.
     """
 
-    __slots__ = ["find_links", "index_urls", "no_index", "index_lookup"]
+    __slots__ = ["find_links", "index_urls", "no_index", "index_lookup", "index_restricted"]
 
     @classmethod
     def create(
@@ -29,6 +29,7 @@ class SearchScope:
         index_urls: List[str],
         no_index: bool,
         index_lookup: Optional[Dict[str, List[str]]] = None,
+        index_restricted: bool = False,
     ) -> "SearchScope":
         """
         Create a SearchScope object after normalizing the `find_links`.
@@ -64,6 +65,7 @@ class SearchScope:
             index_urls=index_urls,
             no_index=no_index,
             index_lookup=index_lookup,
+            index_restricted=index_restricted,
         )
 
     def __init__(
@@ -72,11 +74,13 @@ class SearchScope:
         index_urls: List[str],
         no_index: bool,
         index_lookup: Optional[Dict[str, List[str]]] = None,
+        index_restricted: bool = False,
     ) -> None:
         self.find_links = find_links
         self.index_urls = index_urls
         self.no_index = no_index
         self.index_lookup = index_lookup if index_lookup else {}
+        self.index_restricted = index_restricted
 
     def get_formatted_locations(self) -> str:
         lines = []
@@ -136,6 +140,6 @@ class SearchScope:
         index_urls = self.index_urls
         if project_name in self.index_lookup:
             index_urls = [self.index_lookup[project_name]]
-        elif self.index_urls:
+        elif self.index_restricted and self.index_urls:
             index_urls = [self.index_urls[0]]
         return [mkurl_pypi_url(url) for url in index_urls]

--- a/pipenv/utils/resolver.py
+++ b/pipenv/utils/resolver.py
@@ -245,7 +245,6 @@ class Resolver:
                 resolver.skipped[package_name] = dep
         resolver.initial_constraints = constraints
         resolver.index_lookup = index_lookup
-        resolver.finder.index_lookup = index_lookup
         resolver.markers_lookup = markers_lookup
         return resolver
 
@@ -340,6 +339,7 @@ class Resolver:
         finder = self.package_finder
         index_lookup = self.prepare_index_lookup()
         finder._link_collector.index_lookup = index_lookup
+        finder._link_collector.search_scope.index_restricted = True
         finder._link_collector.search_scope.index_lookup = index_lookup
         return finder
 

--- a/tasks/vendoring/patches/patched/pip_index_safety.patch
+++ b/tasks/vendoring/patches/patched/pip_index_safety.patch
@@ -53,7 +53,7 @@ index fe61e8116..dab85fbb9 100644
      """
 
 -    __slots__ = ["find_links", "index_urls", "no_index"]
-+    __slots__ = ["find_links", "index_urls", "no_index", "index_lookup"]
++    __slots__ = ["find_links", "index_urls", "no_index", "index_lookup", "index_restricted"]
 
      @classmethod
      def create(
@@ -62,31 +62,35 @@ index fe61e8116..dab85fbb9 100644
          index_urls: List[str],
          no_index: bool,
 +        index_lookup: Optional[Dict[str, List[str]]] = None,
++        index_restricted: bool = False,
      ) -> "SearchScope":
          """
          Create a SearchScope object after normalizing the `find_links`.
-@@ -62,6 +63,7 @@ class SearchScope:
+@@ -62,6 +64,7 @@ class SearchScope:
              find_links=built_find_links,
              index_urls=index_urls,
              no_index=no_index,
 +            index_lookup=index_lookup,
++            index_restricted: bool = False,
          )
 
      def __init__(
-@@ -69,10 +71,12 @@ class SearchScope:
+@@ -69,10 +73,12 @@ class SearchScope:
          find_links: List[str],
          index_urls: List[str],
          no_index: bool,
 +        index_lookup: Optional[Dict[str, List[str]]] = None,
++        index_restricted: bool = False,
      ) -> None:
          self.find_links = find_links
          self.index_urls = index_urls
          self.no_index = no_index
 +        self.index_lookup = index_lookup if index_lookup else {}
++        self.index_restricted = index_restricted
 
      def get_formatted_locations(self) -> str:
          lines = []
-@@ -129,4 +133,9 @@ class SearchScope:
+@@ -129,4 +137,9 @@ class SearchScope:
                  loc = loc + "/"
              return loc
 
@@ -94,6 +98,6 @@ index fe61e8116..dab85fbb9 100644
 +        index_urls = self.index_urls
 +        if project_name in self.index_lookup:
 +            index_urls = [self.index_lookup[project_name]]
-+        elif self.index_urls:
++        elif self.index_restricted and self.index_urls:
 +            index_urls = [self.index_urls[0]]
 +        return [mkurl_pypi_url(url) for url in index_urls]

--- a/tasks/vendoring/patches/patched/pip_index_safety.patch
+++ b/tasks/vendoring/patches/patched/pip_index_safety.patch
@@ -1,5 +1,5 @@
 diff --git a/pipenv/patched/pip/_internal/index/collector.py b/pipenv/patched/pip/_internal/index/collector.py
-index 0120610c..ead5227e 100644
+index b3e293ea3..f27a88725 100644
 --- a/pipenv/patched/pip/_internal/index/collector.py
 +++ b/pipenv/patched/pip/_internal/index/collector.py
 @@ -412,9 +412,11 @@ class LinkCollector:
@@ -36,7 +36,7 @@ index 0120610c..ead5227e 100644
          return link_collector
 
 diff --git a/pipenv/patched/pip/_internal/models/search_scope.py b/pipenv/patched/pip/_internal/models/search_scope.py
-index fe61e8116..dab85fbb9 100644
+index fe61e8116..98a2cc97f 100644
 --- a/pipenv/patched/pip/_internal/models/search_scope.py
 +++ b/pipenv/patched/pip/_internal/models/search_scope.py
 @@ -3,7 +3,7 @@ import logging
@@ -57,7 +57,7 @@ index fe61e8116..dab85fbb9 100644
 
      @classmethod
      def create(
-@@ -28,6 +28,7 @@ class SearchScope:
+@@ -28,6 +28,8 @@ class SearchScope:
          find_links: List[str],
          index_urls: List[str],
          no_index: bool,
@@ -66,16 +66,16 @@ index fe61e8116..dab85fbb9 100644
      ) -> "SearchScope":
          """
          Create a SearchScope object after normalizing the `find_links`.
-@@ -62,6 +64,7 @@ class SearchScope:
+@@ -62,6 +64,8 @@ class SearchScope:
              find_links=built_find_links,
              index_urls=index_urls,
              no_index=no_index,
 +            index_lookup=index_lookup,
-+            index_restricted: bool = False,
++            index_restricted=index_restricted,
          )
 
      def __init__(
-@@ -69,10 +73,12 @@ class SearchScope:
+@@ -69,10 +73,14 @@ class SearchScope:
          find_links: List[str],
          index_urls: List[str],
          no_index: bool,

--- a/tests/integration/test_install_uri.py
+++ b/tests/integration/test_install_uri.py
@@ -139,8 +139,8 @@ six = "*"
 @pytest.mark.install
 @pytest.mark.needs_internet
 @pytest.mark.skipif(sys.version_info >= (3, 12), reason="Package does not work with Python 3.12")
-def test_install_specifying_index_url(pipenv_instance_pypi):
-    with pipenv_instance_pypi() as p:
+def test_install_specifying_index_url(pipenv_instance_private_pypi):
+    with pipenv_instance_private_pypi() as p:
         with open(p.pipfile_path, "w") as f:
             contents = """
 [[source]]
@@ -153,6 +153,8 @@ six = "*"
 
 [dev-packages]
 
+[pipenv]
+install_search_all_sources = true
             """.strip()
             f.write(contents)
         c = p.pipenv("install pipenv-test-private-package --index https://test.pypi.org/simple")

--- a/tests/integration/test_lock.py
+++ b/tests/integration/test_lock.py
@@ -647,3 +647,31 @@ dataclasses-json = {extras = ["dev"], version = "==0.5.7"}
         assert "dataclasses-json" in p.pipfile["packages"]
         assert "dataclasses-json" in p.lockfile["default"]
         assert p.lockfile["default"]["dataclasses-json"].get("markers", "") is not None
+
+@pytest.mark.index
+@pytest.mark.install  # private indexes need to be uncached for resolution
+@pytest.mark.skip_lock
+@pytest.mark.needs_internet
+def test_private_index_skip_lock(pipenv_instance_private_pypi):
+    with pipenv_instance_private_pypi() as p:
+        with open(p.pipfile_path, 'w') as f:
+            contents = """
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[[source]]
+url = "https://test.pypi.org/simple"
+verify_ssl = true
+name = "testpypi"
+
+[packages]
+pipenv-test-private-package = {version = "*", index = "testpypi"}
+
+[pipenv]
+install_search_all_sources = true
+            """.strip()
+            f.write(contents)
+        c = p.pipenv('install --skip-lock')
+        assert c.returncode == 0


### PR DESCRIPTION
Thank you for contributing to Pipenv!


### The issue

A while back I broke install_search_all_sources = True and I've realized this patch.

### The fix

Search scopes gets used for resolver and installer, but install we invoke pip interface.   This gives a way to ensure index restricted packages for the resolver, but bypass that during install.

Fixes #5743 
Fixes #5781 

### The checklist

* [X] Associated issue
* [ ] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

