### PR TITLE
Sort packages alphabetically inside each category

### DIFF
--- a/docs/pipfile.md
+++ b/docs/pipfile.md
@@ -10,6 +10,15 @@ This file is managed automatically through locking actions.
 
 You should add both `Pipfile` and `Pipfile.lock` to the project's source control.
 
+## `[pipenv]` Directives
+
+`Pipfile` may contain a `[pipenv]` section to control the behaviour of pipenv itself. Some available settings include:
+
+* `allow_prereleases` - Tell pipenv to install pre-release versions of a package -i.e. a version with an alpha/beta/etc. suffix, such as _1.0b1_. Equivalent to passing the `--pre` flag on the command line.
+* `disable_pip_input` - Prevent pipenv from asking for input. Equivalent to the `--no-input` flag.
+* `install_search_all_sources` - Allow installation of packages from an existing `Pipfile.lock` to search all defined indexes for the constrained package version and hash signatures. See [Specifying Package Indexes](indexes.md).
+
+
 ## Example Pipfile
 
 Here is a simple example of a `Pipfile` and the resulting `Pipfile.lock`.

--- a/docs/pipfile.md
+++ b/docs/pipfile.md
@@ -17,6 +17,7 @@ You should add both `Pipfile` and `Pipfile.lock` to the project's source control
 * `allow_prereleases` - Tell pipenv to install pre-release versions of a package -i.e. a version with an alpha/beta/etc. suffix, such as _1.0b1_. Equivalent to passing the `--pre` flag on the command line.
 * `disable_pip_input` - Prevent pipenv from asking for input. Equivalent to the `--no-input` flag.
 * `install_search_all_sources` - Allow installation of packages from an existing `Pipfile.lock` to search all defined indexes for the constrained package version and hash signatures. See [Specifying Package Indexes](indexes.md).
+* `sort_pipfile` - Sort package names alphabetically inside each category. Categories will be sorted and updated on `install` and `uninstall`. This is purely cosmetic to make reading easier for humans, and has no effect on installation order or dependency resolution. Note that `Pipfile.lock` packages are always sorted alphabetically.
 
 
 ## Example Pipfile

--- a/pipenv/project.py
+++ b/pipenv/project.py
@@ -1117,6 +1117,8 @@ class Project:
         p = self.parsed_pipfile
         if name:
             del p[category][name]
+            if self.settings.get("sort_pipfile"):
+                p[category] = dict(sorted(p[category].items()))
             self.write_toml(p)
             return True
         return False

--- a/pipenv/project.py
+++ b/pipenv/project.py
@@ -1227,7 +1227,7 @@ class Project:
 
         p[category][normalized_name] = entry
 
-        if self.settings.get("sort_alphabetical"):
+        if self.settings.get("sort_pipfile"):
             p[category] = dict(sorted(p[category].items()))
 
         # Write Pipfile.

--- a/pipenv/project.py
+++ b/pipenv/project.py
@@ -1111,6 +1111,9 @@ class Project:
                 return name
         return None
 
+    def _sort_category(self, category):
+        return dict(sorted(category.items()))
+
     def remove_package_from_pipfile(self, package_name, category):
         # Read and append Pipfile.
         name = self.get_package_name_in_pipfile(package_name, category=category)
@@ -1118,7 +1121,7 @@ class Project:
         if name:
             del p[category][name]
             if self.settings.get("sort_pipfile"):
-                p[category] = dict(sorted(p[category].items()))
+                p[category] = self._sort_category(p[category])
             self.write_toml(p)
             return True
         return False
@@ -1230,7 +1233,7 @@ class Project:
         p[category][normalized_name] = entry
 
         if self.settings.get("sort_pipfile"):
-            p[category] = dict(sorted(p[category].items()))
+            p[category] = self._sort_category(p[category])
 
         # Write Pipfile.
         self.write_toml(p)

--- a/pipenv/project.py
+++ b/pipenv/project.py
@@ -1226,7 +1226,9 @@ class Project:
             newly_added = True
 
         p[category][normalized_name] = entry
-        p[category] = dict(sorted(p[category].items()))
+
+        if self.settings.get("sort_alphabetical"):
+            p[category] = dict(sorted(p[category].items()))
 
         # Write Pipfile.
         self.write_toml(p)

--- a/pipenv/project.py
+++ b/pipenv/project.py
@@ -1112,7 +1112,14 @@ class Project:
         return None
 
     def _sort_category(self, category):
-        return dict(sorted(category.items()))
+        # toml tables won't maintain sorted dictionary order
+        # so construct the table in the order that we need
+        sorted_category = dict(sorted(category.items()))
+        table = tomlkit.table()
+        for key, value in sorted_category.items():
+            table.add(key, value)
+
+        return table
 
     def remove_package_from_pipfile(self, package_name, category):
         # Read and append Pipfile.

--- a/pipenv/project.py
+++ b/pipenv/project.py
@@ -1226,6 +1226,7 @@ class Project:
             newly_added = True
 
         p[category][normalized_name] = entry
+        p[category] = dict(sorted(p[category].items()))
 
         # Write Pipfile.
         self.write_toml(p)

--- a/tests/integration/test_install_basic.py
+++ b/tests/integration/test_install_basic.py
@@ -557,9 +557,30 @@ dataclasses-json = {file = "https://files.pythonhosted.org/packages/85/94/1b3021
         c = p.pipenv("""run python -c "from dataclasses_json import dataclass_json" """)
         assert c.returncode == 0
 
+
 @pytest.mark.basic
 @pytest.mark.install
-def test_packages_sorted_alphabetically_in_category(pipenv_instance_private_pypi):
+def test_category_sorted_alphabetically_with_directive(pipenv_instance_private_pypi):
+    with pipenv_instance_private_pypi() as p:
+        with open(p.pipfile_path, "w") as f:
+            contents = """
+[pipenv]
+sort_alphabetical = true
+
+[packages]
+atomicwrites = "*"
+colorama = "*"
+            """.strip()
+            f.write(contents)
+        c = p.pipenv("install build")
+        assert c.returncode == 0
+        assert "build" in p.pipfile["packages"]
+        assert list(p.pipfile["packages"].keys()) == ["atomicwrites", "build", "colorama"]
+
+
+@pytest.mark.basic
+@pytest.mark.install
+def test_category_not_sorted_without_directive(pipenv_instance_private_pypi):
     with pipenv_instance_private_pypi() as p:
         with open(p.pipfile_path, "w") as f:
             contents = """
@@ -571,5 +592,8 @@ colorama = "*"
         c = p.pipenv("install build")
         assert c.returncode == 0
         assert "build" in p.pipfile["packages"]
-        assert list(p.pipfile["packages"].keys()) == ["atomicwrites", "build", "colorama"]
-
+        assert list(p.pipfile["packages"].keys()) == [
+            "atomicwrites",
+            "colorama",
+            "build",
+        ]

--- a/tests/integration/test_install_basic.py
+++ b/tests/integration/test_install_basic.py
@@ -565,7 +565,7 @@ def test_category_sorted_alphabetically_with_directive(pipenv_instance_private_p
         with open(p.pipfile_path, "w") as f:
             contents = """
 [pipenv]
-sort_alphabetical = true
+sort_pipfile = true
 
 [packages]
 atomicwrites = "*"

--- a/tests/integration/test_install_basic.py
+++ b/tests/integration/test_install_basic.py
@@ -580,6 +580,34 @@ colorama = "*"
 
 @pytest.mark.basic
 @pytest.mark.install
+def test_sorting_handles_str_values_and_dict_values(pipenv_instance_private_pypi):
+    with pipenv_instance_private_pypi() as p:
+        with open(p.pipfile_path, "w") as f:
+            contents = """
+[pipenv]
+sort_pipfile = true
+
+[packages]
+zipp = {version = "*"}
+parse = "*"
+colorama = "*"
+atomicwrites = {version = "*"}
+            """.strip()
+            f.write(contents)
+        c = p.pipenv("install build")
+        assert c.returncode == 0
+        assert "build" in p.pipfile["packages"]
+        assert list(p.pipfile["packages"].keys()) == [
+            "atomicwrites",
+            "build",
+            "colorama",
+            "parse",
+            "zipp",
+        ]
+
+
+@pytest.mark.basic
+@pytest.mark.install
 def test_category_not_sorted_without_directive(pipenv_instance_private_pypi):
     with pipenv_instance_private_pypi() as p:
         with open(p.pipfile_path, "w") as f:

--- a/tests/integration/test_install_basic.py
+++ b/tests/integration/test_install_basic.py
@@ -556,3 +556,20 @@ dataclasses-json = {file = "https://files.pythonhosted.org/packages/85/94/1b3021
         assert c.returncode == 0
         c = p.pipenv("""run python -c "from dataclasses_json import dataclass_json" """)
         assert c.returncode == 0
+
+@pytest.mark.basic
+@pytest.mark.install
+def test_packages_sorted_alphabetically_in_category(pipenv_instance_private_pypi):
+    with pipenv_instance_private_pypi() as p:
+        with open(p.pipfile_path, "w") as f:
+            contents = """
+[packages]
+atomicwrites = "*"
+colorama = "*"
+            """.strip()
+            f.write(contents)
+        c = p.pipenv("install build")
+        assert c.returncode == 0
+        assert "build" in p.pipfile["packages"]
+        assert list(p.pipfile["packages"].keys()) == ["atomicwrites", "build", "colorama"]
+

--- a/tests/integration/test_uninstall.py
+++ b/tests/integration/test_uninstall.py
@@ -245,6 +245,7 @@ def test_uninstall_multiple_categories(pipenv_instance_private_pypi):
         assert "six" not in p.lockfile["default"]
 
 
+@pytest.mark.install
 @pytest.mark.uninstall
 def test_category_sorted_alphabetically_with_directive(pipenv_instance_private_pypi):
     with pipenv_instance_private_pypi() as p:
@@ -270,6 +271,7 @@ atomicwrites = "*"
         assert list(p.pipfile["packages"].keys()) == ["atomicwrites", "colorama", "parse"]
 
 
+@pytest.mark.install
 @pytest.mark.uninstall
 def test_category_not_sorted_without_directive(pipenv_instance_private_pypi):
     with pipenv_instance_private_pypi() as p:

--- a/tests/integration/test_uninstall.py
+++ b/tests/integration/test_uninstall.py
@@ -143,6 +143,7 @@ six = "==1.12.0"
         assert c.returncode == 0
 
 
+@pytest.mark.install
 @pytest.mark.uninstall
 def test_normalize_name_uninstall(pipenv_instance_private_pypi):
     with pipenv_instance_private_pypi() as p:
@@ -188,6 +189,7 @@ def test_uninstall_all_dev_with_shared_dependencies(pipenv_instance_pypi):
         assert "six" in p.lockfile["default"]
 
 
+@pytest.mark.install
 @pytest.mark.uninstall
 def test_uninstall_missing_parameters(pipenv_instance_private_pypi):
     with pipenv_instance_private_pypi() as p:
@@ -200,6 +202,7 @@ def test_uninstall_missing_parameters(pipenv_instance_private_pypi):
 
 
 @pytest.mark.categories
+@pytest.mark.install
 @pytest.mark.uninstall
 def test_uninstall_category_with_shared_requirement(pipenv_instance_pypi):
     with pipenv_instance_pypi() as p:
@@ -223,6 +226,7 @@ def test_uninstall_category_with_shared_requirement(pipenv_instance_pypi):
 
 
 @pytest.mark.categories
+@pytest.mark.install
 @pytest.mark.uninstall
 def test_uninstall_multiple_categories(pipenv_instance_private_pypi):
     with pipenv_instance_private_pypi() as p:

--- a/tests/integration/test_uninstall.py
+++ b/tests/integration/test_uninstall.py
@@ -277,6 +277,36 @@ atomicwrites = "*"
 
 @pytest.mark.install
 @pytest.mark.uninstall
+def test_sorting_handles_str_values_and_dict_values(pipenv_instance_private_pypi):
+    with pipenv_instance_private_pypi() as p:
+        with open(p.pipfile_path, "w") as f:
+            contents = """
+[pipenv]
+sort_pipfile = true
+
+[packages]
+zipp = "*"
+parse = {version = "*"}
+colorama = "*"
+build = "*"
+atomicwrites = {version = "*"}
+            """.strip()
+            f.write(contents)
+        c = p.pipenv("install")
+        assert c.returncode == 0
+
+        c = p.pipenv("uninstall build")
+        assert c.returncode == 0
+        assert "build" not in p.pipfile["packages"]
+        assert list(p.pipfile["packages"].keys()) == [
+            "atomicwrites",
+            "colorama",
+            "parse",
+            "zipp",
+        ]
+
+@pytest.mark.install
+@pytest.mark.uninstall
 def test_category_not_sorted_without_directive(pipenv_instance_private_pypi):
     with pipenv_instance_private_pypi() as p:
         with open(p.pipfile_path, "w") as f:

--- a/tests/integration/test_upgrade.py
+++ b/tests/integration/test_upgrade.py
@@ -1,0 +1,52 @@
+import pytest
+
+
+@pytest.mark.upgrade
+def test_category_sorted_alphabetically_with_directive(pipenv_instance_private_pypi):
+    with pipenv_instance_private_pypi() as p:
+        with open(p.pipfile_path, "w") as f:
+            contents = """
+[pipenv]
+sort_pipfile = true
+
+[packages]
+zipp = "*"
+six = 1.11
+colorama = "*"
+atomicwrites = "*"
+            """.strip()
+            f.write(contents)
+
+        package_name = "six"
+        c = p.pipenv(f"upgrade {package_name}")
+        assert c.returncode == 0
+        assert list(p.pipfile["packages"].keys()) == [
+            "atomicwrites",
+            "colorama",
+            "six",
+            "zipp",
+        ]
+
+
+@pytest.mark.upgrade
+def test_category_not_sorted_without_directive(pipenv_instance_private_pypi):
+    with pipenv_instance_private_pypi() as p:
+        with open(p.pipfile_path, "w") as f:
+            contents = """
+[packages]
+zipp = "*"
+six = 1.11
+colorama = "*"
+atomicwrites = "*"
+            """.strip()
+            f.write(contents)
+
+        package_name = "six"
+        c = p.pipenv(f"upgrade {package_name}")
+        assert c.returncode == 0
+        assert list(p.pipfile["packages"].keys()) == [
+            "zipp",
+            "six",
+            "colorama",
+            "atomicwrites",
+        ]


### PR DESCRIPTION
Add a new `[pipenv]` directive to sort package names alphabetically inside the category, for easier reading.

- [x] sort on `install`
- [x] sort on `uninstall`
- [ ] sort on `upgrade`
- [ ] Does this need to run on `update`?

--

Unsure if this is the best place or way to implement. Small prototype to add to discussion in https://github.com/pypa/pipenv/issues/5964 .

Tests:

before patch:

```
AssertionError: assert ['atomicwrite...ama', 'build'] == ['atomicwrite...', 'colorama']
  At index 1 diff: 'colorama' != 'build'
  Full diff:
  - ['atomicwrites', 'build', 'colorama']
  ?                  ---------
  + ['atomicwrites', 'colorama', 'build']
  ?                            +++++++++
```

after patch: pass.

------

### The checklist

* [x] Associated issue
* [ ] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.
