### PR TITLE
Fix repr(Shell)

### DIFF
--- a/news/6321.bugfix.rst
+++ b/news/6321.bugfix.rst
@@ -1,0 +1,1 @@
+Fix repr(Shell)

--- a/pipenv/shells.py
+++ b/pipenv/shells.py
@@ -82,7 +82,7 @@ class Shell:
         self.args = []
 
     def __repr__(self):
-        return "{type(self).__name__}(cmd={self.cmd!r})"
+        return f"{type(self).__name__}(cmd={repr(self.cmd)}, args={repr(self.args)})"
 
     @contextlib.contextmanager
     def inject_path(self, venv):


### PR DESCRIPTION
Thank you for contributing to Pipenv!


### The issue

`repr(shell)` does not currently work properly - it is missing the `f` for a formatted string, and it's missing the `args` field.

### The fix

It fixes that.

### The checklist

* [ ] Associated issue
* [x] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.