### PR TITLE
Better handling of local file install edge cases; handle local file extras

### DIFF
--- a/news/5919.bugfix.rst
+++ b/news/5919.bugfix.rst
@@ -1,0 +1,1 @@
+Better handling of local file install edge cases; handle local file extras.

--- a/pipenv/utils/dependencies.py
+++ b/pipenv/utils/dependencies.py
@@ -969,14 +969,19 @@ def expansive_install_req_from_line(
 
 
 def _file_path_from_pipfile(path_obj, pipfile_entry):
-    if path_obj.is_absolute():
+    parsed_url = urlparse(str(path_obj))
+    if parsed_url.scheme in ["http", "https", "ftp", "file"]:
+        req_str = str(path_obj)
+    elif path_obj.is_absolute():
         req_str = str(path_obj.as_posix())
     else:
         req_str = f"./{str(path_obj.as_posix())}"
+
     if pipfile_entry.get("extras"):
         req_str = f"{req_str}[{','.join(pipfile_entry['extras'])}]"
     if pipfile_entry.get("editable", False):
         req_str = f"-e {req_str}"
+
     return req_str
 
 

--- a/pipenv/utils/dependencies.py
+++ b/pipenv/utils/dependencies.py
@@ -1008,9 +1008,21 @@ def install_req_from_pipfile(name, pipfile):
         else:
             req_str = f"{name}{extras_str}@ {req_str}{subdirectory}"
     elif "path" in _pipfile:
-        req_str = str(Path(_pipfile["path"]).as_posix())
+        path_obj = Path(_pipfile["path"])
+        if path_obj.is_absolute():
+            req_str = str(path_obj.as_posix())
+        else:
+            req_str = f"./{str(path_obj.as_posix())}"
+        if _pipfile.get("editable", False):
+            req_str = f"-e {req_str}"
     elif "file" in _pipfile:
-        req_str = str(Path(_pipfile["file"]).as_posix())
+        path_obj = Path(_pipfile["file"])
+        if path_obj.is_absolute():
+            req_str = str(path_obj.as_posix())
+        else:
+            req_str = f"./{str(path_obj.as_posix())}"
+        if _pipfile.get("editable", False):
+            req_str = f"-e {req_str}"
     else:
         # We ensure version contains an operator. Default to equals (==)
         _pipfile["version"] = version = get_version(pipfile)

--- a/pipenv/utils/dependencies.py
+++ b/pipenv/utils/dependencies.py
@@ -1008,9 +1008,9 @@ def install_req_from_pipfile(name, pipfile):
         else:
             req_str = f"{name}{extras_str}@ {req_str}{subdirectory}"
     elif "path" in _pipfile:
-        req_str = str(Path(_pipfile["path"]).as_posix())
+        req_str = f"-e {str(Path(_pipfile['path']).as_posix())}"
     elif "file" in _pipfile:
-        req_str = str(Path(_pipfile["file"]).as_posix())
+        req_str = f"-e {str(Path(_pipfile['file']).as_posix())}"
     else:
         # We ensure version contains an operator. Default to equals (==)
         _pipfile["version"] = version = get_version(pipfile)

--- a/pipenv/utils/dependencies.py
+++ b/pipenv/utils/dependencies.py
@@ -969,6 +969,11 @@ def expansive_install_req_from_line(
 
 
 def _file_path_from_pipfile(path_obj, pipfile_entry):
+    """Creates an installable file path from a pipfile entry.
+    Handles local and remote paths, files and directories;
+    supports extras and editable specification.
+    Outputs a pip installable line.
+    """
     parsed_url = urlparse(str(path_obj))
     if parsed_url.scheme in ["http", "https", "ftp", "file"]:
         req_str = str(path_obj)
@@ -986,6 +991,10 @@ def _file_path_from_pipfile(path_obj, pipfile_entry):
 
 
 def install_req_from_pipfile(name, pipfile):
+    """Creates an InstallRequirement from a name and a pipfile entry.
+    Handles VCS, local & remote paths, and regular named requirements.
+    "file" and "path" entries are treated the same.
+    """
     _pipfile = {}
     vcs = None
     if hasattr(pipfile, "keys"):

--- a/pipenv/utils/dependencies.py
+++ b/pipenv/utils/dependencies.py
@@ -968,6 +968,18 @@ def expansive_install_req_from_line(
     )
 
 
+def _file_path_from_pipfile(path_obj, pipfile_entry):
+    if path_obj.is_absolute():
+        req_str = str(path_obj.as_posix())
+    else:
+        req_str = f"./{str(path_obj.as_posix())}"
+    if pipfile_entry.get("extras"):
+        req_str = f"{req_str}[{','.join(pipfile_entry['extras'])}]"
+    if pipfile_entry.get("editable", False):
+        req_str = f"-e {req_str}"
+    return req_str
+
+
 def install_req_from_pipfile(name, pipfile):
     _pipfile = {}
     vcs = None
@@ -1009,20 +1021,10 @@ def install_req_from_pipfile(name, pipfile):
             req_str = f"{name}{extras_str}@ {req_str}{subdirectory}"
     elif "path" in _pipfile:
         path_obj = Path(_pipfile["path"])
-        if path_obj.is_absolute():
-            req_str = str(path_obj.as_posix())
-        else:
-            req_str = f"./{str(path_obj.as_posix())}"
-        if _pipfile.get("editable", False):
-            req_str = f"-e {req_str}"
+        req_str = _file_path_from_pipfile(path_obj, _pipfile)
     elif "file" in _pipfile:
         path_obj = Path(_pipfile["file"])
-        if path_obj.is_absolute():
-            req_str = str(path_obj.as_posix())
-        else:
-            req_str = f"./{str(path_obj.as_posix())}"
-        if _pipfile.get("editable", False):
-            req_str = f"-e {req_str}"
+        req_str = _file_path_from_pipfile(path_obj, _pipfile)
     else:
         # We ensure version contains an operator. Default to equals (==)
         _pipfile["version"] = version = get_version(pipfile)

--- a/pipenv/utils/dependencies.py
+++ b/pipenv/utils/dependencies.py
@@ -1008,9 +1008,9 @@ def install_req_from_pipfile(name, pipfile):
         else:
             req_str = f"{name}{extras_str}@ {req_str}{subdirectory}"
     elif "path" in _pipfile:
-        req_str = f"-e {str(Path(_pipfile['path']).as_posix())}"
+        req_str = str(Path(_pipfile["path"]).as_posix())
     elif "file" in _pipfile:
-        req_str = f"-e {str(Path(_pipfile['file']).as_posix())}"
+        req_str = str(Path(_pipfile["file"]).as_posix())
     else:
         # We ensure version contains an operator. Default to equals (==)
         _pipfile["version"] = version = get_version(pipfile)


### PR DESCRIPTION
We definitely don't want relative one directory to be treated as package name and pip documentation does not provide much guidance on this.

### The issue

Fixes #5917 

### The fix

If the path is not absolute, ensure it is prepended with ./ so it is treated as an installable path by pip (and not a named requirement) -- also handle the specification of extras with local file installs.

### The checklist

* [X] Associated issue
* [X] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.
