### PR TITLE
Swap old_version and new_version in `pipenv update --outdated` output

### DIFF
--- a/news/6179.bugfix.rst
+++ b/news/6179.bugfix.rst
@@ -1,0 +1,1 @@
+Swap old_version and new_version in pipenv update --outdated output.

--- a/pipenv/routines/outdated.py
+++ b/pipenv/routines/outdated.py
@@ -88,7 +88,7 @@ def do_outdated(project, pypi_mirror=None, pre=False, clear=False):
     if not outdated:
         click.echo(click.style("All packages are up to date!", fg="green", bold=True))
         sys.exit(0)
-    for package, new_version, old_version in outdated:
+    for package, old_version, new_version in outdated:
         click.echo(
             f"Package {package!r} out-of-date: {old_version!r} installed, {new_version!r} available."
         )


### PR DESCRIPTION
The old and new versions of packages reported by `pipenv update --outdated` are swapped.

<!--
### If this is a patch to the `vendor` directory...

Please try to refrain from submitting patches directly to `vendor` or `patched`, but raise your issue to the upstream project instead, and inform Pipenv to upgrade when the upstream project accepts the fix.

A pull request to upgrade vendor packages is strongly discouraged, unless there is a very good reason (e.g. you need to test Pipenv’s integration to a new vendor feature). Pipenv audits and performs vendor upgrades regularly, generally before a new release is about to drop.

If your patch is not or cannot be accepted by upstream, but is essential to Pipenv (make sure to discuss this with maintainers!), please remember to attach a patch file in `tasks/vendoring/patched`, so this divergence from upstream can be recorded and replayed afterwards.
-->
