### PR TITLE
Set log level in resolver to WARN when verbose is not passed

### DIFF
--- a/news/5897.bugfix.rst
+++ b/news/5897.bugfix.rst
@@ -1,0 +1,1 @@
+Set log level in resolver to WARN when verbose is not passed.

--- a/pipenv/resolver.py
+++ b/pipenv/resolver.py
@@ -1,5 +1,6 @@
 import importlib.util
 import json
+import logging
 import os
 import sys
 
@@ -654,6 +655,9 @@ def main(argv=None):
     os.environ["PYTHONIOENCODING"] = "utf-8"
     os.environ["PYTHONUNBUFFERED"] = "1"
     parsed = handle_parsed_args(parsed)
+    if not parsed.verbose:
+        print(parsed.verbose)
+        logging.getLogger("pipenv").setLevel(logging.WARN)
     _main(
         parsed.pre,
         parsed.clear,


### PR DESCRIPTION
Thank you for contributing to Pipenv!


### The issue

Fixes #5854

### The fix

Set the resolver pipenv log level to WARN when verbose is not passed.


### The checklist

* [X] Associated issue
* [ ] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.
