### PR TITLE
Fix the issue(#6126): add lockfile_path presence in pipenv check command

### DIFF
--- a/news/6126.bugfix.rst
+++ b/news/6126.bugfix.rst
@@ -1,0 +1,1 @@
+Fix a bug that passes pipenv check command if Pipfile.lock not exist

--- a/pipenv/routines/check.py
+++ b/pipenv/routines/check.py
@@ -133,6 +133,9 @@ def do_check(
     else:
         if not quiet and not project.s.is_quiet():
             click.secho("Passed!", fg="green")
+    # Check for lockfile exists
+    if not project.lockfile_exists:
+        return
     if not quiet and not project.s.is_quiet():
         if use_installed:
             click.secho(


### PR DESCRIPTION
Thank you for contributing to Pipenv!


### The issue

This PR fixes issue #6126 

### The fix

I have added additional check of presence of lockfile in pipenv check command so that it doesn't fails if Pipfile.lock is not present.

### The checklist

* [X] Associated issue
* [x] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

