### PR TITLE
Catch req.link = None

### DIFF
--- a/pipenv/environment.py
+++ b/pipenv/environment.py
@@ -770,8 +770,8 @@ class Environment:
         )
         if match is not None:
             if req.link is None:
-                return False
-            if req.editable and req.link and req.link.is_file:
+                return True
+            if req.editable and req.link.is_file:
                 requested_path = req.link.file_path
                 if os.path.exists(requested_path):
                     local_path = requested_path
@@ -796,7 +796,7 @@ class Environment:
                     and vcs_ref == requested_revision
                     and direct_url_metadata["url"] == pipfile_part[req.link.scheme]
                 )
-            elif req.link and req.link.is_vcs:
+            elif req.link.is_vcs:
                 return False
             elif req.specifier is not None:
                 return SpecifierSet(str(req.specifier)).contains(

--- a/pipenv/environment.py
+++ b/pipenv/environment.py
@@ -769,9 +769,13 @@ class Environment:
             None,
         )
         if match is not None:
+            if req.specifier is not None:
+                return SpecifierSet(str(req.specifier)).contains(
+                    match.version, prereleases=True
+                )
             if req.link is None:
                 return True
-            if req.editable and req.link.is_file:
+            elif req.editable and req.link.is_file:
                 requested_path = req.link.file_path
                 if os.path.exists(requested_path):
                     local_path = requested_path
@@ -798,10 +802,6 @@ class Environment:
                 )
             elif req.link.is_vcs:
                 return False
-            elif req.specifier is not None:
-                return SpecifierSet(str(req.specifier)).contains(
-                    match.version, prereleases=True
-                )
             return True
         return False
 

--- a/pipenv/environment.py
+++ b/pipenv/environment.py
@@ -769,6 +769,8 @@ class Environment:
             None,
         )
         if match is not None:
+            if req.link is None:
+                return False
             if req.editable and req.link and req.link.is_file:
                 requested_path = req.link.file_path
                 if os.path.exists(requested_path):


### PR DESCRIPTION
req.link is of type InstallRequirements which can be None. Return False (requirement not met) if this is the case.

### The issue

Fix issue #5950. 

`req` is of type `InstallRequirements`, which has an optional attribute `link` which can be `None`. However, attributes of `req.link` are accessed directly.

### The fix

Catch if `req.link` is `None` and return `False` (requirement not met) before attributes of `req.link` are accessed.


### The checklist

* [x] Associated issue
* [ ] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.