### PR TITLE
Fix the --system without --deploy flag bug

### DIFF
--- a/news/6295.bugfix.rst
+++ b/news/6295.bugfix.rst
@@ -1,0 +1,1 @@
+Fix regression of ``2024.3.0`` when using the ``--system`` flag without ``--deploy`` flag.

--- a/pipenv/routines/install.py
+++ b/pipenv/routines/install.py
@@ -158,18 +158,19 @@ def handle_lockfile(
                     style="red",
                 )
                 raise exceptions.DeployException
-            handle_outdated_lockfile(
-                project,
-                packages,
-                old_hash=old_hash,
-                new_hash=new_hash,
-                system=system,
-                allow_global=allow_global,
-                skip_lock=skip_lock,
-                pre=pre,
-                pypi_mirror=pypi_mirror,
-                categories=categories,
-            )
+            elif not system:
+                handle_outdated_lockfile(
+                    project,
+                    packages,
+                    old_hash=old_hash,
+                    new_hash=new_hash,
+                    system=system,
+                    allow_global=allow_global,
+                    skip_lock=skip_lock,
+                    pre=pre,
+                    pypi_mirror=pypi_mirror,
+                    categories=categories,
+                )
     elif not project.lockfile_exists and not skip_lock:
         handle_missing_lockfile(project, system, allow_global, pre, pypi_mirror)
 

--- a/pipenv/routines/install.py
+++ b/pipenv/routines/install.py
@@ -306,7 +306,7 @@ def do_install(
         categories=pipfile_categories,
         skip_lock=skip_lock,
     )
-    if not deploy:
+    if not (deploy or system):
         new_packages, _ = handle_new_packages(
             project,
             packages,

--- a/tests/integration/test_install_basic.py
+++ b/tests/integration/test_install_basic.py
@@ -388,7 +388,7 @@ def test_system_works(pipenv_instance_pypi):
         assert c.returncode == 0
         c = subprocess_run(["virtualenv", ".venv"])
         assert c.returncode == 0
-        c = p.pipenv("install --system --deploy")
+        c = p.pipenv("install --system")
         assert c.returncode == 0
 
 

--- a/tests/integration/test_install_basic.py
+++ b/tests/integration/test_install_basic.py
@@ -376,6 +376,22 @@ def test_system_and_deploy_work(pipenv_instance_private_pypi):
         assert c.returncode == 0
 
 
+
+@pytest.mark.cli
+@pytest.mark.deploy
+@pytest.mark.system
+def test_system_works(pipenv_instance_pypi):
+    with pipenv_instance_pypi() as p:
+        c = p.pipenv("install urllib3")
+        assert c.returncode == 0
+        c = p.pipenv("--rm")
+        assert c.returncode == 0
+        c = subprocess_run(["virtualenv", ".venv"])
+        assert c.returncode == 0
+        c = p.pipenv("install --system --deploy")
+        assert c.returncode == 0
+
+
 @pytest.mark.basic
 @pytest.mark.install
 def test_install_creates_pipfile(pipenv_instance_pypi):


### PR DESCRIPTION
Fix the --system without --deploy flag bug

### The issue

Fixes #6295 
Fixes #6296 

### The fix

Recent refactor did not consider the `--system` flag without `--deploy`, in part because we were missing a test for it.

Adds test for it.


### The checklist

* [X] Associated issue
* [X] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.
