### PR TITLE
Simplify sorting code

### DIFF
--- a/pipenv/project.py
+++ b/pipenv/project.py
@@ -1114,9 +1114,8 @@ class Project:
     def _sort_category(self, category):
         # toml tables won't maintain sorted dictionary order
         # so construct the table in the order that we need
-        sorted_category = dict(sorted(category.items()))
         table = tomlkit.table()
-        for key, value in sorted_category.items():
+        for key, value in sorted(category.items()):
             table.add(key, value)
 
         return table


### PR DESCRIPTION
For https://github.com/pypa/pipenv/issues/5964
As suggested in https://github.com/pypa/pipenv/pull/5965

We don't need to cast to `dict` first, we can just sort.

### The checklist

* [x] Associated issue
* [ ] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.
