### PR TITLE
Fix uninstall --all fails when venv is deleted

### DIFF
--- a/news/6185.bugfix.rst
+++ b/news/6185.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed ``pipenv uninstall --all`` failing when the virtual environment no longer exists.

--- a/pipenv/environment.py
+++ b/pipenv/environment.py
@@ -826,4 +826,3 @@ class Environment:
             finally:
                 sys.path = original_path
                 sys.prefix = original_prefix
-

--- a/pipenv/environment.py
+++ b/pipenv/environment.py
@@ -99,8 +99,8 @@ class Environment:
 
     @cached_property
     def python_version(self) -> str | None:
-        with self.activated() as e:
-            if e.ok:
+        with self.activated() as active:
+            if active:
                 sysconfig = self.safe_import("sysconfig")
                 py_version = sysconfig.get_python_version()
                 return py_version

--- a/pipenv/environment.py
+++ b/pipenv/environment.py
@@ -767,8 +767,6 @@ class Environment:
                 code = compile(f.read(), activate_this, "exec")
                 exec(code, {"__file__": activate_this})
 
-    EnvironmentActivationResult = namedtuple("EnvironmentActivationResult", ["ok"])
-
     @contextlib.contextmanager
     def activated(self):
         """Helper context manager to activate the environment.

--- a/pipenv/environment.py
+++ b/pipenv/environment.py
@@ -7,7 +7,6 @@ import os
 import site
 import sys
 import typing
-from collections import namedtuple
 from functools import cached_property
 from pathlib import Path
 from sysconfig import get_paths, get_python_version, get_scheme_names
@@ -797,7 +796,7 @@ class Environment:
             and not self.prefix.exists()
             or not hasattr(self, "prefix")
         ):
-            yield self.EnvironmentActivationResult(ok=False)
+            yield False
             return
 
         original_path = sys.path
@@ -825,7 +824,8 @@ class Environment:
             sys.path = self.sys_path
             sys.prefix = self.sys_prefix
             try:
-                yield self.EnvironmentActivationResult(ok=True)
+                yield True
             finally:
                 sys.path = original_path
                 sys.prefix = original_prefix
+

--- a/pipenv/routines/uninstall.py
+++ b/pipenv/routines/uninstall.py
@@ -5,7 +5,7 @@ from pipenv import exceptions
 from pipenv.patched.pip._internal.build_env import get_runnable_pip
 from pipenv.project import Project
 from pipenv.routines.lock import do_lock
-from pipenv.utils import console 
+from pipenv.utils import console
 from pipenv.utils.dependencies import (
     expansive_install_req_from_line,
     get_lockfile_section_using_pipfile_category,

--- a/pipenv/routines/uninstall.py
+++ b/pipenv/routines/uninstall.py
@@ -5,6 +5,7 @@ from pipenv import exceptions
 from pipenv.patched.pip._internal.build_env import get_runnable_pip
 from pipenv.project import Project
 from pipenv.routines.lock import do_lock
+from pipenv.utils import console 
 from pipenv.utils.dependencies import (
     expansive_install_req_from_line,
     get_lockfile_section_using_pipfile_category,
@@ -21,11 +22,11 @@ from pipenv.vendor.importlib_metadata.compat.py39 import normalized_name
 
 def _uninstall_from_environment(project: Project, package, system=False):
     # Execute the uninstall command for the package
-    with project.environment.activated() as e:
-        if not e.ok:
+    with project.environment.activated() as is_active:
+        if not is_active:
             return False
 
-        click.secho(f"Uninstalling {package}...", fg="green", bold=True)
+        console.print(f"Uninstalling {package}...", style="bold green")
         cmd = [
             project_python(project, system=system),
             get_runnable_pip(),

--- a/pipenv/routines/uninstall.py
+++ b/pipenv/routines/uninstall.py
@@ -3,6 +3,7 @@ import sys
 
 from pipenv import exceptions
 from pipenv.patched.pip._internal.build_env import get_runnable_pip
+from pipenv.project import Project
 from pipenv.routines.lock import do_lock
 from pipenv.utils.dependencies import (
     expansive_install_req_from_line,
@@ -18,10 +19,13 @@ from pipenv.vendor import click
 from pipenv.vendor.importlib_metadata.compat.py39 import normalized_name
 
 
-def _uninstall_from_environment(project, package, system=False):
+def _uninstall_from_environment(project: Project, package, system=False):
     # Execute the uninstall command for the package
-    click.secho(f"Uninstalling {package}...", fg="green", bold=True)
-    with project.environment.activated():
+    with project.environment.activated() as e:
+        if not e.ok:
+            return False
+
+        click.secho(f"Uninstalling {package}...", fg="green", bold=True)
         cmd = [
             project_python(project, system=system),
             get_runnable_pip(),
@@ -38,7 +42,7 @@ def _uninstall_from_environment(project, package, system=False):
 
 
 def do_uninstall(
-    project,
+    project: Project,
     packages=None,
     editable_packages=None,
     python=False,

--- a/tests/integration/test_uninstall.py
+++ b/tests/integration/test_uninstall.py
@@ -339,7 +339,7 @@ atomicwrites = "*"
 
 
 @pytest.mark.uninstall
-def test_uninstall_whithout_venv(pipenv_instance_private_pypi):
+def test_uninstall_without_venv(pipenv_instance_private_pypi):
     with pipenv_instance_private_pypi() as p:
         with open(p.pipfile_path, "w") as f:
             contents = """
@@ -354,8 +354,5 @@ atomicwrites = "*"
 
         c = p.pipenv("uninstall --all")
         assert c.returncode == 0
-        assert list(p.pipfile["packages"].keys()) == [
-            "parse",
-            "colorama",
-            "atomicwrites",
-        ]
+        # uninstall --all shold not remove packages from Pipfile
+        assert list(p.pipfile["packages"].keys()) == ["colorama", "atomicwrites"]

--- a/tests/integration/test_uninstall.py
+++ b/tests/integration/test_uninstall.py
@@ -336,3 +336,26 @@ atomicwrites = "*"
             "colorama",
             "atomicwrites",
         ]
+
+
+@pytest.mark.uninstall
+def test_uninstall_whithout_venv(pipenv_instance_private_pypi):
+    with pipenv_instance_private_pypi() as p:
+        with open(p.pipfile_path, "w") as f:
+            contents = """
+[packages]
+colorama = "*"
+atomicwrites = "*"
+            """.strip()
+            f.write(contents)
+
+        c = p.pipenv("install")
+        assert c.returncode == 0
+
+        c = p.pipenv("uninstall --all")
+        assert c.returncode == 0
+        assert list(p.pipfile["packages"].keys()) == [
+            "parse",
+            "colorama",
+            "atomicwrites",
+        ]


### PR DESCRIPTION
### The issue

This is a regression where `pipenv uninstall --all` fails when the venv does not exist.

### The solution

Add a check to make sure the environment is valid (venv exists).

ref #6185 

* [x] Associated issue
* [x] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.
