### PR TITLE
Corrected behavior of `pipenv install --skip-lock`

### DIFF
--- a/news/6225.bugfix.rst
+++ b/news/6225.bugfix.rst
@@ -1,0 +1,1 @@
+Corrected behavior of ``pipenv install --skip-lock`` after behavioral install refactor introduced regression.  No Pipfile.lock is generated with this fix and installation of vcs no longer fails with revision missing error.

--- a/pipenv/routines/install.py
+++ b/pipenv/routines/install.py
@@ -630,15 +630,11 @@ def do_init(
                     packages=packages,
                     editable_packages=editable_packages,
                 )
-    # Write out the lockfile if it doesn't exist.
-    if not project.lockfile_exists:
+    # Write out the lockfile if it doesn't exist and skip_lock is False
+    if not project.lockfile_exists and not skip_lock:
         # Unless we're in a virtualenv not managed by pipenv, abort if we're
         # using the system's python.
-        if (
-            (system or allow_global)
-            and not (project.s.PIPENV_VIRTUALENV)
-            and skip_lock is False
-        ):
+        if (system or allow_global) and not project.s.PIPENV_VIRTUALENV:
             raise exceptions.PipenvOptionsError(
                 "--system",
                 "--system is intended to be used for Pipfile installation, "


### PR DESCRIPTION
### The issue

Fixes Issue #6189 

It would appear my refactor to the behavioral install changes in `2024.0.1` broke the `--skip-lock` flag.

### Before change

```
$ pipenv install --skip-lock
The flag --skip-lock has been reintroduced (but is not recommended).  Without the lock resolver it is difficult to mana
provided.  However it can help manage installs with current deficiencies in locking across platforms.
Creating a virtualenv for this project
Pipfile: C:\Users\matte\Projects\pipenv-triage\issue-6189\Pipfile
Using default python from C:\Users\matte\AppData\Local\Programs\Python\Python311\python.exe3.11.2 to create virtualenv.
[   =] Creating virtual environment...created virtual environment CPython3.11.2.final.0-64 in 2742ms
  creator CPython3Windows(dest=C:\c\users\matte\.virtualenvs\issue-6189-08vX2LT8, clear=False, no_vcs_ignore=False, glo
  seeder FromAppData(download=False, pip=bundle, setuptools=bundle, wheel=bundle, via=copy, app_data_dir=C:\Users\matte
    added seed packages: pip==24.1.2, setuptools==71.1.0, wheel==0.43.0
  activators BashActivator,BatchActivator,FishActivator,NushellActivator,PowerShellActivator,PythonActivator

Successfully created virtual environment!
Virtualenv location: C:\c\Users\matte\.virtualenvs\issue-6189-08vX2LT8
Pipfile.lock not found, creating...
Locking [packages] dependencies...
Building requirements...
Resolving dependencies...
Success!
[ ===] Locking packages...Warning: INFO:pip.subprocessor:Running command git clone --filter=blob:none --quiet https://g
emp\pip-temp-lv88bspj\requests_00b039085c7f46fda8bdcf620a8d539a'
INFO:pip.subprocessor:Running command git checkout -q 61e2240f283f15780ac2d0e2cfefb0fd6fdab627
INFO:pip.subprocessor:Running command git clone --filter=blob:none https://github.com/psf/requests.git 'C:\Users\matte\
INFO:pip.subprocessor:Cloning into 'C:\Users\matte\AppData\Local\Temp\tmphwfn5ymh'...
INFO:pip.subprocessor:Updating files:  23% (31/131)
INFO:pip.subprocessor:Updating files:  24% (32/131)
INFO:pip.subprocessor:Updating files:  25% (33/131)
INFO:pip.subprocessor:Updating files:  26% (35/131)
INFO:pip.subprocessor:Updating files:  27% (36/131)
INFO:pip.subprocessor:Updating files:  28% (37/131)
INFO:pip.subprocessor:Updating files:  29% (38/131)
INFO:pip.subprocessor:Updating files:  30% (40/131)
INFO:pip.subprocessor:Updating files:  31% (41/131)
INFO:pip.subprocessor:Updating files:  32% (42/131)
INFO:pip.subprocessor:Updating files:  33% (44/131)
INFO:pip.subprocessor:Updating files:  34% (45/131)
INFO:pip.subprocessor:Updating files:  35% (46/131)
INFO:pip.subprocessor:Updating files:  36% (48/131)
INFO:pip.subprocessor:Updating files:  37% (49/131)
INFO:pip.subprocessor:Updating files:  38% (50/131)
INFO:pip.subprocessor:Updating files:  39% (52/131)
INFO:pip.subprocessor:Updating files:  40% (53/131)
INFO:pip.subprocessor:Updating files:  41% (54/131)
INFO:pip.subprocessor:Updating files:  42% (56/131)
INFO:pip.subprocessor:Updating files:  43% (57/131)
INFO:pip.subprocessor:Updating files:  44% (58/131)
INFO:pip.subprocessor:Updating files:  45% (59/131)
INFO:pip.subprocessor:Updating files:  46% (61/131)
INFO:pip.subprocessor:Updating files:  47% (62/131)
INFO:pip.subprocessor:Updating files:  48% (63/131)
INFO:pip.subprocessor:Updating files:  49% (65/131)
INFO:pip.subprocessor:Updating files:  50% (66/131)
INFO:pip.subprocessor:Updating files:  51% (67/131)
INFO:pip.subprocessor:Updating files:  52% (69/131)
INFO:pip.subprocessor:Updating files:  53% (70/131)
INFO:pip.subprocessor:Updating files:  54% (71/131)
INFO:pip.subprocessor:Updating files:  55% (73/131)
INFO:pip.subprocessor:Updating files:  56% (74/131)
INFO:pip.subprocessor:Updating files:  57% (75/131)
INFO:pip.subprocessor:Updating files:  58% (76/131)
INFO:pip.subprocessor:Updating files:  59% (78/131)
INFO:pip.subprocessor:Updating files:  60% (79/131)
INFO:pip.subprocessor:Updating files:  61% (80/131)
INFO:pip.subprocessor:Updating files:  62% (82/131)
INFO:pip.subprocessor:Updating files:  63% (83/131)
INFO:pip.subprocessor:Updating files:  64% (84/131)
INFO:pip.subprocessor:Updating files:  65% (86/131)
INFO:pip.subprocessor:Updating files:  66% (87/131)
INFO:pip.subprocessor:Updating files:  67% (88/131)
INFO:pip.subprocessor:Updating files:  68% (90/131)
INFO:pip.subprocessor:Updating files:  69% (91/131)
INFO:pip.subprocessor:Updating files:  70% (92/131)
INFO:pip.subprocessor:Updating files:  71% (94/131)
INFO:pip.subprocessor:Updating files:  72% (95/131)
INFO:pip.subprocessor:Updating files:  73% (96/131)
INFO:pip.subprocessor:Updating files:  74% (97/131)
INFO:pip.subprocessor:Updating files:  75% (99/131)
INFO:pip.subprocessor:Updating files:  76% (100/131)
INFO:pip.subprocessor:Updating files:  77% (101/131)
INFO:pip.subprocessor:Updating files:  78% (103/131)
INFO:pip.subprocessor:Updating files:  79% (104/131)
INFO:pip.subprocessor:Updating files:  80% (105/131)
INFO:pip.subprocessor:Updating files:  81% (107/131)
INFO:pip.subprocessor:Updating files:  82% (108/131)
INFO:pip.subprocessor:Updating files:  83% (109/131)
INFO:pip.subprocessor:Updating files:  84% (111/131)
INFO:pip.subprocessor:Updating files:  85% (112/131)
INFO:pip.subprocessor:Updating files:  86% (113/131)
INFO:pip.subprocessor:Updating files:  87% (114/131)
INFO:pip.subprocessor:Updating files:  88% (116/131)
INFO:pip.subprocessor:Updating files:  89% (117/131)
INFO:pip.subprocessor:Updating files:  90% (118/131)
INFO:pip.subprocessor:Updating files:  91% (120/131)
INFO:pip.subprocessor:Updating files:  92% (121/131)
INFO:pip.subprocessor:Updating files:  93% (122/131)
INFO:pip.subprocessor:Updating files:  94% (124/131)
INFO:pip.subprocessor:Updating files:  95% (125/131)
INFO:pip.subprocessor:Updating files:  96% (126/131)
INFO:pip.subprocessor:Updating files:  97% (128/131)
INFO:pip.subprocessor:Updating files:  98% (129/131)
INFO:pip.subprocessor:Updating files:  99% (130/131)
INFO:pip.subprocessor:Updating files: 100% (131/131)
INFO:pip.subprocessor:Updating files: 100% (131/131), done.
INFO:pip.subprocessor:Running command git checkout -q 61e2240f283f15780ac2d0e2cfefb0fd6fdab627
Locking [dev-packages] dependencies...
Updated Pipfile.lock (20e8bcdd65eff27a0a84f7765eb2e33f87902742e3cd378c3f4bcfeb2a46b0a3)!
Installing dependencies from Pipfile...
: Collecting requests@ git+https://github.com/psf/requests.git@ (from -r c:\users\matte\appdata\local\temp\pipenv-c2zip
: ERROR: The URL 'git+https://github.com/psf/requests.git@' has an empty revision (after @) which is not supported. Inc
ERROR: Couldn't install package: {}
 Package installation failed...
```

### After the fix

* No Pipfile.lock is generated
* Installation doesn't fail
* Output is:

```
$ pipenv install --skip-lock
The flag --skip-lock has been reintroduced (but is not recommended).  Without the lock resolver it is difficult to
manage multiple package indexes, and hash checking is not provided.  However it can help manage installs with current
deficiencies in locking across platforms.
Creating a virtualenv for this project
Pipfile: C:\Users\matte\Projects\pipenv-triage\issue-6189\Pipfile
Using default python from C:\Users\matte\AppData\Local\Programs\Python\Python311\python.exe3.11.2 to create
virtualenv...
[=   ] Creating virtual environment...created virtual environment CPython3.11.2.final.0-64 in 4572ms
  creator CPython3Windows(dest=C:\c\users\matte\.virtualenvs\issue-6189-08vX2LT8, clear=False, no_vcs_ignore=False,
global=False)
  seeder FromAppData(download=False, pip=bundle, setuptools=bundle, wheel=bundle, via=copy,
app_data_dir=C:\Users\matte\AppData\Local\pypa\virtualenv)
    added seed packages: pip==24.1.2, setuptools==71.1.0, wheel==0.43.0
  activators BashActivator,BatchActivator,FishActivator,NushellActivator,PowerShellActivator,PythonActivator

Successfully created virtual environment!
Virtualenv location: C:\c\Users\matte\.virtualenvs\issue-6189-08vX2LT8
Installing dependencies from Pipfile...
```

How does this pull request fix your problem? Did you consider any alternatives? Why is this the *best* solution, in your opinion?


### The checklist

* [X] Associated issue
* [X] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.
