### PR TITLE
pre-commit: Add pyproject-fmt

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,30 +13,30 @@ on:
         required: false
   push:
     paths-ignore:
-      - "news/**"
-      - "examples/**"
-      - "peeps/**"
+      - ".editorconfig"
+      - ".gitattributes"
+      - ".gitignore"
+      - ".gitmodules"
       - "*.ini"
       - "*.md"
       - "**/*.txt"
-      - ".gitignore"
-      - ".gitmodules"
-      - ".gitattributes"
-      - ".editorconfig"
+      - "examples/**"
+      - "news/**"
+      - "peeps/**"
     branches:
       - main
   pull_request:
     paths-ignore:
-      - "news/**"
-      - "examples/**"
-      - "peeps/**"
+      - ".editorconfig"
+      - ".gitattributes"
+      - ".gitignore"
+      - ".gitmodules"
       - "*.ini"
       - "*.md"
       - "**/*.txt"
-      - ".gitignore"
-      - ".gitmodules"
-      - ".gitattributes"
-      - ".editorconfig"
+      - "examples/**"
+      - "news/**"
+      - "peeps/**"
 permissions:
   contents: read # to fetch code (actions/checkout)
 jobs:
@@ -49,7 +49,7 @@ jobs:
       PYTHONIOENCODING: "utf-8"
       GIT_ASK_YESNO: "false"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
@@ -61,10 +61,10 @@ jobs:
     needs: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: 3.x
       - run: |
           python -m pip install --upgrade wheel invoke parver beautifulsoup4 towncrier requests parse hatch-fancy-pypi-readme
           python -m invoke vendoring.update
@@ -75,16 +75,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]  # "3.12-dev" Windows CI hangs indefinitely
+        python-version: [3.7, 3.8, 3.9, "3.10", 3.11, 3.12]
         os: [MacOS, Ubuntu, Windows]
+        exclude:  # Python 3.12 on Windows CI hangs indefinitely
+          - python-version: 3.12
+            os: Windows
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: true
 
       - name: Get python path
         id: python-path
@@ -134,7 +138,7 @@ jobs:
     needs: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -75,11 +75,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10", 3.11, 3.12]
+        python-version: [3.7, 3.8, 3.9, "3.10", 3.11]  # , 3.12]  # Python 3.12 tests are failing
         os: [MacOS, Ubuntu, Windows]
-        exclude:  # Python 3.12 on Windows CI hangs indefinitely
-          - python-version: 3.12
-            os: Windows
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -10,6 +10,6 @@ jobs:
   ruff:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - run: pip install --user ruff
     - run: ruff --format=github .

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
     exclude: .patch
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.0.286
+  rev: v0.0.287
   hooks:
   - id: ruff
     args: [--fix, --exit-non-zero-on-fix]
@@ -51,6 +51,11 @@ repos:
   hooks:
   - id: check-manifest
     stages: [manual]
+
+- repo: https://github.com/tox-dev/pyproject-fmt
+  rev: "1.1.0"
+  hooks:
+  - id: pyproject-fmt
 
 - repo: https://github.com/abravalheri/validate-pyproject
   rev: v0.14

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,21 +1,22 @@
 [build-system]
-requires = ["setuptools>=67.0.0"]
 build-backend = "setuptools.build_meta"
-
+requires = [
+  "setuptools>=67",
+]
 
 [project]
 name = "pipenv"
+description = "Python Development Workflow for Humans."
+readme = "README.md"
+license = {file = "LICENSE"}
 authors = [
   {name = "Pipenv maintainer team", email = "distutils-sig@python.org"},
 ]
-description = "Python Development Workflow for Humans."
-readme = "README.md"
 requires-python = ">=3.7"
-license = {file = "LICENSE"}
 classifiers=[
   "License :: OSI Approved :: MIT License",
   "Programming Language :: Python",
-  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3.7",
   "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
@@ -24,43 +25,38 @@ classifiers=[
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
+dynamic = [
+  "version",
+]
 dependencies = [
   "certifi",
-  "setuptools>=67.0.0",
+  "setuptools>=67",
   "virtualenv>=20.24.2",
 ]
-dynamic = ["version"]
-
-
 [project.optional-dependencies]
 dev = [
-  "towncrier",
   "beautifulsoup4",
-  "sphinx",
-  "flake8>=3.3.0,<4.0",
-  "black==23.3.0",
-  "parver",
+  "black==23.3",
+  "flake8<4.0,>=3.3",
   "invoke",
+  "parver",
+  "sphinx",
+  "towncrier",
 ]
 tests = [
-  "pytest>=5.0",
-  "pytest-timeout",
-  "pytest-xdist",
   "flaky",
   "mock",
+  "pytest>=5",
+  "pytest-timeout",
+  "pytest-xdist",
 ]
-
-
+[project.urls]
+Documentation = "https://pipenv.pypa.io/en/latest/"
+Homepage = "https://github.com/pypa/pipenv"
+Source = "https://github.com/pypa/pipenv.git"
 [project.scripts]
 pipenv = "pipenv:cli"
 pipenv-resolver = "pipenv.resolver:main"
-
-
-[project.urls]
-Homepage = "https://github.com/pypa/pipenv"
-Documentation = "https://pipenv.pypa.io/en/latest/"
-Source = "https://github.com/pypa/pipenv.git"
-
 
 [tool.setuptools.packages.find]
 where = ["."]
@@ -112,73 +108,6 @@ exclude = '''
   | pyproject.toml
 )
 '''
-
-
-[tool.coverage.run]
-parallel = true
-
-
-[tool.mypy]
-ignore_missing_imports = true
-follow_imports = "skip"
-html_report = "mypyhtml"
-python_version = "3.7"
-mypy_path = "typeshed/pyi:typeshed/imports"
-
-
-[tool.pytest.ini_options]
-addopts = "-ra"
-plugins = "xdist"
-testpaths = ["tests"]
-# Add vendor and patched in addition to the default list of ignored dirs
-# Additionally, ignore tasks, news, test subdirectories and peeps directory
-norecursedirs = [
-  ".*",
-  "build",
-  "dist",
-  "CVS",
-  "_darcs",
-  "{arch}",
-  "*.egg",
-  "vendor",
-  "patched",
-  "news",
-  "tasks",
-  "docs",
-  "tests/test_artifacts",
-  "tests/pypi",
-  "peeps",
-]
-filterwarnings = []
-# These are not all the custom markers, but most of the ones with repeat uses
-# `pipenv run pytest --markers` will list all markers including these
-markers = [
-  "install: tests having to do with `pipenv install`",
-  "update: tests having to do with `pipenv update`",
-  "needs_internet: integration tests that require internet to pass",
-  "basic: basic pipenv tests grouping",
-  "dev: tests having to do with dev and dev packages",
-  "system: related or interacting with the os",
-  "utils: grouping of pipenv utility functions",
-  "cli: test grouping that relate to command line like `pipenv --flag args`",
-  "requirements: tests that save and alter pip requirements",
-  "run: tests that run or execute python through pipenv",
-  "script: grouping of tests that execute scripts",
-  "keep_outdated: when an activity is supposed to keep something out of date",
-  "lock: tests that interact with pipenv lock",
-  "markers: pipenv environment markers",
-  "vcs: tests integration with pipenv and vertsion control systems",
-  "project: tests with the project object",
-  "sync: related to `pipenv sync`",
-  "rrule: relating to rrules (as in recurring time)",
-  "tzoffset: timezone offset",
-  "gettz: tests with gettz (get timezone) from dateutil lib",
-  "tzstr: timezone string",
-  "extras",
-  "extended",
-  "ext: extra non-categorized tests",
-]
-
 
 [tool.ruff]
 exclude = [
@@ -240,6 +169,68 @@ max-statements = 155
 "tests/unit/test_funktools.py" = ["B015"]
 "tests/unit/test_utils.py" = ["F811"]
 
+[tool.pytest.ini_options]
+addopts = "-ra"
+plugins = "xdist"
+testpaths = ["tests"]
+# Add vendor and patched in addition to the default list of ignored dirs
+# Additionally, ignore tasks, news, test subdirectories and peeps directory
+norecursedirs = [
+  ".*",
+  "build",
+  "dist",
+  "CVS",
+  "_darcs",
+  "{arch}",
+  "*.egg",
+  "vendor",
+  "patched",
+  "news",
+  "tasks",
+  "docs",
+  "tests/test_artifacts",
+  "tests/pypi",
+  "peeps",
+]
+filterwarnings = []
+# These are not all the custom markers, but most of the ones with repeat uses
+# `pipenv run pytest --markers` will list all markers including these
+markers = [
+  "install: tests having to do with `pipenv install`",
+  "update: tests having to do with `pipenv update`",
+  "needs_internet: integration tests that require internet to pass",
+  "basic: basic pipenv tests grouping",
+  "dev: tests having to do with dev and dev packages",
+  "system: related or interacting with the os",
+  "utils: grouping of pipenv utility functions",
+  "cli: test grouping that relate to command line like `pipenv --flag args`",
+  "requirements: tests that save and alter pip requirements",
+  "run: tests that run or execute python through pipenv",
+  "script: grouping of tests that execute scripts",
+  "keep_outdated: when an activity is supposed to keep something out of date",
+  "lock: tests that interact with pipenv lock",
+  "markers: pipenv environment markers",
+  "vcs: tests integration with pipenv and vertsion control systems",
+  "project: tests with the project object",
+  "sync: related to `pipenv sync`",
+  "rrule: relating to rrules (as in recurring time)",
+  "tzoffset: timezone offset",
+  "gettz: tests with gettz (get timezone) from dateutil lib",
+  "tzstr: timezone string",
+  "extras",
+  "extended",
+  "ext: extra non-categorized tests",
+]
+
+[tool.coverage.run]
+parallel = true
+
+[tool.mypy]
+ignore_missing_imports = true
+follow_imports = "skip"
+html_report = "mypyhtml"
+python_version = "3.7"
+mypy_path = "typeshed/pyi:typeshed/imports"
 
 [tool.towncrier]
 package = "pipenv"


### PR DESCRIPTION
### The issue

Ensure that this repos `pyproject.toml` file is formatted like others.

Also:
* `pre-commit autoupdate`
* Upgrade to `actions/checkout@v4`
* Lint on the current version of Python
* Tests on Python 3.12 are failing on Linux, macOS, and Windows.
    * https://github.com/actions/setup-python/blob/main/docs/advanced-usage.md#allow-pre-releases

### The fix

Add `pyproject-fmt` to our pre-commit processing.
* https://pyproject-fmt.readthedocs.io


### The checklist

* [ ] Associated issue
* [ ] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

<!--
### If this is a patch to the `vendor` directory...

Please try to refrain from submitting patches directly to `vendor` or `patched`, but raise your issue to the upstream project instead, and inform Pipenv to upgrade when the upstream project accepts the fix.

A pull request to upgrade vendor packages is strongly discouraged, unless there is a very good reason (e.g. you need to test Pipenv’s integration to a new vendor feature). Pipenv audits and performs vendor upgrades regularly, generally before a new release is about to drop.

If your patch is not or cannot be accepted by upstream, but is essential to Pipenv (make sure to discuss this with maintainers!), please remember to attach a patch file in `tasks/vendoring/patched`, so this divergence from upstream can be recorded and replayed afterwards.
-->
