### PR TITLE
Bump certifi from 2023.5.7 to 2023.7.22 in /examples

### DIFF
--- a/examples/Pipfile.lock
+++ b/examples/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "8d14434df45e0ef884d6c3f6e8048ba72335637a8631cc44792f52fd20b6f97a"
+            "sha256": "6a44fe37aaf35b2b653e3e4ff422efc6370108bf8a09a43858dfef57f7cd41a8"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -16,11 +16,12 @@
     "default": {
         "certifi": {
             "hashes": [
-                "sha256:0f0d56dc5a6ad56fd4ba36484d6cc34451e1c6548c61daad8c320169f91eddc7",
-                "sha256:c6c2e98f5c7869efca1f8916fed228dd91539f9f1b444c314c06eef02980c716"
+                "sha256:539cc1d13202e33ca466e88b2807e29f4c13049d6d87031a3c110744495cb082",
+                "sha256:92d6037539857d8206b8f6ae472e8b77db8058fec5937a1ef3f54304089edbb9"
             ],
+            "index": "pypi",
             "markers": "python_version >= '3.6'",
-            "version": "==2023.5.7"
+            "version": "==2023.7.22"
         },
         "charset-normalizer": {
             "hashes": [

--- a/news/5941.bugfix.rst
+++ b/news/5941.bugfix.rst
@@ -1,0 +1,1 @@
+Bump certifi from 2023.5.7 to 2023.7.22 in /examples to address a security vulnerability


### PR DESCRIPTION
### The issue

There is a security vulnerability for `certifi` versions <2023.7.22 (see details here: [CVE-2023-37920](https://nvd.nist.gov/vuln/detail/CVE-2023-37920)). Even though this version is only in /examples, it gets detected and flagged by static analysis tools when scanning docker images that have the latest version of pipenv installed.

Related issue: https://github.com/pypa/pipenv/issues/5940

### The fix

Update `certifi` in `/examples` to address the issue


### The checklist

* [x] [Associated issue](https://github.com/pypa/pipenv/issues/5940)
* [x] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

<!--
### If this is a patch to the `vendor` directory...

Please try to refrain from submitting patches directly to `vendor` or `patched`, but raise your issue to the upstream project instead, and inform Pipenv to upgrade when the upstream project accepts the fix.

A pull request to upgrade vendor packages is strongly discouraged, unless there is a very good reason (e.g. you need to test Pipenv’s integration to a new vendor feature). Pipenv audits and performs vendor upgrades regularly, generally before a new release is about to drop.

If your patch is not or cannot be accepted by upstream, but is essential to Pipenv (make sure to discuss this with maintainers!), please remember to attach a patch file in `tasks/vendoring/patched`, so this divergence from upstream can be recorded and replayed afterwards.
-->
