### PR TITLE
Fix for the safety test failure in the CI

### DIFF
--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -150,6 +150,8 @@ def test_pipenv_check(pipenv_instance_private_pypi):
         assert c.returncode == 0
         c = p.pipenv('install six')
         assert c.returncode == 0
+        c = p.pipenv("run python -m pip install --upgrade pip")
+        assert c.returncode == 0
         # Note: added
         # 51457: py <=1.11.0 resolved (1.11.0 installed)!
         # this is installed via pytest, and causes a false positive


### PR DESCRIPTION
Thank you for contributing to Pipenv!


### The issue

Safety test for some reason is picking up an old pip version.

### The fix

Ensure the test itself upgrades pip.


### The checklist

* [X] Associated issue
* [ ] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.
