### PR TITLE
Change `--py` to use `print` instead of `console.print`

### DIFF
--- a/news/5969.behavior.rst
+++ b/news/5969.behavior.rst
@@ -1,0 +1,1 @@
+Change ``--py`` to use ``print`` preventing insertion of newline characters

--- a/pipenv/cli/command.py
+++ b/pipenv/cli/command.py
@@ -27,7 +27,6 @@ from pipenv.utils.processes import subprocess_run
 from pipenv.vendor.click import (
     Choice,
     argument,
-    echo,
     edit,
     group,
     option,
@@ -769,7 +768,7 @@ def do_py(project, ctx=None, system=False, bare=False):
         ctx.abort()
 
     try:
-        (echo if bare else console.print)(project._which("python", allow_global=system))
+        (print if bare else console.print)(project._which("python", allow_global=system))
     except AttributeError:
         console.print("No project found!", style="red")
         ctx.abort()

--- a/pipenv/cli/command.py
+++ b/pipenv/cli/command.py
@@ -27,6 +27,7 @@ from pipenv.utils.processes import subprocess_run
 from pipenv.vendor.click import (
     Choice,
     argument,
+    echo,
     edit,
     group,
     option,
@@ -125,7 +126,7 @@ def cli(
             do_where(state.project, bare=True)
             return 0
         elif py:
-            do_py(state.project, ctx=ctx)
+            do_py(state.project, ctx=ctx, bare=True)
             return 0
         # --support was passed...
         elif support:
@@ -758,7 +759,7 @@ if __name__ == "__main__":
     cli()
 
 
-def do_py(project, ctx=None, system=False):
+def do_py(project, ctx=None, system=False, bare=False):
     if not project.virtualenv_exists:
         err.print(
             "[red]No virtualenv has been created for this project[/red] "
@@ -768,6 +769,7 @@ def do_py(project, ctx=None, system=False):
         ctx.abort()
 
     try:
-        console.print(project._which("python", allow_global=system))
+        (echo if bare else console.print)(project._which("python", allow_global=system))
     except AttributeError:
         console.print("No project found!", style="red")
+        ctx.abort()


### PR DESCRIPTION
### The issue

#5969 

### The fix

Similar to `do_where(bare=True)`, the PR adds the argument `bare=False` to `do_py` and calls it with `bare=True`.
Like `--venv`, it will use `print` instead of `console.print`. (`do_where` uses `click.echo`)


### The checklist

* [x] Associated issue
* [x] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.