### PR TITLE
Vendoring Fall 2024

### DIFF
--- a/news/6293.vendor.rst
+++ b/news/6293.vendor.rst
@@ -1,0 +1,8 @@
+Vendoring
+---------
+* Update vendored dependencies:
+  - importlib-metadata from 8.4.0 to 8.5.0
+  - packaging from 24.0 to 24.1
+  - tomli from 2.0.1 to 2.0.2
+  - tomlkit from 0.12.4 to 0.13.2
+  - zipp from 3.18.1 to 3.20.2

--- a/pipenv/vendor/importlib_metadata/_adapters.py
+++ b/pipenv/vendor/importlib_metadata/_adapters.py
@@ -1,6 +1,6 @@
+import email.message
 import re
 import textwrap
-import email.message
 
 from ._text import FoldedCase
 

--- a/pipenv/vendor/importlib_metadata/_compat.py
+++ b/pipenv/vendor/importlib_metadata/_compat.py
@@ -1,6 +1,5 @@
-import sys
 import platform
-
+import sys
 
 __all__ = ['install', 'NullFinder']
 

--- a/pipenv/vendor/importlib_metadata/_functools.py
+++ b/pipenv/vendor/importlib_metadata/_functools.py
@@ -1,5 +1,5 @@
-import types
 import functools
+import types
 
 
 # from jaraco.functools 3.3

--- a/pipenv/vendor/importlib_metadata/_meta.py
+++ b/pipenv/vendor/importlib_metadata/_meta.py
@@ -1,9 +1,17 @@
 from __future__ import annotations
 
 import os
-from typing import Protocol
-from typing import Any, Dict, Iterator, List, Optional, TypeVar, Union, overload
-
+from typing import (
+    Any,
+    Dict,
+    Iterator,
+    List,
+    Optional,
+    Protocol,
+    TypeVar,
+    Union,
+    overload,
+)
 
 _T = TypeVar("_T")
 

--- a/pipenv/vendor/packaging/__init__.py
+++ b/pipenv/vendor/packaging/__init__.py
@@ -6,7 +6,7 @@ __title__ = "packaging"
 __summary__ = "Core utilities for Python packages"
 __uri__ = "https://github.com/pypa/packaging"
 
-__version__ = "24.0"
+__version__ = "24.1"
 
 __author__ = "Donald Stufft and individual contributors"
 __email__ = "donald@stufft.io"

--- a/pipenv/vendor/packaging/_elffile.py
+++ b/pipenv/vendor/packaging/_elffile.py
@@ -8,10 +8,12 @@ Based on: https://gist.github.com/lyssdod/f51579ae8d93c8657a5564aefc2ffbca
 ELF header: https://refspecs.linuxfoundation.org/elf/gabi4+/ch4.eheader.html
 """
 
+from __future__ import annotations
+
 import enum
 import os
 import struct
-from typing import IO, Optional, Tuple
+from typing import IO
 
 
 class ELFInvalid(ValueError):
@@ -87,11 +89,11 @@ class ELFFile:
         except struct.error as e:
             raise ELFInvalid("unable to parse machine and section information") from e
 
-    def _read(self, fmt: str) -> Tuple[int, ...]:
+    def _read(self, fmt: str) -> tuple[int, ...]:
         return struct.unpack(fmt, self._f.read(struct.calcsize(fmt)))
 
     @property
-    def interpreter(self) -> Optional[str]:
+    def interpreter(self) -> str | None:
         """
         The path recorded in the ``PT_INTERP`` section header.
         """

--- a/pipenv/vendor/packaging/_musllinux.py
+++ b/pipenv/vendor/packaging/_musllinux.py
@@ -4,11 +4,13 @@ This module implements logic to detect if the currently running Python is
 linked against musl, and what musl version is used.
 """
 
+from __future__ import annotations
+
 import functools
 import re
 import subprocess
 import sys
-from typing import Iterator, NamedTuple, Optional, Sequence
+from typing import Iterator, NamedTuple, Sequence
 
 from ._elffile import ELFFile
 
@@ -18,7 +20,7 @@ class _MuslVersion(NamedTuple):
     minor: int
 
 
-def _parse_musl_version(output: str) -> Optional[_MuslVersion]:
+def _parse_musl_version(output: str) -> _MuslVersion | None:
     lines = [n for n in (n.strip() for n in output.splitlines()) if n]
     if len(lines) < 2 or lines[0][:4] != "musl":
         return None
@@ -28,8 +30,8 @@ def _parse_musl_version(output: str) -> Optional[_MuslVersion]:
     return _MuslVersion(major=int(m.group(1)), minor=int(m.group(2)))
 
 
-@functools.lru_cache()
-def _get_musl_version(executable: str) -> Optional[_MuslVersion]:
+@functools.lru_cache
+def _get_musl_version(executable: str) -> _MuslVersion | None:
     """Detect currently-running musl runtime version.
 
     This is done by checking the specified executable's dynamic linking

--- a/pipenv/vendor/packaging/_tokenizer.py
+++ b/pipenv/vendor/packaging/_tokenizer.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import contextlib
 import re
 from dataclasses import dataclass
-from typing import Dict, Iterator, NoReturn, Optional, Tuple, Union
+from typing import Iterator, NoReturn
 
 from .specifiers import Specifier
 
@@ -21,7 +23,7 @@ class ParserSyntaxError(Exception):
         message: str,
         *,
         source: str,
-        span: Tuple[int, int],
+        span: tuple[int, int],
     ) -> None:
         self.span = span
         self.message = message
@@ -34,7 +36,7 @@ class ParserSyntaxError(Exception):
         return "\n    ".join([self.message, self.source, marker])
 
 
-DEFAULT_RULES: "Dict[str, Union[str, re.Pattern[str]]]" = {
+DEFAULT_RULES: dict[str, str | re.Pattern[str]] = {
     "LEFT_PARENTHESIS": r"\(",
     "RIGHT_PARENTHESIS": r"\)",
     "LEFT_BRACKET": r"\[",
@@ -96,13 +98,13 @@ class Tokenizer:
         self,
         source: str,
         *,
-        rules: "Dict[str, Union[str, re.Pattern[str]]]",
+        rules: dict[str, str | re.Pattern[str]],
     ) -> None:
         self.source = source
-        self.rules: Dict[str, re.Pattern[str]] = {
+        self.rules: dict[str, re.Pattern[str]] = {
             name: re.compile(pattern) for name, pattern in rules.items()
         }
-        self.next_token: Optional[Token] = None
+        self.next_token: Token | None = None
         self.position = 0
 
     def consume(self, name: str) -> None:
@@ -154,8 +156,8 @@ class Tokenizer:
         self,
         message: str,
         *,
-        span_start: Optional[int] = None,
-        span_end: Optional[int] = None,
+        span_start: int | None = None,
+        span_end: int | None = None,
     ) -> NoReturn:
         """Raise ParserSyntaxError at the given position."""
         span = (

--- a/pipenv/vendor/packaging/requirements.py
+++ b/pipenv/vendor/packaging/requirements.py
@@ -1,8 +1,9 @@
 # This file is dual licensed under the terms of the Apache License, Version
 # 2.0, and the BSD License. See the LICENSE file in the root of this repository
 # for complete details.
+from __future__ import annotations
 
-from typing import Any, Iterator, Optional, Set
+from typing import Any, Iterator
 
 from ._parser import parse_requirement as _parse_requirement
 from ._tokenizer import ParserSyntaxError
@@ -37,10 +38,10 @@ class Requirement:
             raise InvalidRequirement(str(e)) from e
 
         self.name: str = parsed.name
-        self.url: Optional[str] = parsed.url or None
-        self.extras: Set[str] = set(parsed.extras or [])
+        self.url: str | None = parsed.url or None
+        self.extras: set[str] = set(parsed.extras or [])
         self.specifier: SpecifierSet = SpecifierSet(parsed.specifier)
-        self.marker: Optional[Marker] = None
+        self.marker: Marker | None = None
         if parsed.marker is not None:
             self.marker = Marker.__new__(Marker)
             self.marker._markers = _normalize_extra_values(parsed.marker)

--- a/pipenv/vendor/packaging/tags.py
+++ b/pipenv/vendor/packaging/tags.py
@@ -2,6 +2,8 @@
 # 2.0, and the BSD License. See the LICENSE file in the root of this repository
 # for complete details.
 
+from __future__ import annotations
+
 import logging
 import platform
 import re
@@ -11,15 +13,10 @@ import sys
 import sysconfig
 from importlib.machinery import EXTENSION_SUFFIXES
 from typing import (
-    Dict,
-    FrozenSet,
     Iterable,
     Iterator,
-    List,
-    Optional,
     Sequence,
     Tuple,
-    Union,
     cast,
 )
 
@@ -30,7 +27,7 @@ logger = logging.getLogger(__name__)
 PythonVersion = Sequence[int]
 MacVersion = Tuple[int, int]
 
-INTERPRETER_SHORT_NAMES: Dict[str, str] = {
+INTERPRETER_SHORT_NAMES: dict[str, str] = {
     "python": "py",  # Generic.
     "cpython": "cp",
     "pypy": "pp",
@@ -96,7 +93,7 @@ class Tag:
         return f"<{self} @ {id(self)}>"
 
 
-def parse_tag(tag: str) -> FrozenSet[Tag]:
+def parse_tag(tag: str) -> frozenset[Tag]:
     """
     Parses the provided tag (e.g. `py3-none-any`) into a frozenset of Tag instances.
 
@@ -112,8 +109,8 @@ def parse_tag(tag: str) -> FrozenSet[Tag]:
     return frozenset(tags)
 
 
-def _get_config_var(name: str, warn: bool = False) -> Union[int, str, None]:
-    value: Union[int, str, None] = sysconfig.get_config_var(name)
+def _get_config_var(name: str, warn: bool = False) -> int | str | None:
+    value: int | str | None = sysconfig.get_config_var(name)
     if value is None and warn:
         logger.debug(
             "Config variable '%s' is unset, Python ABI tag may be incorrect", name
@@ -125,7 +122,7 @@ def _normalize_string(string: str) -> str:
     return string.replace(".", "_").replace("-", "_").replace(" ", "_")
 
 
-def _is_threaded_cpython(abis: List[str]) -> bool:
+def _is_threaded_cpython(abis: list[str]) -> bool:
     """
     Determine if the ABI corresponds to a threaded (`--disable-gil`) build.
 
@@ -151,7 +148,7 @@ def _abi3_applies(python_version: PythonVersion, threading: bool) -> bool:
     return len(python_version) > 1 and tuple(python_version) >= (3, 2) and not threading
 
 
-def _cpython_abis(py_version: PythonVersion, warn: bool = False) -> List[str]:
+def _cpython_abis(py_version: PythonVersion, warn: bool = False) -> list[str]:
     py_version = tuple(py_version)  # To allow for version comparison.
     abis = []
     version = _version_nodot(py_version[:2])
@@ -185,9 +182,9 @@ def _cpython_abis(py_version: PythonVersion, warn: bool = False) -> List[str]:
 
 
 def cpython_tags(
-    python_version: Optional[PythonVersion] = None,
-    abis: Optional[Iterable[str]] = None,
-    platforms: Optional[Iterable[str]] = None,
+    python_version: PythonVersion | None = None,
+    abis: Iterable[str] | None = None,
+    platforms: Iterable[str] | None = None,
     *,
     warn: bool = False,
 ) -> Iterator[Tag]:
@@ -244,7 +241,7 @@ def cpython_tags(
                 yield Tag(interpreter, "abi3", platform_)
 
 
-def _generic_abi() -> List[str]:
+def _generic_abi() -> list[str]:
     """
     Return the ABI tag based on EXT_SUFFIX.
     """
@@ -286,9 +283,9 @@ def _generic_abi() -> List[str]:
 
 
 def generic_tags(
-    interpreter: Optional[str] = None,
-    abis: Optional[Iterable[str]] = None,
-    platforms: Optional[Iterable[str]] = None,
+    interpreter: str | None = None,
+    abis: Iterable[str] | None = None,
+    platforms: Iterable[str] | None = None,
     *,
     warn: bool = False,
 ) -> Iterator[Tag]:
@@ -332,9 +329,9 @@ def _py_interpreter_range(py_version: PythonVersion) -> Iterator[str]:
 
 
 def compatible_tags(
-    python_version: Optional[PythonVersion] = None,
-    interpreter: Optional[str] = None,
-    platforms: Optional[Iterable[str]] = None,
+    python_version: PythonVersion | None = None,
+    interpreter: str | None = None,
+    platforms: Iterable[str] | None = None,
 ) -> Iterator[Tag]:
     """
     Yields the sequence of tags that are compatible with a specific version of Python.
@@ -366,7 +363,7 @@ def _mac_arch(arch: str, is_32bit: bool = _32_BIT_INTERPRETER) -> str:
     return "i386"
 
 
-def _mac_binary_formats(version: MacVersion, cpu_arch: str) -> List[str]:
+def _mac_binary_formats(version: MacVersion, cpu_arch: str) -> list[str]:
     formats = [cpu_arch]
     if cpu_arch == "x86_64":
         if version < (10, 4):
@@ -399,7 +396,7 @@ def _mac_binary_formats(version: MacVersion, cpu_arch: str) -> List[str]:
 
 
 def mac_platforms(
-    version: Optional[MacVersion] = None, arch: Optional[str] = None
+    version: MacVersion | None = None, arch: str | None = None
 ) -> Iterator[str]:
     """
     Yields the platform tags for a macOS system.

--- a/pipenv/vendor/packaging/utils.py
+++ b/pipenv/vendor/packaging/utils.py
@@ -2,8 +2,10 @@
 # 2.0, and the BSD License. See the LICENSE file in the root of this repository
 # for complete details.
 
+from __future__ import annotations
+
 import re
-from typing import FrozenSet, NewType, Tuple, Union, cast
+from typing import NewType, Tuple, Union, cast
 
 from .tags import Tag, parse_tag
 from .version import InvalidVersion, Version
@@ -53,7 +55,7 @@ def is_normalized_name(name: str) -> bool:
 
 
 def canonicalize_version(
-    version: Union[Version, str], *, strip_trailing_zero: bool = True
+    version: Version | str, *, strip_trailing_zero: bool = True
 ) -> str:
     """
     This is very similar to Version.__str__, but has one subtle difference
@@ -102,7 +104,7 @@ def canonicalize_version(
 
 def parse_wheel_filename(
     filename: str,
-) -> Tuple[NormalizedName, Version, BuildTag, FrozenSet[Tag]]:
+) -> tuple[NormalizedName, Version, BuildTag, frozenset[Tag]]:
     if not filename.endswith(".whl"):
         raise InvalidWheelFilename(
             f"Invalid wheel filename (extension must be '.whl'): {filename}"
@@ -143,7 +145,7 @@ def parse_wheel_filename(
     return (name, version, build, tags)
 
 
-def parse_sdist_filename(filename: str) -> Tuple[NormalizedName, Version]:
+def parse_sdist_filename(filename: str) -> tuple[NormalizedName, Version]:
     if filename.endswith(".tar.gz"):
         file_stem = filename[: -len(".tar.gz")]
     elif filename.endswith(".zip"):

--- a/pipenv/vendor/tomli/__init__.py
+++ b/pipenv/vendor/tomli/__init__.py
@@ -3,7 +3,7 @@
 # Licensed to PSF under a Contributor Agreement.
 
 __all__ = ("loads", "load", "TOMLDecodeError")
-__version__ = "2.0.1"  # DO NOT EDIT THIS LINE MANUALLY. LET bump2version UTILITY DO IT
+__version__ = "2.0.2"  # DO NOT EDIT THIS LINE MANUALLY. LET bump2version UTILITY DO IT
 
 from ._parser import TOMLDecodeError, load, loads
 

--- a/pipenv/vendor/tomlkit/__init__.py
+++ b/pipenv/vendor/tomlkit/__init__.py
@@ -27,7 +27,7 @@ from pipenv.vendor.tomlkit.api import value
 from pipenv.vendor.tomlkit.api import ws
 
 
-__version__ = "0.12.4"
+__version__ = "0.13.2"
 __all__ = [
     "aot",
     "array",

--- a/pipenv/vendor/tomlkit/_types.py
+++ b/pipenv/vendor/tomlkit/_types.py
@@ -19,10 +19,10 @@ if TYPE_CHECKING:  # pragma: no cover
     # Importing from builtins is preferred over simple assignment, see issues:
     # https://github.com/python/mypy/issues/8715
     # https://github.com/python/mypy/issues/10068
-    from builtins import dict as _CustomDict  # noqa: N812
-    from builtins import float as _CustomFloat  # noqa: N812
-    from builtins import int as _CustomInt  # noqa: N812
-    from builtins import list as _CustomList  # noqa: N812
+    from builtins import dict as _CustomDict
+    from builtins import float as _CustomFloat
+    from builtins import int as _CustomInt
+    from builtins import list as _CustomList
     from typing import Callable
     from typing import Concatenate
     from typing import ParamSpec
@@ -31,8 +31,7 @@ if TYPE_CHECKING:  # pragma: no cover
     P = ParamSpec("P")
 
     class WrapperType(Protocol):
-        def _new(self: WT, value: Any) -> WT:
-            ...
+        def _new(self: WT, value: Any) -> WT: ...
 
 else:
     from collections.abc import MutableMapping

--- a/pipenv/vendor/tomlkit/api.py
+++ b/pipenv/vendor/tomlkit/api.py
@@ -75,6 +75,11 @@ def dump(data: Mapping, fp: IO[str], *, sort_keys: bool = False) -> None:
 
     :param data: a dict-like object to dump
     :param sort_keys: if true, sort the keys in alphabetic order
+
+    :Example:
+
+    >>> with open("output.toml", "w") as fp:
+    ...     tomlkit.dump(data, fp)
     """
     fp.write(dumps(data, sort_keys=sort_keys))
 
@@ -160,7 +165,7 @@ def datetime(raw: str) -> DateTime:
     return item(value)
 
 
-def array(raw: str = None) -> Array:
+def array(raw: str = "[]") -> Array:
     """Create an array item for its string representation.
 
     :Example:
@@ -172,9 +177,6 @@ def array(raw: str = None) -> Array:
     >>> a
     [1, 2, 3]
     """
-    if raw is None:
-        raw = "[]"
-
     return value(raw)
 
 

--- a/pipenv/vendor/tomlkit/exceptions.py
+++ b/pipenv/vendor/tomlkit/exceptions.py
@@ -115,7 +115,7 @@ class UnexpectedCharError(ParseError):
     """
 
     def __init__(self, line: int, col: int, char: str) -> None:
-        message = f"Unexpected character: {repr(char)}"
+        message = f"Unexpected character: {char!r}"
 
         super().__init__(line, col, message=message)
 
@@ -148,7 +148,7 @@ class InvalidCharInStringError(ParseError):
     """
 
     def __init__(self, line: int, col: int, char: str) -> None:
-        message = f"Invalid character {repr(char)} in string"
+        message = f"Invalid character {char!r} in string"
 
         super().__init__(line, col, message=message)
 
@@ -225,3 +225,10 @@ class InvalidStringError(ValueError, TOMLKitError):
             f"Invalid string: {delimiter}{repr_}{delimiter}. "
             f"The character sequences {invalid_sequences} are invalid."
         )
+
+
+class ConvertError(TypeError, ValueError, TOMLKitError):
+    """Raised when item() fails to convert a value.
+    It should be a TypeError, but due to historical reasons
+    it needs to subclass ValueError as well.
+    """

--- a/pipenv/vendor/tomlkit/parser.py
+++ b/pipenv/vendor/tomlkit/parser.py
@@ -481,7 +481,7 @@ class Parser:
                             raw,
                         )
                     except ValueError:
-                        raise self.parse_error(InvalidDateTimeError)
+                        raise self.parse_error(InvalidDateTimeError) from None
 
                 if m.group(1):
                     try:
@@ -513,7 +513,7 @@ class Parser:
                             raw + time_part,
                         )
                     except ValueError:
-                        raise self.parse_error(InvalidDateError)
+                        raise self.parse_error(InvalidDateError) from None
 
                 if m.group(5):
                     try:
@@ -529,7 +529,7 @@ class Parser:
                             raw,
                         )
                     except ValueError:
-                        raise self.parse_error(InvalidTimeError)
+                        raise self.parse_error(InvalidTimeError) from None
 
             item = self._parse_number(raw, trivia)
             if item is not None:
@@ -981,9 +981,9 @@ class Parser:
                         is_aot and i == len(name_parts) - 2,
                         is_super_table=i < len(name_parts) - 2,
                         name=_name.key,
-                        display_name=full_key.as_string()
-                        if i == len(name_parts) - 2
-                        else None,
+                        display_name=(
+                            full_key.as_string() if i == len(name_parts) - 2 else None
+                        ),
                     ),
                 )
 

--- a/pipenv/vendor/tomlkit/source.py
+++ b/pipenv/vendor/tomlkit/source.py
@@ -119,7 +119,7 @@ class Source(str):
             self._idx = len(self)
             self._current = self.EOF
             if exception:
-                raise self.parse_error(exception)
+                raise self.parse_error(exception) from None
 
             return False
 

--- a/pipenv/vendor/vendor.txt
+++ b/pipenv/vendor/vendor.txt
@@ -2,9 +2,9 @@ click-didyoumean==0.3.1
 click==8.1.7
 colorama==0.4.6
 dparse==0.6.3
-importlib-metadata==8.4.0
-  zipp==3.18.1
-packaging==24.0
+importlib-metadata==8.5.0
+  zipp==3.20.2
+packaging==24.1
 pexpect==4.9.0
 pipdeptree==2.23.4
 plette==2.1.0
@@ -13,5 +13,5 @@ python-dotenv==1.0.1
 pythonfinder==2.1.0
 ruamel.yaml==0.18.6
 shellingham==1.5.4
-tomli==2.0.1
-tomlkit==0.12.4
+tomli==2.0.2
+tomlkit==0.13.2

--- a/pipenv/vendor/zipp/compat/overlay.py
+++ b/pipenv/vendor/zipp/compat/overlay.py
@@ -1,0 +1,37 @@
+"""
+Expose zipp.Path as .zipfile.Path.
+
+Includes everything else in ``zipfile`` to match future usage. Just
+use:
+
+>>> from zipp.compat.overlay import zipfile
+
+in place of ``import zipfile``.
+
+Relative imports are supported too.
+
+>>> from zipp.compat.overlay.zipfile import ZipInfo
+
+The ``zipfile`` object added to ``sys.modules`` needs to be
+hashable (#126).
+
+>>> _ = hash(sys.modules['zipp.compat.overlay.zipfile'])
+"""
+
+import importlib
+import sys
+import types
+
+import pipenv.vendor.zipp as zipp
+
+
+class HashableNamespace(types.SimpleNamespace):
+    def __hash__(self):
+        return hash(tuple(vars(self)))
+
+
+zipfile = HashableNamespace(**vars(importlib.import_module('zipfile')))
+zipfile.Path = zipp.Path
+zipfile._path = zipp
+
+sys.modules[__name__ + '.zipfile'] = zipfile  # type: ignore[assignment]

--- a/pipenv/vendor/zipp/compat/py310.py
+++ b/pipenv/vendor/zipp/compat/py310.py
@@ -7,5 +7,7 @@ def _text_encoding(encoding, stacklevel=2, /):  # pragma: no cover
 
 
 text_encoding = (
-    io.text_encoding if sys.version_info > (3, 10) else _text_encoding  # type: ignore
+    io.text_encoding  # type: ignore[unused-ignore, attr-defined]
+    if sys.version_info > (3, 10)
+    else _text_encoding
 )

--- a/pipenv/vendor/zipp/glob.py
+++ b/pipenv/vendor/zipp/glob.py
@@ -28,7 +28,7 @@ class Translator:
         """
         Given a glob pattern, produce a regex that matches it.
         """
-        return self.extend(self.translate_core(pattern))
+        return self.extend(self.match_dirs(self.translate_core(pattern)))
 
     def extend(self, pattern):
         r"""
@@ -40,6 +40,14 @@ class Translator:
         Append '\Z' to imply fullmatch even when match is used.
         """
         return rf'(?s:{pattern})\Z'
+
+    def match_dirs(self, pattern):
+        """
+        Ensure that zipfile.Path directory names are matched.
+
+        zipfile.Path directory names always end in a slash.
+        """
+        return rf'{pattern}[/]?'
 
     def translate_core(self, pattern):
         r"""


### PR DESCRIPTION
Thank you for contributing to Pipenv!


### The issue
Keeps our dependencies up to date.

* Update vendored dependencies:
  - importlib-metadata from 8.4.0 to 8.5.0
  - packaging from 24.0 to 24.1
  - tomli from 2.0.1 to 2.0.2
  - tomlkit from 0.12.4 to 0.13.2
  - zipp from 3.18.1 to 3.20.2

### The checklist

* [ ] Associated issue
* [X] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.
