### PR TITLE
Solving slashes or other less usual symbols in vcs refs were not being interpreted correctly.

### DIFF
--- a/news/5934.bugfix.rst
+++ b/news/5934.bugfix.rst
@@ -1,0 +1,1 @@
+Eveb better handling of vcs branch references that contain special characters.

--- a/pipenv/utils/locking.py
+++ b/pipenv/utils/locking.py
@@ -13,6 +13,7 @@ from pipenv.utils.dependencies import (
     clean_resolved_dep,
     determine_vcs_revision_hash,
     expansive_install_req_from_line,
+    normalize_vcs_url,
     pep423_name,
     translate_markers,
 )
@@ -61,7 +62,9 @@ def format_requirement_for_lockfile(
     if req.link and req.link.is_vcs:
         vcs = req.link.scheme.split("+", 1)[0]
         entry["ref"] = determine_vcs_revision_hash(req, vcs, pipfile_entry.get("ref"))
-        entry[vcs] = original_deps.get(name, req.link.url)
+        vcs_url = original_deps.get(name, req.link.url)
+        vcs_url, _ = normalize_vcs_url(vcs_url)  # Remove possible ref
+        entry[vcs] = vcs_url
         if pipfile_entry.get("subdirectory"):
             entry["subdirectory"] = pipfile_entry["subdirectory"]
     if req.req:

--- a/pipenv/utils/locking.py
+++ b/pipenv/utils/locking.py
@@ -13,7 +13,6 @@ from pipenv.utils.dependencies import (
     clean_resolved_dep,
     determine_vcs_revision_hash,
     expansive_install_req_from_line,
-    normalize_vcs_url,
     pep423_name,
     translate_markers,
 )
@@ -62,9 +61,7 @@ def format_requirement_for_lockfile(
     if req.link and req.link.is_vcs:
         vcs = req.link.scheme.split("+", 1)[0]
         entry["ref"] = determine_vcs_revision_hash(req, vcs, pipfile_entry.get("ref"))
-        vcs_url = original_deps.get(name, req.link.url)
-        vcs_url, _ = normalize_vcs_url(vcs_url)  # Remove possible ref
-        entry[vcs] = vcs_url
+        entry[vcs] = original_deps.get(name, req.link.url)
         if pipfile_entry.get("subdirectory"):
             entry["subdirectory"] = pipfile_entry["subdirectory"]
     if req.req:

--- a/tests/integration/test_lockfile.py
+++ b/tests/integration/test_lockfile.py
@@ -1,0 +1,63 @@
+from collections import defaultdict
+import json
+import pytest
+
+from pipenv.project import Project
+from pipenv.utils import requirements
+
+
+@pytest.fixture
+def pypi_lockfile():
+    lockfile = defaultdict(dict)
+    lockfile["_meta"] = {
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": True,
+            }
+        ]
+    }
+    yield lockfile
+
+
+def test_git_branch_contains_slashes(
+        pipenv_instance_pypi, pypi_lockfile
+):
+    pypi_lockfile["default"]["google-api-python-client"] = {
+        "git": "https://github.com/thehesiod/google-api-python-client.git@thehesiod/batch-retries2",
+        "markers": "python_version >= '3.7'",
+        "ref": "03803c21fc13a345e978f32775b2f2fa23c8e706"
+    }
+
+    with pipenv_instance_pypi() as p:
+        with open(p.lockfile_path, "w") as f:
+            json.dump(pypi_lockfile, f)
+
+        project = Project()
+        lockfile = project.load_lockfile(expand_env_vars=False)
+        deps = lockfile["default"]
+        pip_installable_lines = requirements.requirements_from_lockfile(
+            deps, include_hashes=False, include_markers=True
+        )
+        assert pip_installable_lines == ["google-api-python-client@ git+https://github.com/thehesiod/google-api-python-client.git@03803c21fc13a345e978f32775b2f2fa23c8e706"]
+
+
+def test_git_branch_contains_subdirectory_fragment(pipenv_instance_pypi, pypi_lockfile):
+    pypi_lockfile["default"]["pep508_package"] = {
+        "git": "https://github.com/techalchemy/test-project.git@master",
+        "subdirectory": "parent_folder/pep508-package",
+        "ref": "03803c21fc13a345e978f32775b2f2fa23c8e706"
+    }
+
+    with pipenv_instance_pypi() as p:
+        with open(p.lockfile_path, "w") as f:
+            json.dump(pypi_lockfile, f)
+
+        project = Project()
+        lockfile = project.load_lockfile(expand_env_vars=False)
+        deps = lockfile["default"]
+        pip_installable_lines = requirements.requirements_from_lockfile(
+            deps, include_hashes=False, include_markers=True
+        )
+        assert pip_installable_lines == ['pep508_package@ git+https://github.com/techalchemy/test-project.git@03803c21fc13a345e978f32775b2f2fa23c8e706#subdirectory=parent_folder/pep508-package']


### PR DESCRIPTION
Thank you for contributing to Pipenv!


### The issue

Fixes issue #5934

### The fix

urllib urlparse has to be better at separating netlocs from the remaining path than I can do.


### The checklist

* [X] Associated issue
* [X] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

<!--
### If this is a patch to the `vendor` directory...

Please try to refrain from submitting patches directly to `vendor` or `patched`, but raise your issue to the upstream project instead, and inform Pipenv to upgrade when the upstream project accepts the fix.

A pull request to upgrade vendor packages is strongly discouraged, unless there is a very good reason (e.g. you need to test Pipenv’s integration to a new vendor feature). Pipenv audits and performs vendor upgrades regularly, generally before a new release is about to drop.

If your patch is not or cannot be accepted by upstream, but is essential to Pipenv (make sure to discuss this with maintainers!), please remember to attach a patch file in `tasks/vendoring/patched`, so this divergence from upstream can be recorded and replayed afterwards.
-->
