### PR TITLE
Solve issue with quiet lock not writing the lock file.

### DIFF
--- a/news/6207.bugfix.rst
+++ b/news/6207.bugfix.rst
@@ -1,0 +1,1 @@
+Solve issue with quiet lock not writing the lock file #6207.

--- a/pipenv/cli/command.py
+++ b/pipenv/cli/command.py
@@ -344,7 +344,8 @@ def lock(ctx, state, **kwargs):
         clear=state.clear,
         pre=pre,
         pypi_mirror=state.pypi_mirror,
-        write=not state.quiet,
+        write=True,
+        quiet=state.quiet,
         categories=state.installstate.categories,
     )
 

--- a/pipenv/routines/lock.py
+++ b/pipenv/routines/lock.py
@@ -12,6 +12,7 @@ def do_lock(
     clear=False,
     pre=False,
     write=True,
+    quiet=False,
     pypi_mirror=None,
     categories=None,
     extra_pip_args=None,
@@ -46,15 +47,15 @@ def do_lock(
             packages = project.get_pipfile_section(pipfile_category)
 
         if write:
-            # Alert the user of progress.
-            click.echo(
-                "{} {} {}".format(
-                    click.style("Locking"),
-                    click.style(f"[{pipfile_category}]", fg="yellow"),
-                    click.style("dependencies..."),
-                ),
-                err=True,
-            )
+            if not quiet:  # Alert the user of progress.
+                click.echo(
+                    "{} {} {}".format(
+                        click.style("Locking"),
+                        click.style(f"[{pipfile_category}]", fg="yellow"),
+                        click.style("dependencies..."),
+                    ),
+                    err=True,
+                )
 
         # Prune old lockfile category as new one will be created.
         with contextlib.suppress(KeyError):
@@ -89,15 +90,16 @@ def do_lock(
     if write:
         lockfile.update({"_meta": project.get_lockfile_meta()})
         project.write_lockfile(lockfile)
-        click.echo(
-            "{}".format(
-                click.style(
-                    f"Updated Pipfile.lock ({project.get_lockfile_hash()})!",
-                    bold=True,
-                )
-            ),
-            err=True,
-        )
+        if not quiet:
+            click.echo(
+                "{}".format(
+                    click.style(
+                        f"Updated Pipfile.lock ({project.get_lockfile_hash()})!",
+                        bold=True,
+                    )
+                ),
+                err=True,
+            )
     else:
         return lockfile
 


### PR DESCRIPTION
### The issue

More work needs to be done to respect the quiet state across utilities, which may mean studying up on how we track command state -- I don't want to just extend all the utilities to have a quiet parameter for example.   Anyway, this should fix the issue reported where quiet does not write the lock file changes.

Fixes #6207

### The checklist

* [X] Associated issue
* [ ] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.
