### PR TITLE
Add new paths to front of PATH

### DIFF
--- a/news/6307.bugfix.rst
+++ b/news/6307.bugfix.rst
@@ -1,0 +1,1 @@
+Fix issue where modules could not be found

--- a/pipenv/vendor/pipdeptree/__main__.py
+++ b/pipenv/vendor/pipdeptree/__main__.py
@@ -7,10 +7,8 @@ import sys
 from typing import Sequence
 
 pardir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-# for finding pipdeptree itself
-sys.path.append(pardir)
-# for finding stuff in vendor and patched
-sys.path.append(os.path.dirname(os.path.dirname(pardir)))
+# for finding pipdeptree itself, vendor, and patched
+sys.path = [pardir, os.path.dirname(os.path.dirname(pardir))] + sys.path
 
 from pipenv.vendor.pipdeptree._cli import get_options
 from pipenv.vendor.pipdeptree._detect_env import detect_active_interpreter
@@ -18,7 +16,11 @@ from pipenv.vendor.pipdeptree._discovery import get_installed_distributions
 from pipenv.vendor.pipdeptree._models import PackageDAG
 from pipenv.vendor.pipdeptree._render import render
 from pipenv.vendor.pipdeptree._validate import validate
-from pipenv.vendor.pipdeptree._warning import WarningPrinter, WarningType, get_warning_printer
+from pipenv.vendor.pipdeptree._warning import (
+    WarningPrinter,
+    WarningType,
+    get_warning_printer,
+)
 
 
 def main(args: Sequence[str] | None = None) -> None | int:
@@ -38,7 +40,9 @@ def main(args: Sequence[str] | None = None) -> None | int:
         print(f"(resolved python: {resolved_path})", file=sys.stderr)  # noqa: T201
 
     pkgs = get_installed_distributions(
-        interpreter=options.python, local_only=options.local_only, user_only=options.user_only
+        interpreter=options.python,
+        local_only=options.local_only,
+        user_only=options.user_only,
     )
     tree = PackageDAG.from_pkgs(pkgs)
 


### PR DESCRIPTION
Thank you for contributing to Pipenv!


### The issue

Closes #6305

### The fix

Making sure the new paths were added to the front of `PATH` resolved the error for me.


### The checklist

* [x] Associated issue: #6305
* [x] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

<!--
### If this is a patch to the `vendor` directory...

Please try to refrain from submitting patches directly to `vendor` or `patched`, but raise your issue to the upstream project instead, and inform Pipenv to upgrade when the upstream project accepts the fix.

A pull request to upgrade vendor packages is strongly discouraged, unless there is a very good reason (e.g. you need to test Pipenv’s integration to a new vendor feature). Pipenv audits and performs vendor upgrades regularly, generally before a new release is about to drop.

If your patch is not or cannot be accepted by upstream, but is essential to Pipenv (make sure to discuss this with maintainers!), please remember to attach a patch file in `tasks/vendoring/patched`, so this divergence from upstream can be recorded and replayed afterwards.
-->
