### PR TITLE
Check end of path for shell detection

### DIFF
--- a/news/6197.bugfix.rst
+++ b/news/6197.bugfix.rst
@@ -1,0 +1,1 @@
+Update shell detection to only check the end of the command used.

--- a/pipenv/shells.py
+++ b/pipenv/shells.py
@@ -37,7 +37,10 @@ def _get_activate_script(cmd, venv):
     """
     # Suffix and source command for other shells.
     # Support for fish shell.
-    if cmd.endswith("/fish"):
+    if cmd.endswith("/sh", "/bash", "/zsh"):
+        suffix = ""
+        command = "."
+    elif cmd.endswith("/fish"):
         suffix = ".fish"
         command = "source"
     # Support for csh shell.
@@ -51,8 +54,7 @@ def _get_activate_script(cmd, venv):
         suffix = ".nu"
         command = "overlay use"
     else:
-        suffix = ""
-        command = "."
+        raise ValueError(f"unknown shell {cmd}")
     # Escape any special characters located within the virtualenv path to allow
     # for proper activation.
     venv_location = re.sub(r"([ &$()\[\]])", r"\\\1", str(venv))

--- a/pipenv/shells.py
+++ b/pipenv/shells.py
@@ -37,17 +37,17 @@ def _get_activate_script(cmd, venv):
     """
     # Suffix and source command for other shells.
     # Support for fish shell.
-    if cmd.endswith("fish"):
+    if cmd.endswith("/fish"):
         suffix = ".fish"
         command = "source"
     # Support for csh shell.
-    elif cmd.endswith("csh"):
+    elif cmd.endswith("/csh"):
         suffix = ".csh"
         command = "source"
-    elif cmd.endswith("xonsh"):
+    elif cmd.endswith("/xonsh"):
         suffix = ".xsh"
         command = "source"
-    elif cmd.endswith("nu"):
+    elif cmd.endswith("/nu"):
         suffix = ".nu"
         command = "overlay use"
     else:

--- a/pipenv/shells.py
+++ b/pipenv/shells.py
@@ -37,17 +37,17 @@ def _get_activate_script(cmd, venv):
     """
     # Suffix and source command for other shells.
     # Support for fish shell.
-    if "fish" in cmd:
+    if cmd.endswith("fish"):
         suffix = ".fish"
         command = "source"
     # Support for csh shell.
-    elif "csh" in cmd:
+    elif cmd.endswith("csh"):
         suffix = ".csh"
         command = "source"
-    elif "xonsh" in cmd:
+    elif cmd.endswith("xonsh"):
         suffix = ".xsh"
         command = "source"
-    elif "nu" in cmd:
+    elif cmd.endswith("nu"):
         suffix = ".nu"
         command = "overlay use"
     else:


### PR DESCRIPTION
Thank you for contributing to Pipenv!


### The issue
Shell detection checks the entire path when looking for shell substrings. This can cause the wrong branch to get tripped if shells are installed in a path with another shell in the tree. In my case a `li[nu]xbrew`-installed `zsh` goes down the `nu` shell path.

### The fix

This updates the check to only look at the end of `cmd` when detecting shells.

### The checklist

* [x] Associated issue: #6197 
* [x] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

