### PR TITLE
Update advanced.md to restore Automatic Python Installation header

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -269,6 +269,8 @@ Note
 
 The standard `EDITOR` environment variable is used for this. If you're using VS Code, for example, you'll want to `export EDITOR=code` (if you're on macOS you will want to [install the command](https://code.visualstudio.com/docs/setup/mac#_launching-from-the-command-line) on to your `PATH` first).
 
+## ☤ Automatic Python Installation
+
 This is a very fancy feature, and we're very proud of it:
 
     $ cat Pipfile


### PR DESCRIPTION
### The issue

The docs header "Automatic Python Installation" was inadvertently removed in https://github.com/pypa/pipenv/pull/5909. 

### The fix

Added it back in, where it was before.

### The checklist

N/A, this just corrects a docs typo.

P.S.: I did notice the docs search still identified "Automatic Python Installation" as a heading when e.g. searching for "pyenv", even though it no longer appeared. Is there some search index that should be regenerated?