### PR TITLE
Add PIPENV_REQUESTS_TIMEOUT and use it for requests session (Re-send due to force push)

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -32,3 +32,14 @@ This is useful in the same situations that you would change `PIP_CACHE_DIR` to a
 
 By default, pipenv will initialize a project using whatever version of python the system has as default.
 Besides starting a project with the `--python` flag, you can also use `PIPENV_DEFAULT_PYTHON_VERSION` to specify what version to use when starting a project when `--python` isn't used.
+
+## Environments with network issues
+
+If you are trying to use pipenv in an environment with network issues, you may be able to try modifying
+the following settings when you encounter errors related to network connectivity.
+
+### REQUESTS_TIMEOUT
+
+Default is 10 seconds. You can increase it by setting `PIPENV_REQUESTS_TIMEOUT` environment variable.
+
+Please notice that this setting only affects pipenv itself, not additional packages such as [safety](advanced.rst).

--- a/pipenv/environments.py
+++ b/pipenv/environments.py
@@ -289,6 +289,17 @@ class Setting:
         Default is 120 seconds, an arbitrary number that seems to work.
         """
 
+        self.PIPENV_REQUESTS_TIMEOUT = int(
+            get_from_env("REQUESTS_TIMEOUT", check_for_negation=False, default=10)
+        )
+        """Timeout setting for requests.
+
+        Default is 10 seconds.
+
+        For more information on the role of Timeout in Requests, see
+        [Requests docs](https://requests.readthedocs.io/en/latest/user/advanced/#timeouts).
+        """
+
         self.PIPENV_VENV_IN_PROJECT = get_from_env("VENV_IN_PROJECT")
         """ When set True, will create or use the ``.venv`` in your project directory.
         When Set False, will ignore the .venv in your project directory even if it exists.

--- a/pipenv/project.py
+++ b/pipenv/project.py
@@ -316,7 +316,9 @@ class Project:
                 if version in parsed_url.path and parsed_url.path.endswith("/"):
                     # This might be a version-specific page. Fetch and parse it
                     version_url = urljoin(pkg_url, package_url)
-                    version_response = session.get(version_url, timeout=self.s.PIPENV_REQUESTS_TIMEOUT)
+                    version_response = session.get(
+                        version_url, timeout=self.s.PIPENV_REQUESTS_TIMEOUT
+                    )
                     version_parser = PackageIndexHTMLParser()
                     version_parser.feed(version_response.text)
                     version_hrefs = version_parser.urls

--- a/pipenv/project.py
+++ b/pipenv/project.py
@@ -270,7 +270,7 @@ class Project:
         try:
             collected_hashes = set()
             # Grab the hashes from the new warehouse API.
-            r = session.get(pkg_url, timeout=10)
+            r = session.get(pkg_url, timeout=self.s.PIPENV_REQUESTS_TIMEOUT)
             api_releases = r.json()["releases"]
             cleaned_releases = {}
             for api_version, api_info in api_releases.items():
@@ -299,7 +299,7 @@ class Project:
 
         try:
             collected_hashes = set()
-            response = session.get(pkg_url, timeout=10)
+            response = session.get(pkg_url, timeout=self.s.PIPENV_REQUESTS_TIMEOUT)
             parser = PackageIndexHTMLParser()
             parser.feed(response.text)
             hrefs = parser.urls
@@ -316,7 +316,7 @@ class Project:
                 if version in parsed_url.path and parsed_url.path.endswith("/"):
                     # This might be a version-specific page. Fetch and parse it
                     version_url = urljoin(pkg_url, package_url)
-                    version_response = session.get(version_url, timeout=10)
+                    version_response = session.get(version_url, timeout=self.s.PIPENV_REQUESTS_TIMEOUT)
                     version_parser = PackageIndexHTMLParser()
                     version_parser.feed(version_response.text)
                     version_hrefs = version_parser.urls


### PR DESCRIPTION
Please refer to [#5877](https://github.com/pypa/pipenv/pull/5877)


### The issue

When I was using pipelinev in an environment with network issues, I needed to increase the timeout setting for the connection to complete properly, but I found that the default behavior was set to 10 seconds and could not be changed, so I increased it.

### The fix


Add a new ENV config for timeout, so that user can change it.


### The checklist

* [x] Associated issue
* [ ] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

