### PR TITLE
set regular logging level to ERROR

### DIFF
--- a/pipenv/utils/__init__.py
+++ b/pipenv/utils/__init__.py
@@ -2,7 +2,7 @@ import logging
 
 from pipenv.patched.pip._vendor.rich.console import Console
 
-logging.basicConfig(level=logging.INFO)
+logging.basicConfig(level=logging.ERROR)
 
 console = Console()
 err = Console(stderr=True)


### PR DESCRIPTION
### The issue

Fix noisy output in pipenv check as described in issue #5939. Prior to release v2023.8.19 in `pipenv/utils/__init__.py` logging basic config was set to ERROR, then to INFO. I am not sure whether that was on purpose, was changed in a large commit #5793, maybe it was just used for debugging and then not changed back. @matteius 

### The fix

Change back to `logging.ERROR`.


### The checklist

* [x] Associated issue
* [ ] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.
