### PR TITLE
Corrected behavior of uninstall --all

### DIFF
--- a/news/6209.bugfix.rst
+++ b/news/6209.bugfix.rst
@@ -1,0 +1,1 @@
+Fix regression introduced with the "smarter uninstall" PR.  Uninstall ``--all`` should not clear the Pipfile entries.

--- a/pipenv/utils/virtualenv.py
+++ b/pipenv/utils/virtualenv.py
@@ -185,7 +185,7 @@ def ensure_virtualenv(project, python=None, site_packages=None, pypi_mirror=None
 def cleanup_virtualenv(project, bare=True):
     """Removes the virtualenv directory from the system."""
     if not bare:
-        console.pritn("[red]Environment creation aborted.[/red]")
+        console.print("[red]Environment creation aborted.[/red]")
     try:
         # Delete the virtualenv.
         shutil.rmtree(project.virtualenv_location)

--- a/tests/integration/test_uninstall.py
+++ b/tests/integration/test_uninstall.py
@@ -90,8 +90,11 @@ def test_uninstall_all_local_files(pipenv_instance_private_pypi, testsroot):
         c = p.pipenv(f"install {file_uri}")
         assert c.returncode == 0
         c = p.pipenv("uninstall --all")
-        assert "tablib" not in p.pipfile["packages"]
-        assert "tablib" not in p.lockfile["default"]
+        assert c.returncode == 0
+        assert "tablib" in c.stdout
+        # Uninstall --all is not supposed to remove things from the pipfile
+        # Note that it didn't before, but that instead local filenames showed as hashes
+        assert "tablib" in p.pipfile["packages"]
 
 
 @pytest.mark.install


### PR DESCRIPTION
Thank you for contributing to Pipenv!


### The issue

When I recently refactored the uninstall command behavior to be smarter, I broke the expected behavior of `--all` flag.
Specifically there should not be removal from the Pipfile and the do_purge logic should be invoked (it wasn't after my change).
Fixes #6200 

### The checklist

* [X] Associated issue
* [X] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.
