### PR TITLE
Remove click.echo from pipenv/cli

### DIFF
--- a/news/6182.vendor.rst
+++ b/news/6182.vendor.rst
@@ -1,0 +1,1 @@
+Remove click.echo from pipenv/cli

--- a/pipenv/cli/command.py
+++ b/pipenv/cli/command.py
@@ -186,10 +186,8 @@ def cli(
             pypi_mirror=state.pypi_mirror,
             clear=state.clear,
         )
-    # Check this again before exiting for empty ``pipenv`` command.
     elif ctx.invoked_subcommand is None:
-        # Display help to user, if no commands were passed.
-        print(format_help(ctx.get_help()))
+        console.print(format_help(ctx.get_help()))
 
 
 @cli.command(

--- a/pipenv/cli/options.py
+++ b/pipenv/cli/options.py
@@ -32,7 +32,7 @@ class PipenvGroup(DYMMixin, Group):
 
         def show_help(ctx, param, value):
             if value and not ctx.resilient_parsing:
-                console.print(format_help(ctx.get_help()), highlight=False)
+                console.print(format_help(ctx.get_help()))
                 ctx.exit()
 
         return Option(

--- a/pipenv/cli/options.py
+++ b/pipenv/cli/options.py
@@ -10,7 +10,6 @@ from pipenv.vendor.click import (
     Group,
     Option,
     argument,
-    echo,
     make_pass_decorator,
     option,
 )
@@ -33,12 +32,7 @@ class PipenvGroup(DYMMixin, Group):
 
         def show_help(ctx, param, value):
             if value and not ctx.resilient_parsing:
-                if not ctx.invoked_subcommand:
-                    # legit main help
-                    console.print(format_help(ctx.get_help()), highlight=False)
-                else:
-                    # legit sub-command help
-                    echo(ctx.get_help(), color=ctx.color)
+                console.print(format_help(ctx.get_help()), highlight=False)
                 ctx.exit()
 
         return Option(

--- a/pipenv/cli/options.py
+++ b/pipenv/cli/options.py
@@ -2,7 +2,7 @@ import os
 import re
 
 from pipenv.project import Project
-from pipenv.utils import err
+from pipenv.utils import console, err
 from pipenv.utils.internet import is_valid_url
 from pipenv.vendor.click import (
     BadArgumentUsage,
@@ -35,7 +35,7 @@ class PipenvGroup(DYMMixin, Group):
             if value and not ctx.resilient_parsing:
                 if not ctx.invoked_subcommand:
                     # legit main help
-                    echo(format_help(ctx.get_help()))
+                    console.print(format_help(ctx.get_help()), highlight=False)
                 else:
                     # legit sub-command help
                     echo(ctx.get_help(), color=ctx.color)

--- a/pipenv/utils/__init__.py
+++ b/pipenv/utils/__init__.py
@@ -3,6 +3,5 @@ import logging
 from pipenv.patched.pip._vendor.rich.console import Console
 
 logging.basicConfig(level=logging.INFO)
-
-console = Console()
+console = Console(highlight=False)
 err = Console(stderr=True)

--- a/pipenv/utils/display.py
+++ b/pipenv/utils/display.py
@@ -1,6 +1,3 @@
-from pipenv.vendor import click
-
-
 def format_help(help):
     """Formats the help string."""
     help = help.replace("Options:", "[bold]Options:[/bold]")

--- a/pipenv/utils/display.py
+++ b/pipenv/utils/display.py
@@ -3,28 +3,20 @@ from pipenv.vendor import click
 
 def format_help(help):
     """Formats the help string."""
-    help = help.replace("Options:", str(click.style("Options:", bold=True)))
-    help = help.replace(
-        "Usage: pipenv", str("Usage: {}".format(click.style("pipenv", bold=True)))
-    )
-    help = help.replace("  check", str(click.style("  check", fg="red", bold=True)))
-    help = help.replace("  clean", str(click.style("  clean", fg="red", bold=True)))
-    help = help.replace("  graph", str(click.style("  graph", fg="red", bold=True)))
-    help = help.replace(
-        "  install", str(click.style("  install", fg="magenta", bold=True))
-    )
-    help = help.replace("  lock", str(click.style("  lock", fg="green", bold=True)))
-    help = help.replace("  open", str(click.style("  open", fg="red", bold=True)))
-    help = help.replace("  run", str(click.style("  run", fg="yellow", bold=True)))
-    help = help.replace("  shell", str(click.style("  shell", fg="yellow", bold=True)))
-    help = help.replace(
-        "  scripts", str(click.style("  scripts", fg="yellow", bold=True))
-    )
-    help = help.replace("  sync", str(click.style("  sync", fg="green", bold=True)))
-    help = help.replace(
-        "  uninstall", str(click.style("  uninstall", fg="magenta", bold=True))
-    )
-    help = help.replace("  update", str(click.style("  update", fg="green", bold=True)))
+    help = help.replace("Options:", "[bold]Options:[/bold]")
+    help = help.replace("Usage: pipenv", "Usage: [bold]pipenv[/bold]")
+    help = help.replace("  check", "[bold red]  check[/red bold]")
+    help = help.replace("  clean", "[bold red]  clean[/red bold]")
+    help = help.replace("  graph", "[bold red]  graph[/red bold]")
+    help = help.replace("  install", "[bold magenta]  install[/magenta bold]")
+    help = help.replace("  lock", "[bold green]  lock[/green bold]")
+    help = help.replace("  open", "[bold red]  open[/red bold]")
+    help = help.replace("  run", "[bold yellow]  run[/yellow bold]")
+    help = help.replace("  shell", "[bold yellow]  shell[/yellow bold]")
+    help = help.replace("  scripts", "[bold yellow]  scripts[/yellow bold]")
+    help = help.replace("  sync", "[bold green]  sync[/green bold]")
+    help = help.replace("  uninstall", "[bold magenta]  uninstall[/magenta bold]")
+    help = help.replace("  update", "[bold green]  update[/green bold]")
     additional_help = """
 Usage Examples:
    Create a new project using Python 3.7, specifically:
@@ -52,14 +44,14 @@ Usage Examples:
    $ {}
 
 Commands:""".format(
-        click.style("pipenv --python 3.7", fg="yellow"),
-        click.style("pipenv --rm", fg="yellow"),
-        click.style("pipenv install --dev", fg="yellow"),
-        click.style("pipenv lock --pre", fg="yellow"),
-        click.style("pipenv graph", fg="yellow"),
-        click.style("pipenv check", fg="yellow"),
-        click.style("pipenv install -e .", fg="yellow"),
-        click.style("pipenv run pip freeze", fg="yellow"),
+        "[yellow]pipenv --python 3.7[/yellow]",
+        "[yellow]pipenv --rm[/yellow]",
+        "[yellow]pipenv install --dev[/yellow]",
+        "[yellow]pipenv lock --pre[/yellow]",
+        "[yellow]pipenv graph[/yellow]",
+        "[yellow]pipenv check[/yellow]",
+        "[yellow]pipenv install -e .[/yellow]",
+        "[yellow]pipenv run pip freeze[/yellow]",
     )
     help = help.replace("Commands:", additional_help)
     return help


### PR DESCRIPTION
### The issue

We want to remove vendored click library as it is sizable and much of its functionality can be done with rich already.

### The fix

replace `click.echo` calls in:

pipenv/cli/command.py
pipenv/cli/options.py

replace `click.style` calls in:

pipenv/utils/display.py

### Notes

This will not remove all uses of click library in pipenv/cli, this is part of an incremental transition from click to rich.

@oz123 

