### PR TITLE
Fix license declaration

### DIFF
--- a/news/6329.bugfix.rst
+++ b/news/6329.bugfix.rst
@@ -1,0 +1,1 @@
+Fix license declaration for PyPI

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires = [
 name = "pipenv"
 description = "Python Development Workflow for Humans."
 readme = "README.md"
-license = { file = "LICENSE" }
+license = {text = "MIT License (MIT)"}
 authors = [
   { name = "Pipenv maintainer team", email = "distutils-sig@python.org" },
 ]


### PR DESCRIPTION
Thank you for contributing to Pipenv!


### The issue

The license declaration is incompatible with PyPI (and some licence checkers like trivy). If the licence is not set correctly, it's not possible to check it. Secondly, it doesn't look so nice on PyPI.

### The fix

fix the license declaration in pyproject.toml


### The checklist

* [x] Associated issue https://github.com/pypa/pipenv/issues/5949
* [x] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.
