### PR TITLE
Update diagnose URL in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -5,7 +5,7 @@ about: Create a report to help us improve
 
 Be sure to check the existing issues (both open and closed!), and make sure you are running the latest version of Pipenv.
 
-Check the [diagnose documentation](https://pipenv.pypa.io/en/latest/diagnose/) for common issues before posting! We may close your issue if it is very similar to one of them. Please be considerate, or be on your way.
+Check the [diagnose documentation](https://pipenv.pypa.io/en/latest/diagnose.html) for common issues before posting! We may close your issue if it is very similar to one of them. Please be considerate, or be on your way.
 
 Make sure to mention your debugging experience if the documented solution failed.
 


### PR DESCRIPTION
The URL to the diagnose page seems to have changed and is a broken link in the issue template.