### PR TITLE
Fix File path by removing the dot

### DIFF
--- a/news/6327.bugfix.rst
+++ b/news/6327.bugfix.rst
@@ -1,0 +1,1 @@
+Fix incorrect path for 'pipenv shell'

--- a/pipenv/shells.py
+++ b/pipenv/shells.py
@@ -62,7 +62,7 @@ def _get_activate_script(cmd, venv):
     if suffix == "nu":
         return f"overlay use {venv_location}"
     elif suffix == ".ps1":
-        return f". {venv_location}\\Scripts\\Activate.{suffix}"
+        return f". {venv_location}\\Scripts\\Activate{suffix}"
 
     # The leading space can make history cleaner in some shells.
     return f" {command} {venv_location}/bin/activate{suffix}"


### PR DESCRIPTION
Thank you for contributing to Pipenv!


### The issue
Running "pipenv shell" on MacOS in Powershell (pwsh) references incorrect Activate.ps1

issue link: https://github.com/pypa/pipenv/issues/6318 

### The fix

Fix file path by removing the dot in `shells.py`

### The checklist

- [x] Associated issue (https://github.com/pypa/pipenv/issues/6318 )

- [x]  A news fragment in the `news/ `directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, .`behavior.rst`, `.doc.rst`. .`vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.