### PR TITLE
feat(install): add 'exact' option

### DIFF
--- a/pipenv/cli/command.py
+++ b/pipenv/cli/command.py
@@ -212,6 +212,7 @@ def install(state, **kwargs):
         python=state.python,
         pypi_mirror=state.pypi_mirror,
         system=state.system,
+        exact=state.installstate.exact,
         ignore_pipfile=state.installstate.ignore_pipfile,
         requirementstxt=state.installstate.requirementstxt,
         pre=state.installstate.pre,

--- a/pipenv/cli/options.py
+++ b/pipenv/cli/options.py
@@ -77,6 +77,7 @@ class InstallState:
     def __init__(self):
         self.dev = False
         self.pre = False
+        self.exact = False
         self.ignore_pipfile = False
         self.code = False
         self.requirementstxt = None
@@ -127,6 +128,24 @@ def editable_option(f):
         callback=callback,
         type=click_types.Path(file_okay=False),
         help="An editable Python package URL or path, often to a VCS repository.",
+    )(f)
+
+
+def exact_option(f):
+    def callback(ctx, param, value):
+        state = ctx.ensure_object(State)
+        state.installstate.exact = value
+        return value
+
+    return option(
+        "--exact",
+        is_flag=True,
+        default=False,
+        expose_value=False,
+        help="Add exact package version to Pipfile when installing, instead of *.",
+        callback=callback,
+        type=click_types.BOOL,
+        show_envvar=True,
     )(f)
 
 
@@ -607,6 +626,7 @@ def install_options(f):
     f = sync_options(f)
     f = index_option(f)
     f = requirementstxt_option(f)
+    f = exact_option(f)
     f = ignore_pipfile_option(f)
     f = editable_option(f)
     f = package_arg(f)

--- a/pipenv/project.py
+++ b/pipenv/project.py
@@ -1197,12 +1197,22 @@ class Project:
         else:
             return name, normalized_name, entry
 
-    def add_package_to_pipfile(self, package, pip_line, dev=False, category=None):
+    def add_package_to_pipfile(
+        self, package, pip_line, dev=False, category=None, exact=False
+    ):
         category = category if category else "dev-packages" if dev else "packages"
 
         name, normalized_name, entry = self.generate_package_pipfile_entry(
             package, pip_line, category=category
         )
+
+        if exact:
+            from pipenv.utils.resolver import resolve_deps
+
+            resolved_packages, resolver = resolve_deps(
+                {normalized_name: package.name}, None, self, category=category
+            )
+            entry = str(resolver.install_reqs[normalized_name].specifier)
 
         return self.add_pipfile_entry_to_pipfile(
             name, normalized_name, entry, category=category

--- a/pipenv/routines/install.py
+++ b/pipenv/routines/install.py
@@ -36,6 +36,7 @@ def do_install(
     python=False,
     pypi_mirror=None,
     system=False,
+    exact=False,
     ignore_pipfile=False,
     requirementstxt=False,
     pre=False,
@@ -243,7 +244,11 @@ def do_install(
                     if categories:
                         for category in categories:
                             added, cat, normalized_name = project.add_package_to_pipfile(
-                                pkg_requirement, pkg_line, dev, category
+                                pkg_requirement,
+                                pkg_line,
+                                dev,
+                                category=category,
+                                exact=exact,
                             )
                             if added:
                                 new_packages.append((normalized_name, cat))
@@ -253,7 +258,7 @@ def do_install(
                                 )
                     else:
                         added, cat, normalized_name = project.add_package_to_pipfile(
-                            pkg_requirement, pkg_line, dev
+                            pkg_requirement, pkg_line, dev, exact=exact
                         )
                         if added:
                             new_packages.append((normalized_name, cat))


### PR DESCRIPTION
### The issue

Tries to very crudely address https://github.com/pypa/pipenv/issues/5531 .

### The fix

Introduces an `--exact` argument to `pipenv install` that locks the exact package version to `Pipfile` instead of `*`. It is a very rudimentary implementation and I am sure calling `resolve_deps` that early in the pipeline might introduce some unintended behavior. But I wanted to open up the PR to get some conversation going, and perhaps inspire someone else to implement a proper fix. Also to just say hi to @matteius I guess 👋 

### To-do

* [ ] Write tests.
* [ ] Add docs.
* [ ] Update `news/`.

### The checklist

* [X] Associated issue
* [ ] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

<!--
### If this is a patch to the `vendor` directory...

Please try to refrain from submitting patches directly to `vendor` or `patched`, but raise your issue to the upstream project instead, and inform Pipenv to upgrade when the upstream project accepts the fix.

A pull request to upgrade vendor packages is strongly discouraged, unless there is a very good reason (e.g. you need to test Pipenv’s integration to a new vendor feature). Pipenv audits and performs vendor upgrades regularly, generally before a new release is about to drop.

If your patch is not or cannot be accepted by upstream, but is essential to Pipenv (make sure to discuss this with maintainers!), please remember to attach a patch file in `tasks/vendoring/patched`, so this divergence from upstream can be recorded and replayed afterwards.
-->
