### PR TITLE
Fix: dont call load dot env in shell sub command

### DIFF
--- a/news/6202.bugfix.rst
+++ b/news/6202.bugfix.rst
@@ -1,0 +1,1 @@
+Fix loading dot env twice #6198

--- a/pipenv/cli/command.py
+++ b/pipenv/cli/command.py
@@ -390,8 +390,7 @@ def shell(state, fancy=False, shell_args=None, anyway=False, quiet=False):
                 "New shell not activated to avoid nested environments."
             )
             sys.exit(1)
-    # Load .env file.
-    load_dot_env(state.project)
+
     # Use fancy mode for Windows or pwsh on *nix.
     if (
         os.name == "nt"


### PR DESCRIPTION
dot env is always globally loaded.

Fix #6198
