### PR TITLE
Correct for local package installs always being treated as editable.

### DIFF
--- a/news/6222.bugfix.rst
+++ b/news/6222.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed regression where all local file installations were incorrectly treated as editable. Ensure that local file installations are explicitly marked as editable in both Pipfile and Pipfile.lock entries if editable installation is desired.

--- a/pipenv/utils/dependencies.py
+++ b/pipenv/utils/dependencies.py
@@ -390,7 +390,7 @@ def dependency_as_pip_install_line(
     if not vcs:
         for k in ["file", "path"]:
             if k in dep:
-                if is_editable_path(dep[k]):
+                if dep.get("editable") and is_editable_path(dep[k]):
                     line.append("-e")
                 extras = ""
                 if "extras" in dep:

--- a/pipenv/utils/requirements.py
+++ b/pipenv/utils/requirements.py
@@ -201,7 +201,7 @@ def requirement_from_lockfile(
         line = []
         if k in package_info:
             path = package_info[k]
-            if is_editable_path(path):
+            if package_info.get("editable") and is_editable_path(path):
                 line.append("-e")
             line.append(f"{package_info[k]}")
             if os_markers:


### PR DESCRIPTION
### The issue

Fixes #6221 

### The fix

Local file installs were not considering if user wanted it marked editable.   This was a regression, that seems like it has been long standing at this point.

### The checklist

* [X] Associated issue
* [X] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.
