### PR TITLE
Remove linuxbrew from path when detecting shell

### DIFF
--- a/news/6197.bugfix.rst
+++ b/news/6197.bugfix.rst
@@ -1,0 +1,1 @@
+Remove linuxbrew from path when detecting shells.

--- a/pipenv/shells.py
+++ b/pipenv/shells.py
@@ -35,6 +35,11 @@ def _get_activate_script(cmd, venv):
     This is POSIX-only at the moment since the compat (pexpect-based) shell
     does not work elsewhere anyway.
     """
+
+    # Split on linuxbrew in case users have installed there shell using it.
+    # Otherwise the `nu` substring will trigger the nu shell path.
+    cmd = cmd.split(".linuxbrew")[-1]
+
     # Suffix and source command for other shells.
     # Support for fish shell.
     if "fish" in cmd:


### PR DESCRIPTION
### The issue

Installing shells through linuxbrew are always detected as `nu` shells because of the substring check.

### The fix

Split `cmd` by `.linuxbrew` to avoid having it in the check.

This only fixes the specific case of installing things via brew. #6212 offers a broader fix if `cmd` contains other shell names anywhere in the path. It comes with a higher risk of breaking setups though (maybe worth saving for a major release).

### The checklist

* [x] Associated issue: pypa#6197
* [x] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.