### PR TITLE
Handle case where setup name is referencing a variable that is a string

### DIFF
--- a/news/5905.bugfix.rst
+++ b/news/5905.bugfix.rst
@@ -1,0 +1,1 @@
+Handle case better where setup.py name is referencing a variable that is a string while encouraging folks to migrate their projects to pyproject.toml


### PR DESCRIPTION
Thank you for contributing to Pipenv!


### The issue

Fixes #5904 

### The fix

Consider more edge cases in the setup.py ast parser and encourage more people to move away from complicated setup.py


### The checklist

* [X] Associated issue
* [X] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.
