### PR TITLE
Add --from-pipfile subcommand to `pipenv requirements`

### DIFF
--- a/news/6156.feature.rst
+++ b/news/6156.feature.rst
@@ -1,0 +1,1 @@
+The ``pipenv requirements`` subcommand now supports the ``--from-pipfile`` flag. When this flag is used, the requirements file will only include the packages explicitly listed in the Pipfile, excluding any sub-packages.

--- a/pipenv/cli/command.py
+++ b/pipenv/cli/command.py
@@ -744,9 +744,21 @@ def verify(state):
     default="",
     help="Only add requirement of the specified categories.",
 )
+@option(
+    "--root-only",
+    is_flag=True,
+    default=False,
+    help="Only include root dependencies from Pipfile.",
+)
 @pass_state
 def requirements(
-    state, dev=False, dev_only=False, hash=False, exclude_markers=False, categories=""
+    state,
+    dev=False,
+    dev_only=False,
+    hash=False,
+    exclude_markers=False,
+    categories="",
+    root_only=False,
 ):
     from pipenv.routines.requirements import generate_requirements
 
@@ -757,6 +769,7 @@ def requirements(
         include_hashes=hash,
         include_markers=not exclude_markers,
         categories=categories,
+        root_only=root_only,
     )
 
 

--- a/pipenv/cli/command.py
+++ b/pipenv/cli/command.py
@@ -745,10 +745,10 @@ def verify(state):
     help="Only add requirement of the specified categories.",
 )
 @option(
-    "--root-only",
+    "--from-pipfile",
     is_flag=True,
     default=False,
-    help="Only include root dependencies from Pipfile.",
+    help="Only include dependencies from Pipfile.",
 )
 @pass_state
 def requirements(
@@ -758,7 +758,7 @@ def requirements(
     hash=False,
     exclude_markers=False,
     categories="",
-    root_only=False,
+    from_pipfile=False,
 ):
     from pipenv.routines.requirements import generate_requirements
 
@@ -769,7 +769,7 @@ def requirements(
         include_hashes=hash,
         include_markers=not exclude_markers,
         categories=categories,
-        root_only=root_only,
+        from_pipfile=from_pipfile,
     )
 
 

--- a/pipenv/routines/requirements.py
+++ b/pipenv/routines/requirements.py
@@ -13,8 +13,10 @@ def generate_requirements(
     include_hashes=False,
     include_markers=True,
     categories="",
+    root_only=False,
 ):
     lockfile = project.load_lockfile(expand_env_vars=False)
+    pipfile_root_package_names = project.pipfile_package_names["combined"]
 
     for i, package_index in enumerate(lockfile["_meta"]["sources"]):
         prefix = "-i" if i == 0 else "--extra-index-url"
@@ -26,12 +28,31 @@ def generate_requirements(
     if categories_list:
         for category in categories_list:
             category = get_lockfile_section_using_pipfile_category(category.strip())
-            deps.update(lockfile.get(category, {}))
+            category_deps = lockfile.get(category, {})
+            if root_only:
+                category_deps = {
+                    k: v
+                    for k, v in category_deps.items()
+                    if k in pipfile_root_package_names
+                }
+            deps.update(category_deps)
     else:
         if dev or dev_only:
-            deps.update(lockfile["develop"])
+            dev_deps = lockfile["develop"]
+            if root_only:
+                dev_deps = {
+                    k: v for k, v in dev_deps.items() if k in pipfile_root_package_names
+                }
+            deps.update(dev_deps)
         if not dev_only:
-            deps.update(lockfile["default"])
+            default_deps = lockfile["default"]
+            if root_only:
+                default_deps = {
+                    k: v
+                    for k, v in default_deps.items()
+                    if k in pipfile_root_package_names
+                }
+            deps.update(default_deps)
 
     pip_installable_lines = requirements_from_lockfile(
         deps, include_hashes=include_hashes, include_markers=include_markers

--- a/pipenv/routines/requirements.py
+++ b/pipenv/routines/requirements.py
@@ -13,7 +13,7 @@ def generate_requirements(
     include_hashes=False,
     include_markers=True,
     categories="",
-    root_only=False,
+    from_pipfile=False,
 ):
     lockfile = project.load_lockfile(expand_env_vars=False)
     pipfile_root_package_names = project.pipfile_package_names["combined"]
@@ -29,7 +29,7 @@ def generate_requirements(
         for category in categories_list:
             category = get_lockfile_section_using_pipfile_category(category.strip())
             category_deps = lockfile.get(category, {})
-            if root_only:
+            if from_pipfile:
                 category_deps = {
                     k: v
                     for k, v in category_deps.items()
@@ -39,14 +39,16 @@ def generate_requirements(
     else:
         if dev or dev_only:
             dev_deps = lockfile["develop"]
-            if root_only:
+            if from_pipfile:
                 dev_deps = {
-                    k: v for k, v in dev_deps.items() if k in pipfile_root_package_names
+                    k: v
+                    for k, v in dev_deps.items()
+                    if k in pipfile_root_package_names
                 }
             deps.update(dev_deps)
         if not dev_only:
             default_deps = lockfile["default"]
-            if root_only:
+            if from_pipfile:
                 default_deps = {
                     k: v
                     for k, v in default_deps.items()

--- a/pipenv/routines/requirements.py
+++ b/pipenv/routines/requirements.py
@@ -41,9 +41,7 @@ def generate_requirements(
             dev_deps = lockfile["develop"]
             if from_pipfile:
                 dev_deps = {
-                    k: v
-                    for k, v in dev_deps.items()
-                    if k in pipfile_root_package_names
+                    k: v for k, v in dev_deps.items() if k in pipfile_root_package_names
                 }
             deps.update(dev_deps)
         if not dev_only:

--- a/tests/integration/test_requirements.py
+++ b/tests/integration/test_requirements.py
@@ -116,7 +116,7 @@ def test_requirements_generates_requirements_from_lockfile_from_categories(pipen
 
 
 @pytest.mark.requirements
-def test_requirements_generates_requirements_with_root_only(pipenv_instance_pypi):
+def test_requirements_generates_requirements_with_from_pipfile(pipenv_instance_pypi):
     with pipenv_instance_pypi() as p:
         packages = ('requests', '2.31.0')
         sub_packages = ('urllib3', '2.2.1')  # subpackages not explicitly written in Pipfile.
@@ -132,31 +132,31 @@ def test_requirements_generates_requirements_with_root_only(pipenv_instance_pypi
             f.write(contents)
         p.pipenv('lock')
 
-        c = p.pipenv('requirements --root-only')
+        c = p.pipenv('requirements --from-pipfile')
         assert c.returncode == 0
         assert f'{packages[0]}=={packages[1]}' in c.stdout
         assert f'{sub_packages[0]}=={sub_packages[1]}' not in c.stdout
         assert f'{dev_packages[0]}=={dev_packages[1]}' not in c.stdout
 
-        d = p.pipenv('requirements --dev --root-only')
+        d = p.pipenv('requirements --dev --from-pipfile')
         assert d.returncode == 0
         assert f'{packages[0]}=={packages[1]}' in d.stdout
         assert f'{sub_packages[0]}=={sub_packages[1]}' not in d.stdout
         assert f'{dev_packages[0]}=={dev_packages[1]}' in d.stdout
 
-        e = p.pipenv('requirements --dev-only --root-only')
+        e = p.pipenv('requirements --dev-only --from-pipfile')
         assert e.returncode == 0
         assert f'{packages[0]}=={packages[1]}' not in e.stdout
         assert f'{sub_packages[0]}=={sub_packages[1]}' not in e.stdout
         assert f'{dev_packages[0]}=={dev_packages[1]}' in e.stdout
 
-        f = p.pipenv('requirements --categories=dev-packages --root-only')
+        f = p.pipenv('requirements --categories=dev-packages --from-pipfile')
         assert f.returncode == 0
         assert f'{packages[0]}=={packages[1]}' not in f.stdout
         assert f'{sub_packages[0]}=={sub_packages[1]}' not in f.stdout
         assert f'{dev_packages[0]}=={dev_packages[1]}' in f.stdout
 
-        g = p.pipenv('requirements --categories=packages,dev-packages --root-only')
+        g = p.pipenv('requirements --categories=packages,dev-packages --from-pipfile')
         assert g.returncode == 0
         assert f'{packages[0]}=={packages[1]}' in g.stdout
         assert f'{sub_packages[0]}=={sub_packages[1]}' not in g.stdout


### PR DESCRIPTION
### The issue

This is an enhancement of subcommand regards to https://github.com/pypa/pipenv/issues/6130
`pipenv requirements --from-pipfile` subcommand supports delimination of subpackages when command executed.

### The fix
- Add `--from-pipfile` flag
- Load explicitly mentioned packages in Pipfile and initialize new set called `pipfile_root_package_names`
- If flag is True, add packages in deps only if the name is in `pipfile_root_package_names`



### The checklist

* [x] Associated issue
* [x] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

<!--
### If this is a patch to the `vendor` directory...

Please try to refrain from submitting patches directly to `vendor` or `patched`, but raise your issue to the upstream project instead, and inform Pipenv to upgrade when the upstream project accepts the fix.

A pull request to upgrade vendor packages is strongly discouraged, unless there is a very good reason (e.g. you need to test Pipenv’s integration to a new vendor feature). Pipenv audits and performs vendor upgrades regularly, generally before a new release is about to drop.

If your patch is not or cannot be accepted by upstream, but is essential to Pipenv (make sure to discuss this with maintainers!), please remember to attach a patch file in `tasks/vendoring/patched`, so this divergence from upstream can be recorded and replayed afterwards.
-->
