### PR TITLE
Pass through pipfile index urls when creating https session so that keyring fully works

### DIFF
--- a/news/5994.bugfix.rst
+++ b/news/5994.bugfix.rst
@@ -1,0 +1,1 @@
+Pass through pipfile index urls when creating https session so that keyring fully works

--- a/pipenv/project.py
+++ b/pipenv/project.py
@@ -239,7 +239,7 @@ class Project:
         if self.sessions.get(source["name"]):
             session = self.sessions[source["name"]]
         else:
-            session = get_requests_session(                
+            session = get_requests_session(
                 self.s.PIPENV_MAX_RETRIES,
                 source.get("verify_ssl", True),
                 cache_dir=self.s.PIPENV_CACHE_DIR,

--- a/pipenv/project.py
+++ b/pipenv/project.py
@@ -239,10 +239,11 @@ class Project:
         if self.sessions.get(source["name"]):
             session = self.sessions[source["name"]]
         else:
-            session = get_requests_session(
+            session = get_requests_session(                
                 self.s.PIPENV_MAX_RETRIES,
                 source.get("verify_ssl", True),
                 cache_dir=self.s.PIPENV_CACHE_DIR,
+                source=source.get("url"),
             )
             self.sessions[source["name"]] = session
         return session

--- a/pipenv/utils/internet.py
+++ b/pipenv/utils/internet.py
@@ -8,10 +8,11 @@ from pipenv.patched.pip._internal.network.download import PipSession
 from pipenv.patched.pip._vendor.urllib3 import util as urllib3_util
 
 
-def get_requests_session(max_retries=1, verify_ssl=True, cache_dir=USER_CACHE_DIR):
+def get_requests_session(max_retries=1, verify_ssl=True, cache_dir=USER_CACHE_DIR, source=None):
     """Load requests lazily."""
     pip_client_cert = os.environ.get("PIP_CLIENT_CERT")
-    requests_session = PipSession(cache=cache_dir, retries=max_retries)
+    index_urls = [source] if source else None
+    requests_session = PipSession(cache=cache_dir, retries=max_retries, index_urls=index_urls)
     if pip_client_cert:
         requests_session.cert = pip_client_cert
     if verify_ssl is False:

--- a/pipenv/utils/internet.py
+++ b/pipenv/utils/internet.py
@@ -8,11 +8,15 @@ from pipenv.patched.pip._internal.network.download import PipSession
 from pipenv.patched.pip._vendor.urllib3 import util as urllib3_util
 
 
-def get_requests_session(max_retries=1, verify_ssl=True, cache_dir=USER_CACHE_DIR, source=None):
+def get_requests_session(
+    max_retries=1, verify_ssl=True, cache_dir=USER_CACHE_DIR, source=None
+):
     """Load requests lazily."""
     pip_client_cert = os.environ.get("PIP_CLIENT_CERT")
     index_urls = [source] if source else None
-    requests_session = PipSession(cache=cache_dir, retries=max_retries, index_urls=index_urls)
+    requests_session = PipSession(
+        cache=cache_dir, retries=max_retries, index_urls=index_urls
+    )
     if pip_client_cert:
         requests_session.cert = pip_client_cert
     if verify_ssl is False:


### PR DESCRIPTION
### The issue

See https://github.com/pypa/pipenv/issues/5751#issuecomment-1773922272 and ramblings thereafter

Prior to this fix, `pipenv lock` would work, but with warnings because some calls within pipenv correctly used keyring, but others didn't:

> Locking [packages] dependencies...
> Building requirements...
> Resolving dependencies...
> Success!
> [====] Locking...Warning: WARNING:pipenv.patched.pip._internal.network.auth:Keyring is skipped due to an exception: expected str, bytes or os.PathLike object, not NoneType
> Locking [dev-packages] dependencies...
> Building requirements...
> Resolving dependencies...
> Success!
> [ =] Locking...Warning: WARNING:pipenv.patched.pip._internal.network.auth:Keyring is skipped due to an exception: expected str, bytes or os.PathLike object, not NoneType

With this fix in place, I no longer get any warnings as all calls to the pip repo use keyring:


> Locking [packages] dependencies...
> Building requirements...
> Resolving dependencies...
> Success!
> Locking [dev-packages] dependencies...
> Building requirements...
> Resolving dependencies...
> Success!

### The fix

How does this pull request fix your problem? Did you consider any alternatives? Why is this the *best* solution, in your opinion?


### The checklist

* [ ] Associated issue
* [x] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.
