### PR TITLE
Handle unsupported python versioning on Pipfile

### DIFF
--- a/news/6164.bugfix.rst
+++ b/news/6164.bugfix.rst
@@ -1,0 +1,1 @@
+Pipenv only supports absolute python version. If the user specifies a Python version with inequality signs like >=3.12, <3.12 in the [requires] field, the code has been modified to explicitly express in an error log that absolute versioning must be used.

--- a/pipenv/utils/virtualenv.py
+++ b/pipenv/utils/virtualenv.py
@@ -241,18 +241,11 @@ def ensure_python(project, python=None):
         if python:
             range_pattern = r"^[<>]=?|!="
             if re.search(range_pattern, python):
-                click.echo(
-                    "{}: Python version range specifier '{}' is not supported. {}".format(
-                        click.style("Error", fg="red", bold=True),
-                        click.style(python, fg="cyan"),
-                        click.style(
-                            "Please use an absolute version number or specify the path to the Python executable on Pipfile.",
-                            fg="yellow",
-                        ),
-                    ),
-                    err=True,
+                err.print(
+                    f"[bold red]Error[/bold red]: Python version range specifier '[cyan]{python}[/cyan]' is not supported. "
+                    "[yellow]Please use an absolute version number or specify the path to the Python executable on Pipfile.[/yellow]"
                 )
-                abort()
+                sys.exit(1)
 
     if not python:
         python = project.s.PIPENV_DEFAULT_PYTHON_VERSION

--- a/pipenv/utils/virtualenv.py
+++ b/pipenv/utils/virtualenv.py
@@ -1,5 +1,6 @@
 import contextlib
 import os
+import re
 import shutil
 import sys
 from pathlib import Path
@@ -237,6 +238,22 @@ def ensure_python(project, python=None):
     # Find out which python is desired.
     if not python:
         python = project.required_python_version
+        if python:
+            range_pattern = r"^[<>]=?|!="
+            if re.search(range_pattern, python):
+                click.echo(
+                    "{}: Python version range specifier '{}' is not supported. {}".format(
+                        click.style("Error", fg="red", bold=True),
+                        click.style(python, fg="cyan"),
+                        click.style(
+                            "Please use an absolute version number or specify the path to the Python executable on Pipfile.",
+                            fg="yellow",
+                        ),
+                    ),
+                    err=True,
+                )
+                abort()
+
     if not python:
         python = project.s.PIPENV_DEFAULT_PYTHON_VERSION
     path_to_python = find_a_system_python(python)

--- a/tests/integration/test_install_basic.py
+++ b/tests/integration/test_install_basic.py
@@ -403,6 +403,64 @@ def test_create_pipfile_requires_python_full_version(pipenv_instance_private_pyp
             'python_version': python_version
             }
 
+@pytest.mark.basic
+@pytest.mark.install
+@pytest.mark.virtualenv
+def test_install_with_pipfile_including_exact_python_version(pipenv_instance_pypi):
+    valid_version = f"{sys.version_info.major}.{sys.version_info.minor}"
+
+    with pipenv_instance_pypi() as p:
+        with open(p.pipfile_path, 'w') as f:
+            f.write(f"""
+[[source]]
+url = "https://test.pypi.org/simple"
+verify_ssl = true
+name = "testpypi"
+
+[packages]
+pytz = "*"
+
+[requires]
+python_version = "{valid_version}"
+""")
+
+        c = p.pipenv("install")
+        assert c.returncode == 0
+        assert os.path.isfile(p.pipfile_path)
+        assert p.pipfile["requires"]["python_version"] == valid_version
+
+        c = p.pipenv("--rm")
+        assert c.returncode == 0
+
+@pytest.mark.basic
+@pytest.mark.install
+@pytest.mark.virtualenv
+def test_install_with_pipfile_including_invalid_python_version(pipenv_instance_pypi):
+    invalid_versions = [
+        f">={sys.version_info.major}.{sys.version_info.minor}",
+        f"<={sys.version_info.major}.{sys.version_info.minor}",
+        f">{sys.version_info.major}.{sys.version_info.minor}",
+        f"<{sys.version_info.major}.{sys.version_info.minor}",
+    ]
+
+    with pipenv_instance_pypi() as p:
+        for version in invalid_versions:
+            with open(p.pipfile_path, 'w') as f:
+                f.write(f"""
+[[source]]
+url = "https://test.pypi.org/simple"
+verify_ssl = true
+name = "testpypi"
+
+[packages]
+pytz = "*"
+
+[requires]
+python_version = "{version}"
+""")
+            c = p.pipenv("install --verbose")
+            assert c.returncode != 0
+
 
 @pytest.mark.basic
 @pytest.mark.install

--- a/tests/integration/test_install_basic.py
+++ b/tests/integration/test_install_basic.py
@@ -458,7 +458,7 @@ pytz = "*"
 [requires]
 python_version = "{version}"
 """)
-            c = p.pipenv("install --verbose")
+            c = p.pipenv("install")
             assert c.returncode != 0
 
 


### PR DESCRIPTION
### The issue

This is a bug fix of Pipfile [requires] regards to https://github.com/pypa/pipenv/issues/6144
Pipenv only supports absolute python version. If the user specifies a Python version with inequality signs like >=3.12, <3.12 in the [requires] field, the code has been modified to explicitly express in an error log that absolute versioning must be used.

### The fix
- Add protection logic to parse python verison on Pipfile.
- Enhance error log that absolute versioning must be used.
- Add test codes.

### The checklist

* [x] Associated issue
* [x] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

<!--
### If this is a patch to the `vendor` directory...

Please try to refrain from submitting patches directly to `vendor` or `patched`, but raise your issue to the upstream project instead, and inform Pipenv to upgrade when the upstream project accepts the fix.

A pull request to upgrade vendor packages is strongly discouraged, unless there is a very good reason (e.g. you need to test Pipenv’s integration to a new vendor feature). Pipenv audits and performs vendor upgrades regularly, generally before a new release is about to drop.

If your patch is not or cannot be accepted by upstream, but is essential to Pipenv (make sure to discuss this with maintainers!), please remember to attach a patch file in `tasks/vendoring/patched`, so this divergence from upstream can be recorded and replayed afterwards.
-->
