### PR TITLE
chore: Ignore examples directory for dist #6314

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -27,3 +27,5 @@ prune .azure-pipelines
 prune .github
 prune pipenv/vendor/importlib_metadata/tests
 prune pipenv/vendor/importlib_resources/tests
+
+exclude examples/*


### PR DESCRIPTION
Thank you for contributing to Pipenv!


### The issue

When you install pipenv you are getting the `examples/` directory in this project which includes a Pipfile and it's lock file, and some security scanners will start reporting the packages declared in these as vulnerabilities (even thought the packages only get installed if you `pipenv sync`). 

### The fix

Update the MANIFEST to exclude the examples directory

### The checklist

* [x] Associated issue
* [ ] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

