### PR TITLE
Include the package name in the information to the resolver

### DIFF
--- a/pipenv/resolver.py
+++ b/pipenv/resolver.py
@@ -83,7 +83,11 @@ def handle_parsed_args(parsed):
         with open(parsed.constraints_file) as constraints:
             file_constraints = constraints.read().strip().split("\n")
         os.unlink(parsed.constraints_file)
-        parsed.packages += sorted(file_constraints)
+        packages = {}
+        for line in file_constraints:
+            dep_name, pip_line = line.split(",", 1)
+            packages[dep_name] = pip_line
+        parsed.packages = packages
     return parsed
 
 
@@ -579,12 +583,8 @@ def resolve_packages(
         else None
     )
 
-    if not isinstance(packages, set):
-        packages = set(packages)
-    if not isinstance(constraints, set):
-        constraints = set(constraints) if constraints else set()
     if constraints:
-        packages |= constraints
+        packages.update(constraints)
 
     def resolve(
         packages, pre, project, sources, clear, system, category, requirements_dir=None

--- a/pipenv/utils/dependencies.py
+++ b/pipenv/utils/dependencies.py
@@ -467,14 +467,14 @@ def convert_deps_to_pip(
     include_index=False,
 ):
     """ "Converts a Pipfile-formatted dependency to a pip-formatted one."""
-    dependencies = []
+    dependencies = {}
     if indexes is None:
         indexes = []
     for dep_name, dep in deps.items():
         req = dependency_as_pip_install_line(
             dep_name, dep, include_hashes, include_markers, include_index, indexes
         )
-        dependencies.append(req)
+        dependencies[dep_name] = req
     return dependencies
 
 
@@ -942,7 +942,7 @@ def expansive_install_req_from_line(
     :return: A tuple of the InstallRequirement and the name of the package (if determined).
     """
     name = None
-    pip_line = pip_line.strip("'")
+    pip_line = pip_line.strip("'").lstrip(" ")
     for new_req_symbol in ("@ ", " @ "):  # Check for new style pip lines
         if new_req_symbol in pip_line:
             pip_line_parts = pip_line.split(new_req_symbol, 1)

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -13,10 +13,10 @@ from pipenv.exceptions import PipenvUsageError
 
 # Pipfile format <-> requirements.txt format.
 DEP_PIP_PAIRS = [
-    ({"django": ">1.10"}, "django>1.10"),
-    ({"Django": ">1.10"}, "Django>1.10"),
-    ({"requests": {"extras": ["socks"], "version": ">1.10"}}, "requests[socks]>1.10"),
-    ({"requests": {"extras": ["socks"], "version": "==1.10"}}, "requests[socks]==1.10"),
+    ({"django": ">1.10"}, {"django": "django>1.10"}),
+    ({"Django": ">1.10"}, {"django": "Django>1.10"}),
+    ({"requests": {"extras": ["socks"], "version": ">1.10"}}, {"requests": "requests[socks]>1.10"}),
+    ({"requests": {"extras": ["socks"], "version": "==1.10"}}, {"requests": "requests[socks]==1.10"}),
     (
         {
             "dataclasses-json": {
@@ -25,11 +25,11 @@ DEP_PIP_PAIRS = [
                 "editable": True,
             }
         },
-        "dataclasses-json@ git+https://github.com/lidatong/dataclasses-json.git@v0.5.7",
+        {"dataclasses-json": "dataclasses-json@ git+https://github.com/lidatong/dataclasses-json.git@v0.5.7"},
     ),
     (
         {"dataclasses-json": {"git": "https://github.com/lidatong/dataclasses-json.git", "ref": "v0.5.7"}},
-        "dataclasses-json@ git+https://github.com/lidatong/dataclasses-json.git@v0.5.7",
+        {"dataclasses-json": "dataclasses-json@ git+https://github.com/lidatong/dataclasses-json.git@v0.5.7"},
     ),
     (
         # Extras in url
@@ -39,7 +39,7 @@ DEP_PIP_PAIRS = [
                 "extras": ["pipenv"],
             }
         },
-        "dparse[pipenv] @ https://github.com/oz123/dparse/archive/refs/heads/master.zip",
+        {"dparse": "dparse[pipenv] @ https://github.com/oz123/dparse/archive/refs/heads/master.zip"},
     ),
     (
         {
@@ -50,7 +50,7 @@ DEP_PIP_PAIRS = [
                 "editable": False,
             }
         },
-        "requests[security]@ git+https://github.com/requests/requests.git@main",
+        {"requests": "requests[security]@ git+https://github.com/requests/requests.git@main"},
     ),
 ]
 
@@ -64,7 +64,7 @@ def mock_unpack(link, source_dir, download_dir, only_download=False, session=Non
 @pytest.mark.parametrize("deps, expected", DEP_PIP_PAIRS)
 @pytest.mark.needs_internet
 def test_convert_deps_to_pip(deps, expected):
-    assert dependencies.convert_deps_to_pip(deps) == [expected]
+    assert dependencies.convert_deps_to_pip(deps) == expected
 
 
 @pytest.mark.utils
@@ -72,7 +72,7 @@ def test_convert_deps_to_pip(deps, expected):
 def test_convert_deps_to_pip_star_specifier():
     deps = {"uvicorn": "*"}
     expected = "uvicorn"
-    assert dependencies.convert_deps_to_pip(deps) == [expected]
+    assert dependencies.convert_deps_to_pip(deps) == expected
 
 
 @pytest.mark.utils
@@ -80,7 +80,7 @@ def test_convert_deps_to_pip_star_specifier():
 def test_convert_deps_to_pip_extras_no_version():
     deps = {"uvicorn": {"extras": ["standard"], "version": "*"}}
     expected = "uvicorn[standard]"
-    assert dependencies.convert_deps_to_pip(deps) == [expected]
+    assert dependencies.convert_deps_to_pip(deps) == expected
 
 
 @pytest.mark.utils
@@ -95,7 +95,7 @@ def test_convert_deps_to_pip_extras_no_version():
                     "hash": "sha256:2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
                 }
             },
-            "FooProject==1.2 --hash=sha256:2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
+            {"FooProject": "FooProject==1.2 --hash=sha256:2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"},
         ),
         (
             {
@@ -105,7 +105,7 @@ def test_convert_deps_to_pip_extras_no_version():
                     "hash": "sha256:2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
                 }
             },
-            "FooProject[stuff]==1.2 --hash=sha256:2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
+            {"FooProject": "FooProject[stuff]==1.2 --hash=sha256:2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"},
         ),
         (
             {
@@ -115,7 +115,7 @@ def test_convert_deps_to_pip_extras_no_version():
                     "extras": ["standard"],
                 }
             },
-            "git+https://github.com/encode/uvicorn.git@master#egg=uvicorn[standard]",
+            {"uvicorn": "git+https://github.com/encode/uvicorn.git@master#egg=uvicorn[standard]"},
         ),
     ],
 )
@@ -126,8 +126,8 @@ def test_convert_deps_to_pip_one_way(deps, expected):
 @pytest.mark.utils
 def test_convert_deps_to_pip_one_way():
     deps = {"uvicorn": {}}
-    expected = "uvicorn"
-    assert dependencies.convert_deps_to_pip(deps) == [expected.lower()]
+    expected = {"uvicorn": "uvicorn"}
+    assert dependencies.convert_deps_to_pip(deps) == expected
 
 
 @pytest.mark.utils

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -14,7 +14,7 @@ from pipenv.exceptions import PipenvUsageError
 # Pipfile format <-> requirements.txt format.
 DEP_PIP_PAIRS = [
     ({"django": ">1.10"}, {"django": "django>1.10"}),
-    ({"Django": ">1.10"}, {"django": "Django>1.10"}),
+    ({"Django": ">1.10"}, {"Django": "Django>1.10"}),
     ({"requests": {"extras": ["socks"], "version": ">1.10"}}, {"requests": "requests[socks]>1.10"}),
     ({"requests": {"extras": ["socks"], "version": "==1.10"}}, {"requests": "requests[socks]==1.10"}),
     (
@@ -71,7 +71,7 @@ def test_convert_deps_to_pip(deps, expected):
 @pytest.mark.needs_internet
 def test_convert_deps_to_pip_star_specifier():
     deps = {"uvicorn": "*"}
-    expected = "uvicorn"
+    expected = {"uvicorn": "uvicorn"}
     assert dependencies.convert_deps_to_pip(deps) == expected
 
 
@@ -79,7 +79,7 @@ def test_convert_deps_to_pip_star_specifier():
 @pytest.mark.needs_internet
 def test_convert_deps_to_pip_extras_no_version():
     deps = {"uvicorn": {"extras": ["standard"], "version": "*"}}
-    expected = "uvicorn[standard]"
+    expected = {"uvicorn": "uvicorn[standard]"}
     assert dependencies.convert_deps_to_pip(deps) == expected
 
 


### PR DESCRIPTION
Specifying the package name with `name @ requirement` works for some things, but that information is lost the way the data is passed to the resolver currently.   This updates the constraints file to have req_name, pip_line format.

### The issue

Improvements for the case of #5904


### The checklist

* [X] Associated issue
* [ ] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.
