### PR TITLE
Fix launching PowerShell on UNC paths

### DIFF
--- a/news/6322.bugfix.rst
+++ b/news/6322.bugfix.rst
@@ -1,0 +1,1 @@
+Fix launching PowerShell on UNC paths

--- a/pipenv/shells.py
+++ b/pipenv/shells.py
@@ -73,7 +73,7 @@ def _handover(cmd, args):
     if os.name != "nt":
         os.execvp(cmd, args)
     else:
-        sys.exit(subprocess.call(args, shell=True, universal_newlines=True))
+        sys.exit(subprocess.call(args, universal_newlines=True))
 
 
 class Shell:


### PR DESCRIPTION
Thank you for contributing to Pipenv!


### The issue

When using PowerShell in Windows, executing `pipenv shell` inside a UNC path (such as a SMB share) will cause a `CMD.EXE` error to be thrown, and a change to an incorrect CWD (normally, `C:\Windows`)

### The fix

By disabling the shell functionality of `subprocess.call`, this is avoided.

On Windows, when this parameter is set to true, causes an intermediate `CMD.EXE` to be spawned between Python and PowerShell, which does not support the UNC path, causing the wrong CWD to be presented to the final PowerShell shell.

### The checklist

* [x] Associated issue (#4438)
* [x] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.
