### PR TITLE
Bug fix for skip-lock +additional issue in main branch

### DIFF
--- a/pipenv/exceptions.py
+++ b/pipenv/exceptions.py
@@ -58,7 +58,7 @@ def handle_exception(exc_type, exception, traceback, hook=sys.excepthook):
 sys.excepthook = handle_exception
 
 
-class PipenvException:
+class PipenvException(Exception):
     message = "[bold][red]ERROR[/red][/bold]: {}"
 
     def __init__(self, message=None, **kwargs):

--- a/pipenv/project.py
+++ b/pipenv/project.py
@@ -668,16 +668,10 @@ class Project:
 
     @property
     def parsed_pipfile(self) -> tomlkit.toml_document.TOMLDocument | TPipfile:
-        """Parse Pipfile into a TOMLFile and cache it
-
-        (call clear_pipfile_cache() afterwards if mutating)"""
+        """Parse Pipfile into a TOMLFile and cache it"""
         contents = self.read_pipfile()
-        # use full contents to get around str/bytes 2/3 issues
-        cache_key = (self.pipfile_location, contents)
-        if cache_key not in _pipfile_cache:
-            parsed = self._parse_pipfile(contents)
-            _pipfile_cache[cache_key] = parsed
-        return _pipfile_cache[cache_key]
+        parsed = self._parse_pipfile(contents)
+        return parsed
 
     def read_pipfile(self) -> str:
         # Open the pipfile, read it into memory.

--- a/pipenv/utils/dependencies.py
+++ b/pipenv/utils/dependencies.py
@@ -893,7 +893,6 @@ def get_link_from_line(line):
     link = create_link(
         urlunsplit(parsed_url._replace(scheme=original_scheme))  # type: ignore
     )
-
     return link
 
 

--- a/pipenv/utils/virtualenv.py
+++ b/pipenv/utils/virtualenv.py
@@ -185,7 +185,7 @@ def ensure_virtualenv(project, python=None, site_packages=None, pypi_mirror=None
 def cleanup_virtualenv(project, bare=True):
     """Removes the virtualenv directory from the system."""
     if not bare:
-        console.pritn("[red]Environment creation aborted.[/red]")
+        console.print("[red]Environment creation aborted.[/red]")
     try:
         # Delete the virtualenv.
         shutil.rmtree(project.virtualenv_location)


### PR DESCRIPTION
Remove caching of pipfile to avoid issue with new attributes from parsing not showing up in the entries such as the case of --skip-lock.   Fix code issue introduced in a different PR with removing virtualenv.

Related to issue #6189 

### The checklist

* [X] Associated issue
* [ ] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

<!--
### If this is a patch to the `vendor` directory...

Please try to refrain from submitting patches directly to `vendor` or `patched`, but raise your issue to the upstream project instead, and inform Pipenv to upgrade when the upstream project accepts the fix.

A pull request to upgrade vendor packages is strongly discouraged, unless there is a very good reason (e.g. you need to test Pipenv’s integration to a new vendor feature). Pipenv audits and performs vendor upgrades regularly, generally before a new release is about to drop.

If your patch is not or cannot be accepted by upstream, but is essential to Pipenv (make sure to discuss this with maintainers!), please remember to attach a patch file in `tasks/vendoring/patched`, so this divergence from upstream can be recorded and replayed afterwards.
-->
