### PR TITLE
Add markers to Pipfile when parsing requirements.txt

### DIFF
--- a/news/6008.bugfix.rst
+++ b/news/6008.bugfix.rst
@@ -1,0 +1,1 @@
+Add markers to Pipfile when parsing requirements.txt

--- a/pipenv/utils/requirements.py
+++ b/pipenv/utils/requirements.py
@@ -100,7 +100,7 @@ def import_requirements(project, r=None, dev=False, categories=None):
             else:
                 package_string = str(package.req)
                 if package.markers:
-                    package_string += f' ; {package.markers}'
+                    package_string += f" ; {package.markers}"
                 if categories:
                     for category in categories:
                         project.add_package_to_pipfile(

--- a/pipenv/utils/requirements.py
+++ b/pipenv/utils/requirements.py
@@ -98,13 +98,16 @@ def import_requirements(project, r=None, dev=False, categories=None):
                 else:
                     project.add_package_to_pipfile(package, package_string, dev=dev)
             else:
+                package_string = str(package.req)
+                if package.markers:
+                    package_string += f' ; {package.markers}'
                 if categories:
                     for category in categories:
                         project.add_package_to_pipfile(
-                            package, str(package.req), dev=dev, category=category
+                            package, package_string, dev=dev, category=category
                         )
                 else:
-                    project.add_package_to_pipfile(package, str(package.req), dev=dev)
+                    project.add_package_to_pipfile(package, package_string, dev=dev)
     indexes = sorted(set(indexes))
     trusted_hosts = sorted(set(trusted_hosts))
     for index in indexes:


### PR DESCRIPTION
If there are markers specified in requirements.txt they are not currently transferred to Pipfile while generating it. This commit adds markers to Pipfile as defined in requirements.txt

### The issue

Using Pipenv with requirements.txt fails when generating Pipfile if there are markers defined in requirements.txt and those markers are for example specifying diffrent os.  For example this requirements.txt:
`windows-curses==2.3.1 ; sys_platform == 'win32' and python_version == '3.11'`
When run under Linux OS with:
`pipenv install -r requirements.txt`
Throws the following error:
```CRITICAL:pipenv.patched.pip._internal.resolution.resolvelib.factory:Could not find a version that satisfies the requirement windows-curses==2.3.1 (from versions: none)
[ResolutionFailure]:   File "/home/geonik/Project/piptest/venv/lib/python3.11/site-packages/pipenv/resolver.py", line 704, in _main
[ResolutionFailure]:       resolve_packages(
[ResolutionFailure]:   File "/home/geonik/Project/piptest/venv/lib/python3.11/site-packages/pipenv/resolver.py", line 662, in resolve_packages
[ResolutionFailure]:       results, resolver = resolve(
[ResolutionFailure]:       ^^^^^^^^
[ResolutionFailure]:   File "/home/geonik/Project/piptest/venv/lib/python3.11/site-packages/pipenv/resolver.py", line 642, in resolve
[ResolutionFailure]:       return resolve_deps(
[ResolutionFailure]:       ^^^^^^^^^^^^^
[ResolutionFailure]:   File "/home/geonik/Project/piptest/venv/lib/python3.11/site-packages/pipenv/utils/resolver.py", line 1173, in resolve_deps
[ResolutionFailure]:       results, hashes, markers_lookup, resolver, skipped = actually_resolve_deps(
[ResolutionFailure]:       ^^^^^^^^^^^^^^^^^^^^^^
[ResolutionFailure]:   File "/home/geonik/Project/piptest/venv/lib/python3.11/site-packages/pipenv/utils/resolver.py", line 953, in actually_resolve_deps
[ResolutionFailure]:       resolver.resolve()
[ResolutionFailure]:   File "/home/geonik/Project/piptest/venv/lib/python3.11/site-packages/pipenv/utils/resolver.py", line 694, in resolve
[ResolutionFailure]:       raise ResolutionFailure(message=str(e))
[pipenv.exceptions.ResolutionFailure]: Warning: Your dependencies could not be resolved. You likely have a mismatch in your sub-dependencies.
  You can use $ pipenv run pip install <requirement_name> to bypass this mechanism, then run $ pipenv graph to inspect the versions actually installed in the virtualenv.
  Hint: try $ pipenv lock --pre if it is a pre-release dependency.
ERROR: No matching distribution found for windows-curses==2.3.1

Traceback (most recent call last):
  File "/home/geonik/Project/piptest/venv/bin/pipenv", line 8, in <module>
    sys.exit(cli())
             ^^^^^
  File "/home/geonik/Project/piptest/venv/lib/python3.11/site-packages/pipenv/vendor/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/geonik/Project/piptest/venv/lib/python3.11/site-packages/pipenv/cli/options.py", line 58, in main
    return super().main(*args, **kwargs, windows_expand_args=False)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/geonik/Project/piptest/venv/lib/python3.11/site-packages/pipenv/vendor/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/home/geonik/Project/piptest/venv/lib/python3.11/site-packages/pipenv/vendor/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/geonik/Project/piptest/venv/lib/python3.11/site-packages/pipenv/vendor/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/geonik/Project/piptest/venv/lib/python3.11/site-packages/pipenv/vendor/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/geonik/Project/piptest/venv/lib/python3.11/site-packages/pipenv/vendor/click/decorators.py", line 84, in new_func
    return ctx.invoke(f, obj, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/geonik/Project/piptest/venv/lib/python3.11/site-packages/pipenv/vendor/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/geonik/Project/piptest/venv/lib/python3.11/site-packages/pipenv/cli/command.py", line 233, in install
    do_install(
  File "/home/geonik/Project/piptest/venv/lib/python3.11/site-packages/pipenv/routines/install.py", line 170, in do_install
    do_init(
  File "/home/geonik/Project/piptest/venv/lib/python3.11/site-packages/pipenv/routines/install.py", line 743, in do_init
    do_lock(
  File "/home/geonik/Project/piptest/venv/lib/python3.11/site-packages/pipenv/routines/lock.py", line 65, in do_lock
    venv_resolve_deps(
  File "/home/geonik/Project/piptest/venv/lib/python3.11/site-packages/pipenv/utils/resolver.py", line 1116, in venv_resolve_deps
    c = resolve(cmd, st, project=project)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/geonik/Project/piptest/venv/lib/python3.11/site-packages/pipenv/utils/resolver.py", line 991, in resolve
    raise RuntimeError("Failed to lock Pipfile.lock!")
RuntimeError: Failed to lock Pipfile.lock!
```


### The fix

This PR fixes the problem mentioned by supplying back the markers to Pipfile generator

### The checklist

* [] Associated issue
* [x] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.