### PR TITLE
Chore: Resolve CI deprecation warnings

### DIFF
--- a/.github/workflows/pypi_upload.yml
+++ b/.github/workflows/pypi_upload.yml
@@ -19,18 +19,17 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Create Release
       id: create_release
-      uses: actions/create-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      uses: ncipollo/release-action@v1
       with:
-        tag_name: ${{ github.ref }}
-        release_name: Release ${{ github.ref }}
+        tag: ${{ github.ref }}
+        name: Release ${{ github.ref_name }}
         draft: false
         prerelease: false
+        token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Set up Python 3.10
       uses: actions/setup-python@v4
@@ -56,7 +55,7 @@ jobs:
         user: __token__
         password: ${{ secrets.PYPI_TOKEN }}
         # repository_url: https://test.pypi.org/legacy/
-        packages_dir: dist/
+        packages-dir: dist/
 
     # git push https://${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git HEAD:master
     # we need to use a deploy key for this to get around branch protection as the default token fails


### PR DESCRIPTION
Thank you for contributing to Pipenv!


### The issue

Fixes #6015 

### The fix

By changing the release creation action from the archived, no longer receiving updates version to a new, updated and working version.  The [releases look the same as here](https://github.com/stumpylog/pipenv/releases) with the new version.  All the actions run without warnings now:
- CI: https://github.com/stumpylog/pipenv/actions/runs/6960511112
- Upload: https://github.com/stumpylog/pipenv/actions/runs/6960554210
Obviously with failures as I can't push to PyPi, but it gets far enough to see no warnings

### The checklist

* [x] Associated issue
* [ ] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

Not sure a simple update like this is worth of a news fragment?

<!--
### If this is a patch to the `vendor` directory...

Please try to refrain from submitting patches directly to `vendor` or `patched`, but raise your issue to the upstream project instead, and inform Pipenv to upgrade when the upstream project accepts the fix.

A pull request to upgrade vendor packages is strongly discouraged, unless there is a very good reason (e.g. you need to test Pipenv’s integration to a new vendor feature). Pipenv audits and performs vendor upgrades regularly, generally before a new release is about to drop.

If your patch is not or cannot be accepted by upstream, but is essential to Pipenv (make sure to discuss this with maintainers!), please remember to attach a patch file in `tasks/vendoring/patched`, so this divergence from upstream can be recorded and replayed afterwards.
-->
