### PR TITLE
Only editable entry should trigger editable installs

### DIFF
--- a/news/6069.bugfix.rst
+++ b/news/6069.bugfix.rst
@@ -1,0 +1,1 @@
+Adjusted logic which assumed any file, path or VCS install should be considered editable.  Instead relies on the user specified editable flag to mark requirement as editable install.

--- a/pipenv/utils/dependencies.py
+++ b/pipenv/utils/dependencies.py
@@ -1207,9 +1207,7 @@ def is_required_version(version, specified_version):
 
 def is_editable(pipfile_entry):
     if hasattr(pipfile_entry, "get"):
-        return pipfile_entry.get("editable", False) or any(
-            pipfile_entry.get(key) for key in ("file", "path") + VCS_LIST
-        )
+        return pipfile_entry.get("editable", False)
     return False
 
 


### PR DESCRIPTION
Exploration of #6054 

### The checklist

* [X] Associated issue
* [ ] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.
