### PR TITLE
New branch, removes empty flag in SVN install command. Fixes SVN inst…

### DIFF
--- a/news/5993.bugfix.rst
+++ b/news/5993.bugfix.rst
@@ -1,0 +1,1 @@
+Removing empty string argument from SVN command to fix SVN installs.

--- a/pipenv/patched/pip/_internal/vcs/subversion.py
+++ b/pipenv/patched/pip/_internal/vcs/subversion.py
@@ -288,17 +288,22 @@ class Subversion(VersionControl):
             display_path(dest),
         )
         if verbosity <= 0:
-            flag = "--quiet"
+            cmd_args = make_command(
+                "checkout",
+                "--quiet",
+                self.get_remote_call_options(),
+                rev_options.to_args(),
+                url,
+                dest,
+            )
         else:
-            flag = ""
-        cmd_args = make_command(
-            "checkout",
-            flag,
-            self.get_remote_call_options(),
-            rev_options.to_args(),
-            url,
-            dest,
-        )
+            cmd_args = make_command(
+                "checkout",
+                self.get_remote_call_options(),
+                rev_options.to_args(),
+                url,
+                dest,
+            )
         self.run_command(cmd_args)
 
     def switch(self, dest: str, url: HiddenText, rev_options: RevOptions) -> None:


### PR DESCRIPTION
…alls

Thank you for contributing to Pipenv!


### The issue

This branch fixes pipenv install of SVN repos. Pipenv was adding and extra empty argument when the verbosity flag was <= 0. This empty string was causing an error with SVN checkout commands.

### The fix

This pull request removes the empty flag from the command arguments when the verbosity is not set.
