### PR TITLE
fix: when a resolution is failed show a helpful error

### DIFF
--- a/pipenv/exceptions.py
+++ b/pipenv/exceptions.py
@@ -79,7 +79,6 @@ class PipenvException(ClickException):
             if isinstance(self.extra, str):
                 self.extra = [self.extra]
             for extra in self.extra:
-                extra = f"[pipenv.exceptions.{self.__class__.__name__}]: {extra}"
                 console.print(extra)
         console.print(f"{self.message}")
 
@@ -310,29 +309,16 @@ class DependencyConflict(PipenvException):
 class ResolutionFailure(PipenvException):
     def __init__(self, message, no_version_found=False):
         extra = (
-            "{}: Your dependencies could not be resolved. You likely have a "
-            "mismatch in your sub-dependencies.\n  "
-            "You can use {} to bypass this mechanism, then run "
-            "{} to inspect the versions actually installed in the virtualenv.\n  "
-            "Hint: try {} if it is a pre-release dependency."
-            "".format(
-                click.style("Warning", fg="red", bold=True),
-                click.style("$ pipenv run pip install <requirement_name>", fg="yellow"),
-                click.style("$ pipenv graph", fg="yellow"),
-                click.style("$ pipenv lock --pre", fg="yellow"),
-            ),
+            "Your dependencies could not be resolved. You likely have a "
+            "mismatch in your sub-dependencies.\n"
+            "You can use [yellow]$ pipenv run pip install <requirement_name>[/yellow] to bypass this mechanism, then run "
+            "[yellow]$ pipenv graph[/yellow] to inspect the versions actually installed in the virtualenv.\n"
+            "Hint: try [yellow]$ pipenv lock --pre[/yellow] if it is a pre-release dependency."
         )
-        if "no version found at all" in message:
-            no_version_found = True
-        message = click.style(f"{message}", fg="yellow")
-        if no_version_found:
-            message = "{}\n{}".format(
-                message,
-                click.style(
-                    "Please check your version specifier and version number. "
-                    "See PEP440 for more information.",
-                    fg="cyan",
-                ),
+        if "no version found at all" in str(message):
+            message += (
+                "[cyan]Please check your version specifier and version number. "
+                "See PEP440 for more information.[/cyan]"
             )
         PipenvException.__init__(self, message, extra=extra)
 

--- a/pipenv/utils/resolver.py
+++ b/pipenv/utils/resolver.py
@@ -765,10 +765,9 @@ def resolve(cmd, st, project):
     out = c.stdout.read()
     if returncode != 0:
         st.console.print(environments.PIPENV_SPINNER_FAIL_TEXT.format("Locking Failed!"))
-        # err.print(out.strip())
         if not is_verbose:
             err.print(errors)
-        raise RuntimeError("Failed to lock Pipfile.lock!")
+        raise ResolutionFailure("Failed to lock Pipfile.lock!")
     if is_verbose:
         err.print(out.strip())
     return subprocess.CompletedProcess(c.args, returncode, out, errors)
@@ -904,10 +903,7 @@ def venv_resolve_deps(
                 cmd.append("--constraints-file")
                 cmd.append(constraints_file.name)
                 st.console.print("Resolving dependencies...")
-                try:
-                    c = resolve(cmd, st, project=project)
-                except InstallationError:
-                    sys.exit(1)
+                c = resolve(cmd, st, project=project)
                 if c.returncode == 0:
                     try:
                         with open(target_file.name) as fh:

--- a/pipenv/utils/resolver.py
+++ b/pipenv/utils/resolver.py
@@ -904,7 +904,10 @@ def venv_resolve_deps(
                 cmd.append("--constraints-file")
                 cmd.append(constraints_file.name)
                 st.console.print("Resolving dependencies...")
-                c = resolve(cmd, st, project=project)
+                try:
+                    c = resolve(cmd, st, project=project)
+                except InstallationError:
+                    sys.exit(1)
                 if c.returncode == 0:
                     try:
                         with open(target_file.name) as fh:


### PR DESCRIPTION
Also, exist the program immediately.

For example:
```
 $ pipenv install bottle==0.16.0
 Installing bottle==0.16.0...
  Installation Succeeded
 Installing dependencies from Pipfile.lock (2110f5)...
 All dependencies are now up-to-date!
 Upgrading bottle==0.16.0 in  dependencies.
 Building requirements...
 Resolving dependencies...
 ✘ Locking Failed!
 ⠼ Locking
 packages...CRITICAL:pipenv.patched.pip._internal.resolution.resolvelib.factory:Could
 not find a version that satisfies the requirement bottle==0.16.0 (from
 versions: 0.4.3, 0.4.4, 0.4.6, 0.4.7, 0.4.8, 0.4.9, 0.4.10, 0.4.11,
 0.4.12, 0.4.13, 0.4.14,
 0.5.3, 0.5.4, 0.5.6, 0.5.7, 0.5.8, 0.6.0, 0.6.1, 0.6.2, 0.6.3, 0.6.4,
 0.6.5, 0.6.6, 0.8.1, 0.8.2, 0.8.3, 0.8.4, 0.8.5, 0.9.1, 0.9.2, 0.9.3,
 0.9.4, 0.9.5, 0.9.6, 0.9.7, 0.9.8, 0.10.1, 0.10.2, 0.10.3, 0.10.4,
 0.10.5, 0.10.6, 0.10.7,
 0.10.8, 0.10.9, 0.10.10, 0.10.11, 0.10.12, 0.11.1, 0.11.2, 0.11.3,
 0.11.4, 0.11.5, 0.11.6, 0.11.7, 0.12.1, 0.12.2, 0.12.3, 0.12.4, 0.12.5,
 0.12.6, 0.12.7, 0.12.8, 0.12.9, 0.12.10, 0.12.11, 0.12.12, 0.12.13,
 0.12.14, 0.12.15, 0.12.16,
 0.12.17, 0.12.18, 0.12.19, 0.12.20, 0.12.21, 0.12.22, 0.12.23, 0.12.24,
 0.12.25, 0.13.0, 0.13.1, 0.13.2)
 [ResolutionFailure]:   File
 "/home/oznt/Software/pypa/pipenv/pipenv/resolver.py", line 451, in main
 [ResolutionFailure]:       _main(
 [ResolutionFailure]:   File
 "/home/oznt/Software/pypa/pipenv/pipenv/resolver.py", line 436, in
 _main
 [ResolutionFailure]:       resolve_packages(
 [ResolutionFailure]:   File
 "/home/oznt/Software/pypa/pipenv/pipenv/resolver.py", line 400, in
 resolve_packages
 [ResolutionFailure]:       results, resolver = resolve_deps(
 [ResolutionFailure]:       ^^^^^^^^^^^^^
 [ResolutionFailure]:   File
 "/home/oznt/Software/pypa/pipenv/pipenv/utils/resolver.py", line 971,
 in resolve_deps
 [ResolutionFailure]:       results, hashes, internal_resolver =
 actually_resolve_deps(
 [ResolutionFailure]:       ^^^^^^^^^^^^^^^^^^^^^^
 [ResolutionFailure]:   File
 "/home/oznt/Software/pypa/pipenv/pipenv/utils/resolver.py", line 735,
 in actually_resolve_deps
 [ResolutionFailure]:       resolver.resolve()
 [ResolutionFailure]:   File
 "/home/oznt/Software/pypa/pipenv/pipenv/utils/resolver.py", line 460,
 in resolve
 [ResolutionFailure]:       raise ResolutionFailure(message=e)
 Your dependencies could not be resolved. You likely have a mismatch in
 your sub-dependencies.
 You can use $ pipenv run pip install <requirement_name> to bypass this
 mechanism, then run $ pipenv graph to inspect the versions actually
 installed in the virtualenv.
 Hint: try $ pipenv lock --pre if it is a pre-release dependency.
 ERROR: No matching distribution found for bottle==0.16.0
```

Or:

```
oznt@gentoo:/tmp/bla |pipenv-H8EVR25f| $ pipenv install noSuchDog
Installing noSuchDog...
 Installation Succeeded
Installing dependencies from Pipfile.lock (2110f5)...
All dependencies are now up-to-date!
Upgrading noSuchDog in  dependencies.
Building requirements...
Resolving dependencies...
✘ Locking Failed!
⠹ Locking
packages...CRITICAL:pipenv.patched.pip._internal.resolution.resolvelib.factory:Could
not find a version that satisfies the requirement nosuchdog (from
versions: none)
[ResolutionFailure]:   File
"/home/oznt/Software/pypa/pipenv/pipenv/resolver.py", line 451, in main
[ResolutionFailure]:       _main(
[ResolutionFailure]:   File
"/home/oznt/Software/pypa/pipenv/pipenv/resolver.py", line 436, in _main
[ResolutionFailure]:       resolve_packages(
[ResolutionFailure]:   File
"/home/oznt/Software/pypa/pipenv/pipenv/resolver.py", line 400, in
resolve_packages
[ResolutionFailure]:       results, resolver = resolve_deps(
[ResolutionFailure]:       ^^^^^^^^^^^^^
[ResolutionFailure]:   File
"/home/oznt/Software/pypa/pipenv/pipenv/utils/resolver.py", line 971, in
resolve_deps
[ResolutionFailure]:       results, hashes, internal_resolver =
actually_resolve_deps(
[ResolutionFailure]:       ^^^^^^^^^^^^^^^^^^^^^^
[ResolutionFailure]:   File
"/home/oznt/Software/pypa/pipenv/pipenv/utils/resolver.py", line 735, in
actually_resolve_deps
[ResolutionFailure]:       resolver.resolve()
[ResolutionFailure]:   File
"/home/oznt/Software/pypa/pipenv/pipenv/utils/resolver.py", line 460, in
resolve
[ResolutionFailure]:       raise ResolutionFailure(message=e)
Your dependencies could not be resolved. You likely have a mismatch in
your sub-dependencies.
You can use $ pipenv run pip install <requirement_name> to bypass this
mechanism, then run $ pipenv graph to inspect the versions actually
installed in the virtualenv.
Hint: try $ pipenv lock --pre if it is a pre-release dependency.
ERROR: No matching distribution found for nosuchdog
```

Thank you for contributing to Pipenv!


### The issue

What is the thing you want to fix? Is it associated with an issue on GitHub? Please mention it.

Always consider opening an issue first to describe your problem, so we can discuss what is the best way to amend it.  Note that if you do not describe the goal of this change or link to a related issue, the maintainers may close the PR without further review.

If your pull request makes a significant change to Pipenv, such as the user interface or intended functionality, please open a discussion or issue report first.

### The fix

How does this pull request fix your problem? Did you consider any alternatives? Why is this the *best* solution, in your opinion?


### The checklist

* [ ] Associated issue
* [ ] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

<!--
### If this is a patch to the `vendor` directory...

Please try to refrain from submitting patches directly to `vendor` or `patched`, but raise your issue to the upstream project instead, and inform Pipenv to upgrade when the upstream project accepts the fix.

A pull request to upgrade vendor packages is strongly discouraged, unless there is a very good reason (e.g. you need to test Pipenv’s integration to a new vendor feature). Pipenv audits and performs vendor upgrades regularly, generally before a new release is about to drop.

If your patch is not or cannot be accepted by upstream, but is essential to Pipenv (make sure to discuss this with maintainers!), please remember to attach a patch file in `tasks/vendoring/patched`, so this divergence from upstream can be recorded and replayed afterwards.
-->
