### PR TITLE
Update some external links on the docs

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -234,7 +234,7 @@ Example:
 
 Note
 
-Each month, [PyUp.io](https://pyup.io>)updates the `safety` database of insecure Python packages and [makes it available to the open source community for free](https://pyup.io/safety/). Each time you run `pipenv check` to show you vulnerable dependencies,
+Each month, [PyUp.io](https://pyup.io) updates the `safety` database of insecure Python packages and [makes it available to the open source community for free](https://pyup.io/safety/). Each time you run `pipenv check` to show you vulnerable dependencies,
 Pipenv makes an API call to retrieve and use those results.
 
 For more up-to-date vulnerability data, you may also use your own safety API key by setting the environment variable `PIPENV_PYUP_API_KEY`.

--- a/docs/pipfile.md
+++ b/docs/pipfile.md
@@ -2,7 +2,7 @@
 
 `Pipfile` contains the specification for the project top-level requirements and any desired specifiers.
 This file is managed by the developers invoking pipenv commands.
-The `Pipfile` uses inline tables and the [TOML Spec](https://github.com/toml-lang/toml#user-content-spec>).
+The `Pipfile` uses inline tables and the [TOML Spec](https://toml.io/en/latest#spec).
 
 `Pipfile.lock` replaces the `requirements.txt` file used in most Python projects and adds
 security benefits of tracking the packages hashes that were last locked.

--- a/docs/shell.md
+++ b/docs/shell.md
@@ -43,7 +43,7 @@ To prevent pipenv from loading the `.env` file, set the `PIPENV_DONT_LOAD_ENV` e
 
     $ PIPENV_DONT_LOAD_ENV=1 pipenv shell
 
-See [theskumar/python-dotenv](https://github.com/theskumar/python-dotenv>) for more information on `.env` files.
+See [theskumar/python-dotenv](https://github.com/theskumar/python-dotenv) for more information on `.env` files.
 
 ## Shell Completion
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -13,7 +13,7 @@ Add a package to your project, recalibrating entire lock file using the Pipfile 
     $ pipenv install <package>
 
 - Note: This will create a `Pipfile` if one doesn't exist. If one does exist, it will automatically be edited with the new package you provided, the lock file updated and the new dependencies installed.
-- `pipenv install` is fully compatible with `pip install` [package specifiers](https://pip.pypa.io/en/stable/user_guide/#installing-packages>).
+- `pipenv install` is fully compatible with `pip install` [package specifiers](https://pip.pypa.io/en/stable/user_guide/#installing-packages).
 - Additional arguments may be supplied to `pip` by supplying `pipenv` with `--extra-pip-args`.
 
 Update everything (equivalent to `pipenv lock && pipenv sync`):


### PR DESCRIPTION
### The issue

I believe during the conversion from `.rst` to `.md` a minor typo was introduced on the link for `python-dotenv` repo on [pipenv docs](https://pipenv.pypa.io/en/latest/shell/#automatic-loading-of-env)

### The fix

Remove the extra `>`

> **_ps._**: Since this typo was observed, I took the liberty to `grep` the repo and see if there were similar cases. I found three more that seemed relevant. Note that in the TOML case, the `Spec` header was moved from the `READ.md` into their docs

### The checklist

* [ ] Associated issue
* [ ] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

<!--
### If this is a patch to the `vendor` directory...

Please try to refrain from submitting patches directly to `vendor` or `patched`, but raise your issue to the upstream project instead, and inform Pipenv to upgrade when the upstream project accepts the fix.

A pull request to upgrade vendor packages is strongly discouraged, unless there is a very good reason (e.g. you need to test Pipenv’s integration to a new vendor feature). Pipenv audits and performs vendor upgrades regularly, generally before a new release is about to drop.

If your patch is not or cannot be accepted by upstream, but is essential to Pipenv (make sure to discuss this with maintainers!), please remember to attach a patch file in `tasks/vendoring/patched`, so this divergence from upstream can be recorded and replayed afterwards.
-->
