### PR TITLE
Ignore resource warning

### DIFF
--- a/news/6151.bugfix.rst
+++ b/news/6151.bugfix.rst
@@ -1,0 +1,1 @@
+Disable ``ResourceWarning`` warning for temporary files that are cleaned on program exit.

--- a/pipenv/routines/install.py
+++ b/pipenv/routines/install.py
@@ -48,7 +48,7 @@ def do_install(
     requirements_directory = fileutils.create_tracked_tempdir(
         suffix="-requirements", prefix="pipenv-"
     )
-    warnings.filterwarnings("default", category=ResourceWarning)
+    warnings.filterwarnings("ignore", category=ResourceWarning)
     packages = packages if packages else []
     editable_packages = editable_packages if editable_packages else []
     package_args = [p for p in packages if p] + [p for p in editable_packages if p]


### PR DESCRIPTION
### The issue

When running `pipenv install -r requirements.txt`, a warning (`ResourceWarning: unclosed file`) is shown to users. 
This warning comes from temporary directories that will be cleared on program exit, and is therefore not meaningful to the user.

### The fix

Ignore the warning.

Fixes #6151
Fixes #6155 

### The checklist

* [x] Associated issue
* [x] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.
