### PR TITLE
Preserve uncleaned VCS URL in the lock file.

### DIFF
--- a/news/6256.bugfix.rst
+++ b/news/6256.bugfix.rst
@@ -1,0 +1,1 @@
+Fixes regression in lock file generation that caused environment variable references (e.g., ${GIT_PASSWORD}) in VCS URLs to be stripped out. This restores the ability to use credential placeholders in version control system URLs.

--- a/pipenv/utils/dependencies.py
+++ b/pipenv/utils/dependencies.py
@@ -283,10 +283,7 @@ def clean_resolved_dep(project, dep, is_top_level=False, current_entry=None):
                     [extra.strip() for extra in extras_section.split(",")]
                 )
 
-            # Extract the clean VCS URL
-            clean_vcs_url = extract_vcs_url(vcs_url)
-
-            lockfile[vcs_type] = clean_vcs_url
+            lockfile[vcs_type] = vcs_url
             lockfile["ref"] = dep.get("ref")
             if "subdirectory" in dep:
                 lockfile["subdirectory"] = dep["subdirectory"]

--- a/tests/integration/test_install_vcs.py
+++ b/tests/integration/test_install_vcs.py
@@ -12,10 +12,6 @@ def test_install_github_vcs(pipenv_instance_pypi):
         assert "dataclass-factory" in p.pipfile["packages"]
 
 
-import os
-import pytest
-
-
 @pytest.mark.basic
 @pytest.mark.install
 @pytest.mark.parametrize("use_credentials", [True, False])

--- a/tests/integration/test_install_vcs.py
+++ b/tests/integration/test_install_vcs.py
@@ -8,3 +8,34 @@ def test_install_github_vcs(pipenv_instance_pypi):
         c = p.pipenv("install git+https://github.com/reagento/adaptix.git@2.16")
         assert not c.returncode
         assert "dataclass-factory" in p.pipfile["packages"]
+
+
+@pytest.mark.basic
+@pytest.mark.install
+@pytest.mark.parametrize("use_credentials", [True, False])
+def test_install_github_vcs_with_credentials(pipenv_instance_pypi, use_credentials):
+    with pipenv_instance_pypi() as p:
+        # Set environment variables
+        os.environ['GIT_REPO'] = 'github.com/reagento/adaptix.git'
+        if use_credentials:
+            os.environ['GIT_USERNAME'] = 'git'  # Use 'git' as a dummy username
+            os.environ['GIT_PASSWORD'] = ''  # Empty password for public repos
+            url = f"git+https://${{GIT_USERNAME}}:${{GIT_PASSWORD}}@${{GIT_REPO}}@2.16"
+        else:
+            url = f"git+https://${{GIT_REPO}}@2.16"
+
+        c = p.pipenv(f"install {url}")
+        assert not c.returncode
+        assert "adaptix" in p.pipfile["packages"]
+
+        # Check if the URL in the lockfile still contains the environment variables
+        lockfile_content = p.lockfile
+        assert "${GIT_REPO}" in lockfile_content['default']['adaptix']['git']
+        if use_credentials:
+            assert "${GIT_USERNAME}" in lockfile_content['default']['adaptix']['git']
+            assert "${GIT_PASSWORD}" in lockfile_content['default']['adaptix']['git']
+
+        # Verify that the package is installed and usable
+        c = p.pipenv("run python -c 'import adaptix; print(adaptix.__version__)'")
+        assert not c.returncode
+        assert "2.16" in c.stdout

--- a/tests/integration/test_install_vcs.py
+++ b/tests/integration/test_install_vcs.py
@@ -40,6 +40,5 @@ def test_install_github_vcs_with_credentials(pipenv_instance_pypi, use_credentia
             assert "${GIT_PASSWORD}" in lockfile_content['default']['dataclass-factory']['git']
 
         # Verify that the package is installed and usable
-        c = p.pipenv("run python -c 'import dataclass_factory; print(dataclass_factory.__version__)'")
-        assert c.returncode == 0, f"Version check failed with error: {c.stderr}"
-        assert "2.16" in c.stdout
+        c = p.pipenv("run python -c 'import dataclass_factory'")
+        assert c.returncode == 0, f"Failed to import library: {c.stderr}"

--- a/tests/integration/test_install_vcs.py
+++ b/tests/integration/test_install_vcs.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 
 
@@ -20,9 +22,9 @@ def test_install_github_vcs_with_credentials(pipenv_instance_pypi, use_credentia
         if use_credentials:
             os.environ['GIT_USERNAME'] = 'git'  # Use 'git' as a dummy username
             os.environ['GIT_PASSWORD'] = ''  # Empty password for public repos
-            url = f"git+https://${{GIT_USERNAME}}:${{GIT_PASSWORD}}@${{GIT_REPO}}@2.16"
+            url = "git+https://${{GIT_USERNAME}}:${{GIT_PASSWORD}}@${{GIT_REPO}}@2.16"
         else:
-            url = f"git+https://${{GIT_REPO}}@2.16"
+            url = "git+https://${{GIT_REPO}}@2.16"
 
         c = p.pipenv(f"install {url}")
         assert not c.returncode

--- a/tests/integration/test_install_vcs.py
+++ b/tests/integration/test_install_vcs.py
@@ -34,16 +34,16 @@ def test_install_github_vcs_with_credentials(pipenv_instance_pypi, use_credentia
         c = p.pipenv(f"install '{url}'")
         assert c.returncode == 0, f"Install failed with error: {c.stderr}"
 
-        assert "adaptix" in p.pipfile["packages"]
+        assert "dataclass-factory" in p.pipfile["packages"]
 
         # Check if the URL in the lockfile still contains the environment variables
         lockfile_content = p.lockfile
-        assert "${GIT_REPO}" in lockfile_content['default']['adaptix']['git']
+        assert "${GIT_REPO}" in lockfile_content['default']['dataclass-factory']['git']
         if use_credentials:
-            assert "${GIT_USERNAME}" in lockfile_content['default']['adaptix']['git']
-            assert "${GIT_PASSWORD}" in lockfile_content['default']['adaptix']['git']
+            assert "${GIT_USERNAME}" in lockfile_content['default']['dataclass-factory']['git']
+            assert "${GIT_PASSWORD}" in lockfile_content['default']['dataclass-factory']['git']
 
         # Verify that the package is installed and usable
-        c = p.pipenv("run python -c 'import adaptix; print(adaptix.__version__)'")
+        c = p.pipenv("run python -c 'import dataclass-factory; print(dataclass-factory.__version__)'")
         assert c.returncode == 0, f"Version check failed with error: {c.stderr}"
         assert "2.16" in c.stdout

--- a/tests/integration/test_install_vcs.py
+++ b/tests/integration/test_install_vcs.py
@@ -40,6 +40,6 @@ def test_install_github_vcs_with_credentials(pipenv_instance_pypi, use_credentia
             assert "${GIT_PASSWORD}" in lockfile_content['default']['dataclass-factory']['git']
 
         # Verify that the package is installed and usable
-        c = p.pipenv("run python -c 'import dataclass-factory; print(dataclass-factory.__version__)'")
+        c = p.pipenv("run python -c 'import dataclass_factory; print(dataclass_factory.__version__)'")
         assert c.returncode == 0, f"Version check failed with error: {c.stderr}"
         assert "2.16" in c.stdout

--- a/tests/integration/test_install_vcs.py
+++ b/tests/integration/test_install_vcs.py
@@ -12,6 +12,10 @@ def test_install_github_vcs(pipenv_instance_pypi):
         assert "dataclass-factory" in p.pipfile["packages"]
 
 
+import os
+import pytest
+
+
 @pytest.mark.basic
 @pytest.mark.install
 @pytest.mark.parametrize("use_credentials", [True, False])
@@ -22,12 +26,14 @@ def test_install_github_vcs_with_credentials(pipenv_instance_pypi, use_credentia
         if use_credentials:
             os.environ['GIT_USERNAME'] = 'git'  # Use 'git' as a dummy username
             os.environ['GIT_PASSWORD'] = ''  # Empty password for public repos
-            url = "git+https://${{GIT_USERNAME}}:${{GIT_PASSWORD}}@${{GIT_REPO}}@2.16"
+            url = "git+https://${GIT_USERNAME}:${GIT_PASSWORD}@${GIT_REPO}@2.16"
         else:
-            url = "git+https://${{GIT_REPO}}@2.16"
+            url = "git+https://${GIT_REPO}@2.16"
 
-        c = p.pipenv(f"install {url}")
-        assert not c.returncode
+        # Use single quotes to prevent shell expansion
+        c = p.pipenv(f"install '{url}'")
+        assert c.returncode == 0, f"Install failed with error: {c.stderr}"
+
         assert "adaptix" in p.pipfile["packages"]
 
         # Check if the URL in the lockfile still contains the environment variables
@@ -39,5 +45,5 @@ def test_install_github_vcs_with_credentials(pipenv_instance_pypi, use_credentia
 
         # Verify that the package is installed and usable
         c = p.pipenv("run python -c 'import adaptix; print(adaptix.__version__)'")
-        assert not c.returncode
+        assert c.returncode == 0, f"Version check failed with error: {c.stderr}"
         assert "2.16" in c.stdout

--- a/tests/unit/test_dependencies.py
+++ b/tests/unit/test_dependencies.py
@@ -1,0 +1,31 @@
+import pytest
+from pipenv.utils.dependencies import clean_resolved_dep
+
+def test_clean_resolved_dep_with_vcs_url():
+    project = {}  # Mock project object, adjust as needed
+    dep = {
+        "name": "example-package",
+        "git": "git+https://${GIT_USERNAME}:${GIT_PASSWORD}@github.com/username/repo.git",
+        "ref": "main"
+    }
+
+    result = clean_resolved_dep(project, dep)
+
+    assert "example-package" in result
+    assert result["example-package"]["git"] == "git+https://${GIT_USERNAME}:${GIT_PASSWORD}@github.com/username/repo.git"
+    assert result["example-package"]["ref"] == "main"
+
+def test_clean_resolved_dep_with_vcs_url_and_extras():
+    project = {}  # Mock project object, adjust as needed
+    dep = {
+        "name": "example-package",
+        "git": "git+https://${GIT_USERNAME}:${GIT_PASSWORD}@github.com/username/repo.git[extra1,extra2]",
+        "ref": "main"
+    }
+
+    result = clean_resolved_dep(project, dep)
+
+    assert "example-package" in result
+    assert result["example-package"]["git"] == "git+https://${GIT_USERNAME}:${GIT_PASSWORD}@github.com/username/repo.git[extra1,extra2]"
+    assert result["example-package"]["ref"] == "main"
+    assert result["example-package"]["extras"] == ["extra1", "extra2"]


### PR DESCRIPTION
I was overzealous with the cleaning the VCS URL in https://github.com/pypa/pipenv/pull/6242 -- this reverts the part of the change that cleans the lock file version, and just leaves the extraction for the Pipfile version (which I believe resolves both the prior and this issue).

### The issue

Fixes #6256 

### The checklist

* [X] Associated issue
* [X] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.
