### PR TITLE
Use fancy mode for pwsh on *nix (draft)

### DIFF
--- a/pipenv/cli/command.py
+++ b/pipenv/cli/command.py
@@ -388,8 +388,12 @@ def shell(state, fancy=False, shell_args=None, anyway=False, quiet=False):
             sys.exit(1)
     # Load .env file.
     load_dot_env(state.project)
-    # Use fancy mode for Windows.
-    if os.name == "nt":
+    # Use fancy mode for Windows or pwsh on *nix.
+    if (
+        os.name == "nt"
+        or os.environ["PIPENV_SHELL"].split(os.path.sep)[-1] == "pwsh"
+        or os.environ["SHELL"].split(os.path.sep)[-1] == "pwsh"
+    ):
         fancy = True
     do_shell(
         state.project,

--- a/pipenv/cli/command.py
+++ b/pipenv/cli/command.py
@@ -391,8 +391,8 @@ def shell(state, fancy=False, shell_args=None, anyway=False, quiet=False):
     # Use fancy mode for Windows or pwsh on *nix.
     if (
         os.name == "nt"
-        or os.environ["PIPENV_SHELL"].split(os.path.sep)[-1] == "pwsh"
-        or os.environ["SHELL"].split(os.path.sep)[-1] == "pwsh"
+        or (os.environ.get("PIPENV_SHELL") or "").split(os.path.sep)[-1] == "pwsh"
+        or (os.environ.get("SHELL") or "").split(os.path.sep)[-1] == "pwsh"
     ):
         fancy = True
     do_shell(


### PR DESCRIPTION
Ran into this issue when attempting to activate pipenv environments using pwsh on mac. I'm not 100% sure this is the correct solution as the [documentation](https://docs.pipenv.org/basics/#about-shell-configuration) for fancy mode is sparse, but it seems the code enforces fancy mode if running on windows (because it's assumed it's pwsh?)

Definitely looking for some feedback. Thanks.

### The issue

Issue is described in https://github.com/pypa/pipenv/issues/6107

### The fix

Defaulting to fancy mode for pwsh on *nix


### The checklist

* [X] Associated issue
* [ ] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.
