### PR TITLE
Add nested vcs dependency subdirectory when locking to Pipfile.lock (Fix #6120)

### DIFF
--- a/news/6136.bugfix.rst
+++ b/news/6136.bugfix.rst
@@ -1,0 +1,1 @@
+Fix a bug that vcs subdependencies were locked without their subdirectory fragment if they had one

--- a/tests/integration/test_lock.py
+++ b/tests/integration/test_lock.py
@@ -532,7 +532,8 @@ def test_lock_nested_vcs_direct_url(pipenv_instance_pypi):
         assert "git" in p.lockfile["default"]["pep508-package"]
         assert "sibling-package" in p.lockfile["default"]
         assert "git" in p.lockfile["default"]["sibling-package"]
-        assert "subdirectory" in p.lockfile["default"]["sibling-package"]["git"]
+        assert "subdirectory" in p.lockfile["default"]["sibling-package"]
+        assert p.lockfile["default"]["sibling-package"]["subdirectory"] == "parent_folder/sibling_package"
         assert "version" not in p.lockfile["default"]["sibling-package"]
 
 


### PR DESCRIPTION
### The issue
When installing a package that has a vcs dependency with a subdirectory, the subdirectory isn't added to the Pipfile.lock.

This is a tentative fix for #6120

### The fix

When formatting the vcs requirement for lockfile in `format_requirement_for_lockfile`

- `normalize_vcs_url` to clean the vcs's url as is done in `install_req_from_pipfile` - this removes the fragments from the url
- Inspect and add the `req.link.subdirectory_fragment` to the lockfile if parsed by the `Link` object

As discussed in #6120, alternatives could have been to honor #4259 and work on the install portion to be able to resolve correctly the Pipfile entry with the `subdirectory` as a vcs url fragment.


### The checklist

* [x] Associated issue
* [x] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.