### PR TITLE
Drop 3.7 test runner

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -75,7 +75,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10", 3.11]  # , 3.12]  # Python 3.12 tests are failing
+        python-version: [3.8, 3.9, "3.10", 3.11, 3.12]
         os: [MacOS, Ubuntu, Windows]
 
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -75,7 +75,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8, 3.9, "3.10", 3.11, 3.12]
+        python-version: [3.8, 3.9, "3.10", 3.11]  # 3.12 has issues with windows hanging indefinitely at present
         os: [MacOS, Ubuntu, Windows]
 
     steps:

--- a/tests/integration/test_install_categories.py
+++ b/tests/integration/test_install_categories.py
@@ -96,7 +96,7 @@ setup(
     author_email='test@pipenv.package',
     license='MIT',
     packages=[],
-    install_requires=['six'],
+    install_requires=['six', 'setuptools'],
     zip_safe=False
 )
             """.strip()


### PR DESCRIPTION
### The issue

The 3.7 tests are failing because the recent lock adjustments and packages we depend on dropped 3.7, but it only affects the test runner for now -- we will pursue https://github.com/pypa/pipenv/pull/5879 soon since the latest rounds of bug fixes after the last major refactor are almost complete/stabilized.


### The fix

Drop 3.7 from test CI

### The checklist

* [ ] Associated issue
* [ ] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.
