### PR TITLE
Fixed a bug with locking packages with non canonical names

### DIFF
--- a/news/6056.bugfix.rst
+++ b/news/6056.bugfix.rst
@@ -1,0 +1,1 @@
+Fix a bug with locking projects that contains packages with non canonical names from private indexes

--- a/pipenv/patched/pip/_internal/resolution/resolvelib/factory.py
+++ b/pipenv/patched/pip/_internal/resolution/resolvelib/factory.py
@@ -247,7 +247,6 @@ class Factory:
         # Hopefully the Project model can correct this mismatch in the future.
         template = ireqs[0]
         assert template.req, "Candidates found on index must be PEP 508"
-        project_name = template.req.name
         name = canonicalize_name(template.req.name)
 
         extras: FrozenSet[str] = frozenset()
@@ -283,7 +282,7 @@ class Factory:
 
         def iter_index_candidate_infos() -> Iterator[IndexCandidateInfo]:
             result = self._finder.find_best_candidate(
-                project_name=project_name,
+                project_name=name,
                 specifier=specifier,
                 hashes=hashes,
             )

--- a/pipenv/patched/pip/_internal/resolution/resolvelib/factory.py
+++ b/pipenv/patched/pip/_internal/resolution/resolvelib/factory.py
@@ -247,6 +247,7 @@ class Factory:
         # Hopefully the Project model can correct this mismatch in the future.
         template = ireqs[0]
         assert template.req, "Candidates found on index must be PEP 508"
+        project_name = template.req.name
         name = canonicalize_name(template.req.name)
 
         extras: FrozenSet[str] = frozenset()
@@ -282,7 +283,7 @@ class Factory:
 
         def iter_index_candidate_infos() -> Iterator[IndexCandidateInfo]:
             result = self._finder.find_best_candidate(
-                project_name=name,
+                project_name=project_name,
                 specifier=specifier,
                 hashes=hashes,
             )

--- a/tests/integration/test_lock.py
+++ b/tests/integration/test_lock.py
@@ -285,6 +285,33 @@ pipenv-test-private-package = {version = "*", index = "testpypi"}
         assert c.returncode == 0
 
 
+@pytest.mark.lock
+@pytest.mark.index
+@pytest.mark.install  # private indexes need to be uncached for resolution
+@pytest.mark.requirements
+@pytest.mark.needs_internet
+def test_private_index_lock_requirements_for_not_canonical_package(pipenv_instance_private_pypi):
+    with pipenv_instance_private_pypi() as p:
+        with open(p.pipfile_path, 'w') as f:
+            contents = """
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[[source]]
+url = "https://test.pypi.org/simple"
+verify_ssl = true
+name = "testpypi"
+
+[packages]
+pipenv_test_private_package = {version = "*", index = "testpypi"}
+            """.strip()
+            f.write(contents)
+        c = p.pipenv('lock')
+        assert c.returncode == 0
+
+
 @pytest.mark.index
 @pytest.mark.install
 def test_lock_updated_source(pipenv_instance_private_pypi):


### PR DESCRIPTION
### The issue

Fix a bug with locking projects that contains packages with non canonical names from private indexes
More details here:
https://github.com/pypa/pipenv/issues/6056

### The checklist

* [ X] Associated issue
* [X ] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.
* [] Send a fix to pip ?