### PR TITLE
ignore_compatibility was supposed to default to False

### DIFF
--- a/news/5926.bugfix.rst
+++ b/news/5926.bugfix.rst
@@ -1,0 +1,1 @@
+ignore_compatibility was supposed to default to False (except for hash collection)

--- a/pipenv/utils/resolver.py
+++ b/pipenv/utils/resolver.py
@@ -337,7 +337,7 @@ class Resolver:
         )
         return finder
 
-    def finder(self, ignore_compatibility=True):
+    def finder(self, ignore_compatibility=False):
         finder = self.package_finder
         index_lookup = self.prepare_index_lookup()
         finder._link_collector.index_lookup = index_lookup


### PR DESCRIPTION
ignore_compatibility was supposed to default to False, collect hashes already passes True.


### The issue

Fixes #5924 

### The checklist

* [X] Associated issue
* [] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.
