### PR TITLE
Fix activate path for pwsh on MacOS

### DIFF
--- a/news/6318.bugfix.rst
+++ b/news/6318.bugfix.rst
@@ -1,0 +1,1 @@
+Running "pipenv shell" on MacOS in Powershell (pwsh) references incorrect Activate.ps1

--- a/pipenv/shells.py
+++ b/pipenv/shells.py
@@ -61,7 +61,7 @@ def _get_activate_script(cmd, venv):
 
     if suffix == "nu":
         return f"overlay use {venv_location}"
-    elif suffix == ".ps1":
+    elif suffix == ".ps1" and os.name == "nt":
         return f". {venv_location}\\Scripts\\Activate.{suffix}"
 
     # The leading space can make history cleaner in some shells.


### PR DESCRIPTION
### The issue

Running "pipenv shell" on MacOS in Powershell (pwsh) references incorrect Activate.ps1

### The fix

Adds a check for os.name and removes the extra '.' before the extension

### The checklist

* [x] Associated issue
* [x] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.