### PR TITLE
Prevent regression with install upgrading packages; duplicated sources in Pipfile prevention

### DIFF
--- a/news/6306.bugfix.rst
+++ b/news/6306.bugfix.rst
@@ -1,0 +1,1 @@
+Fix issue where pipenv install would unintentionally upgrade packages that had wildcard (*) specifiers in the Pipfile, even when locked versions existed and no upgrade was requested.

--- a/pipenv/routines/install.py
+++ b/pipenv/routines/install.py
@@ -109,7 +109,7 @@ def handle_new_packages(
             project.update_settings({"allow_prereleases": pre})
 
     # Use the update routine for new packages
-    if perform_upgrades:
+    if perform_upgrades and (packages or editable_packages):
         try:
             do_update(
                 project,

--- a/pipenv/routines/update.py
+++ b/pipenv/routines/update.py
@@ -280,10 +280,7 @@ def upgrade(
 
     index_name = None
     if index_url:
-        if project.get_index_by_url(index_url):
-            index_name = project.get_index_by_url(index_url)["name"]
-        else:
-            index_name = add_index_to_pipfile(project, index_url)
+        index_name = add_index_to_pipfile(project, index_url)
 
     if extra_pip_args:
         os.environ["PIPENV_EXTRA_PIP_ARGS"] = json.dumps(extra_pip_args)

--- a/tests/integration/test_install_basic.py
+++ b/tests/integration/test_install_basic.py
@@ -799,10 +799,11 @@ sh = "*"
         c = p.pipenv("graph --json")
         assert c.returncode == 0
 
+        import json
         graph_data = json.loads(c.stdout)
-        for package in graph_data:
-            if package["package"] == "sh":
-                assert package["version"] == "1.14.1"
+        for entry in graph_data:
+            if entry["package"]["package_name"] == "sh":
+                assert entry["package"]["installed_version"] == "1.14.1"
                 break
         else:
             pytest.fail("sh package not found in graph output")

--- a/tests/integration/test_install_basic.py
+++ b/tests/integration/test_install_basic.py
@@ -799,7 +799,6 @@ sh = "*"
         c = p.pipenv("graph --json")
         assert c.returncode == 0
 
-        import json
         graph_data = json.loads(c.stdout)
         for entry in graph_data:
             if entry["package"]["package_name"] == "sh":

--- a/tests/integration/test_install_vcs.py
+++ b/tests/integration/test_install_vcs.py
@@ -106,7 +106,7 @@ pytest-xdist = {git = "https://github.com/pytest-dev/pytest-xdist.git", ref = "v
 
         # Verify package appears in develop section of lockfile
         assert "pytest-xdist" in p.lockfile["develop"]
-        assert p.lockfile["develop"]["pytest-xdist"]["git"] == "git+https://github.com/pytest-dev/pytest-xdist.git"
+        assert p.lockfile["develop"]["pytest-xdist"]["git"] == "https://github.com/pytest-dev/pytest-xdist.git"
         assert p.lockfile["develop"]["pytest-xdist"]["ref"] == "4dd2978031eaf7017c84a1cc77667379a2b11c64"
 
         # Verify the package is importable


### PR DESCRIPTION
Prevent regression with install upgrading packages; duplicated sources in Pipfile prevention

### The issue

Fixes #6306 


### The checklist

* [X] Associated issue
* [X] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.
