### PR TITLE
ci: fix ruff linter

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -12,4 +12,4 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - run: pip install --user ruff
-    - run: ruff --format=github .
+    - run: ruff --output-format=github .

--- a/news/5983.trivial.rst
+++ b/news/5983.trivial.rst
@@ -1,0 +1,1 @@
+Update Ruff linter in CI to remove deperecated option "--format"


### PR DESCRIPTION


### The issue

Ruff linter had stopped working due to a deprecated argument being used in our CI.
This PR aims to fix #5983

### The fix

In our GitHub actions for Ruff linter, we use the new option of `--output-format` instead of deprecated "--format"

### The checklist

* [x] Associated issue: #5983
* [x] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

<!--
### If this is a patch to the `vendor` directory...

Please try to refrain from submitting patches directly to `vendor` or `patched`, but raise your issue to the upstream project instead, and inform Pipenv to upgrade when the upstream project accepts the fix.

A pull request to upgrade vendor packages is strongly discouraged, unless there is a very good reason (e.g. you need to test Pipenv’s integration to a new vendor feature). Pipenv audits and performs vendor upgrades regularly, generally before a new release is about to drop.

If your patch is not or cannot be accepted by upstream, but is essential to Pipenv (make sure to discuss this with maintainers!), please remember to attach a patch file in `tasks/vendoring/patched`, so this divergence from upstream can be recorded and replayed afterwards.
-->
