### PR TITLE
Make `project.get_default_index()` populate a default name

### DIFF
--- a/news/6021.bugfix.rst
+++ b/news/6021.bugfix.rst
@@ -1,0 +1,1 @@
+Fix KeyError when using a source without a name in Pipfile

--- a/pipenv/project.py
+++ b/pipenv/project.py
@@ -1023,7 +1023,7 @@ class Project:
         return sources
 
     def get_default_index(self):
-        return self.pipfile_sources()[0]
+        return self.populate_source(self.pipfile_sources()[0])
 
     def get_index_by_name(self, index_name):
         for source in self.pipfile_sources():


### PR DESCRIPTION
### The issue

Running pipenv with a `Pipfile` using a source without a name, like

```
[[source]]
url = "https://pypi.python.org/simple"
verify_ssl = true

[dev-packages]
"flake8" = "*"
mypy = "*"
pydocstyle = "*"
pylint = "*"
twine = "*"

[packages]
aiodns = "*"
aiohttp = "*"
async-timeout = "*"
```

results in a missing key error:

```
Traceback (most recent call last):
  File "/usr/local/.pyenv/versions/3.11.5/lib/python3.11/site-packages/pipenv/resolver.py", line 675, in <module>
    main()
  File "/usr/local/.pyenv/versions/3.11.5/lib/python3.11/site-packages/pipenv/resolver.py", line 661, in main
    _main(
  File "/usr/local/.pyenv/versions/3.11.5/lib/python3.11/site-packages/pipenv/resolver.py", line 645, in _main
    resolve_packages(
  File "/usr/local/.pyenv/versions/3.11.5/lib/python3.11/site-packages/pipenv/resolver.py", line 612, in resolve_packages
    results, resolver = resolve(
                        ^^^^^^^^
  File "/usr/local/.pyenv/versions/3.11.5/lib/python3.11/site-packages/pipenv/resolver.py", line 592, in resolve
    return resolve_deps(
           ^^^^^^^^^^^^^
  File "/usr/local/.pyenv/versions/3.11.5/lib/python3.11/site-packages/pipenv/utils/resolver.py", line 910, in resolve_deps
    results, hashes, internal_resolver = actually_resolve_deps(
                                         ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/.pyenv/versions/3.11.5/lib/python3.11/site-packages/pipenv/utils/resolver.py", line 672, in actually_resolve_deps
    resolver = Resolver.create(
               ^^^^^^^^^^^^^^^^
  File "/usr/local/.pyenv/versions/3.11.5/lib/python3.11/site-packages/pipenv/utils/resolver.py", line 222, in create
    index_lookup[package_name] = project.get_default_index()["name"]
                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^
KeyError: 'name'

```

### The fix

My fix is to populate the source with a default name. My initial take was raising a proper error but then I saw that providing a default name was already handled in other places so I figured this was the right solution.

### The checklist

* [ ] Associated issue
* [x] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

<!--
### If this is a patch to the `vendor` directory...

Please try to refrain from submitting patches directly to `vendor` or `patched`, but raise your issue to the upstream project instead, and inform Pipenv to upgrade when the upstream project accepts the fix.

A pull request to upgrade vendor packages is strongly discouraged, unless there is a very good reason (e.g. you need to test Pipenv’s integration to a new vendor feature). Pipenv audits and performs vendor upgrades regularly, generally before a new release is about to drop.

If your patch is not or cannot be accepted by upstream, but is essential to Pipenv (make sure to discuss this with maintainers!), please remember to attach a patch file in `tasks/vendoring/patched`, so this divergence from upstream can be recorded and replayed afterwards.
-->
