### PR TITLE
Ignore existing venv dir when PIPENV_VENV_IN_PROJECT is false

### DIFF
--- a/pipenv/project.py
+++ b/pipenv/project.py
@@ -426,15 +426,11 @@ class Project:
 
         dot_venv = os.path.join(self.project_directory, ".venv")
 
-        # If there's no .venv in project root, set location based on config.
-        if not os.path.exists(dot_venv):
+        # If there's no .venv in project root or it is a folder, set location based on config.
+        if not os.path.exists(dot_venv) or os.path.isdir(dot_venv):
             if self.is_venv_in_project():
                 return dot_venv
             return str(get_workon_home().joinpath(self.virtualenv_name))
-
-        # If .venv in project root is a directory, use it.
-        if os.path.isdir(dot_venv):
-            return dot_venv
 
         # Now we assume .venv in project root is a file. Use its content.
         with open(dot_venv) as f:


### PR DESCRIPTION
Hi !

### The issue

I have a project installed on my host (macOS) which use the `PIPENV_VENV_IN_PROJECT=1` env vars to install pipenv deps into `my_project/.venv` folder. Now I am working on a docker-compose setup, which has another Python version, with the local project bind mounted into the container.

In the Dockerfile, I am only copying Pipfiles and running `pipenv install` with `PIPENV_VENV_IN_PROJECT=0` so that the venv is built specifically for this container env and embedded in the docker image.

With my local code mounted inside the container, alongside the host `.venv`, I was expecting `pipenv` commands to follow `PIPENV_VENV_IN_PROJECT=0` set inside the container context and ignore the mounted `.venv`.

Turns out, it is not working even though the documentation clearly states:
```
self.PIPENV_VENV_IN_PROJECT = get_from_env("VENV_IN_PROJECT")
""" When set True, will create or use the ``.venv`` in your project directory.
When Set False, will ignore the .venv in your project directory even if it exists.
If unset (default), will use the .venv of project directory should it exist, otherwise
will create new virtual environments in a global location.
"""
```

This issue was already raised in this comment https://github.com/pypa/pipenv/issues/2763#issuecomment-1083715772

### The fix

Tweaked the `get_location_for_virtualenv` function to adjust loading priorities based on the expected behavior and added an integration test
