### PR TITLE
pipenv upgrade invoke -d

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -22,7 +22,7 @@ parse = "*"
 importlib-metadata = {version = "*"}
 colorama= {version = "*", sys_platform = "== 'win32'"}
 myst-parser = {extras = ["linkify"], version = "*"}
-invoke = "==2.0.0"
+invoke = "*"
 exceptiongroup = "==1.1.0"
 tomli = "*"
 pyyaml = "==6.0.1"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "17bdb469468e202231af0ffdf68a89c9172c48d48d01d7c13971669fea641959"
+            "sha256": "cd0cb0cbad24f3667d1c1a9b9f08c8e8cedde82357a496e5575d12bee75da7c5"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -408,12 +408,12 @@
         },
         "invoke": {
             "hashes": [
-                "sha256:7ab5dd9cd76b787d560a78b1a9810d252367ab595985c50612702be21d671dd7",
-                "sha256:a860582bcf7a4b336fe18ef53937f0f28cec1c0053ffa767c2fcf7ba0b850f59"
+                "sha256:6ea924cc53d4f78e3d98bc436b08069a03077e6f85ad1ddaa8a116d7dad15820",
+                "sha256:ee6cbb101af1a859c7fe84f2a264c059020b0cb7fe3535f9424300ab568f6bd5"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.6'",
-            "version": "==2.0.0"
+            "version": "==2.2.0"
         },
         "jaraco.classes": {
             "hashes": [


### PR DESCRIPTION
Fixes #6137

No news fragment required as its our own internal pipfile.

### The checklist

* [X] Associated issue
* [ ] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.
