### PR TITLE
include markers when skipping lock

### DIFF
--- a/news/5920.bugfix.rst
+++ b/news/5920.bugfix.rst
@@ -1,0 +1,1 @@
+Include the Pipfile markers in the install phase when using ``--skip-lock``.

--- a/pipenv/routines/install.py
+++ b/pipenv/routines/install.py
@@ -402,6 +402,7 @@ def do_install_dependencies(
                 install_req, markers, req_line = install_req_from_pipfile(
                     req_name, pipfile_entry
                 )
+                req_line = f"{req_line}; {markers}" if markers else f"{req_line}"
                 deps_list.append(
                     (
                         install_req,


### PR DESCRIPTION


### The issue

Fixes #5912 

### The fix

Include the Pipfile markers in the install phase when using `--skip-lock`

### The checklist

* [X] Associated issue
* [X] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.
