### PR TITLE
correct regression in --skip-lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,7 +133,7 @@ Features & Improvements
 Behavior Changes
 ----------------
 
-- ``pipenv==3000.0.0`` denotes the first major release of our semver strategy.
+- ``pipenv==2024.0.0`` denotes the first major release of our semver strategy.
   As much requested, the ``install`` no longer does a complete lock operation.  Instead ``install`` follows the same code path as pipenv update (which is upgrade + sync).
   This is what most new users expect the behavior to be; it is a behavioral change, a necessary one to make the tool more usable.
   Remember that complete lock resolution can be invoked with ``pipenv lock`` just as before.  `#6098 <https://github.com/pypa/pipenv/issues/6098>`_

--- a/news/6304.bugfix.rst
+++ b/news/6304.bugfix.rst
@@ -1,0 +1,1 @@
+Fix regression where ``--skip-lock --dev`` was incorrectly searching Lockfile categories ("default", "develop") instead of Pipfile categories ("packages", "dev-packages"), causing packages to not be found.

--- a/pipenv/routines/install.py
+++ b/pipenv/routines/install.py
@@ -323,7 +323,7 @@ def do_install(
 
     try:
         if dev:  # Install both develop and default package categories from Pipfile.
-            pipfile_categories = ["default", "develop"]
+            pipfile_categories = ["packages", "dev-packages"]
         do_install_dependencies(
             project,
             dev=dev,

--- a/tests/integration/test_install_twists.py
+++ b/tests/integration/test_install_twists.py
@@ -4,8 +4,8 @@ import sys
 
 import pytest
 
-from pipenv.vendor.packaging import version
 from pipenv.utils.shell import temp_environ
+from pipenv.vendor.packaging import version
 
 
 @pytest.mark.extras
@@ -569,5 +569,5 @@ pytest = "*"
                 break
         else:
             # This will execute if we don't find aws-cdk-lib in the output
-            assert False, "aws-cdk-lib not found in pip freeze output"
+            raise AssertionError("aws-cdk-lib not found in pip freeze output")
 

--- a/tests/integration/test_install_twists.py
+++ b/tests/integration/test_install_twists.py
@@ -4,6 +4,7 @@ import sys
 
 import pytest
 
+from pipenv.vendor.packaging import version
 from pipenv.utils.shell import temp_environ
 
 
@@ -527,3 +528,46 @@ name = "pypi"
         assert updated_source_count == source_count, "No new [[source]] sections should be added"
         assert "requests" in p.pipfile["packages"]
         assert p.pipfile["packages"]["requests"].get("index") is not None
+
+
+@pytest.mark.basic
+@pytest.mark.install
+def test_install_dev_with_skip_lock(pipenv_instance_pypi):
+    """Test aws-cdk-lib installation and version verification."""
+    with pipenv_instance_pypi() as p:
+        # Create the Pipfile with specified contents
+        with open(p.pipfile_path, "w") as f:
+            contents = """
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+aws-cdk-lib = "==2.164.1"
+
+[dev-packages]
+pytest = "*"
+            """.strip()
+            f.write(contents)
+
+        # Install dependencies with --skip-lock
+        c = p.pipenv("install --dev --skip-lock")
+        assert c.returncode == 0
+
+        # Check pip freeze output
+        c = p.pipenv("run pip freeze")
+        assert c.returncode == 0
+        freeze_output = c.stdout.strip()
+
+        # Find aws-cdk-lib in pip freeze output and verify version
+        for line in freeze_output.split('\n'):
+            if line.startswith('aws-cdk-lib=='):
+                installed_version = line.split('==')[1]
+                assert version.parse(installed_version) == version.parse("2.164.1"), \
+                    f"aws-cdk-lib version {installed_version} is to be expected 2.164.1"
+                break
+        else:
+            # This will execute if we don't find aws-cdk-lib in the output
+            assert False, "aws-cdk-lib not found in pip freeze output"
+


### PR DESCRIPTION
correct regression in --skip-lock being passed the lockfile categories for the Pipfile categories and not finding anything.


### The issue

Fixes #6301 

### The fix

We were using the wrong pipfile categories with `--dev` flag (lockfile categories instead of pipfile) -- its a shame those two name groups differ.


### The checklist

* [X] Associated issue
* [X] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.
