### PR TITLE
Set upper limits on code complexity

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
     exclude: .patch
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.9.0
+  rev: v0.9.3
   hooks:
   - id: ruff
     args: [--fix, --exit-non-zero-on-fix]

--- a/pipenv/environment.py
+++ b/pipenv/environment.py
@@ -816,12 +816,11 @@ class Environment:
             if self.is_venv:
                 os.environ["PYTHONPATH"] = self.base_paths["PYTHONPATH"]
                 os.environ["VIRTUAL_ENV"] = prefix
-            else:
-                if not self.project.s.PIPENV_USE_SYSTEM and not os.environ.get(
-                    "VIRTUAL_ENV"
-                ):
-                    os.environ["PYTHONPATH"] = self.base_paths["PYTHONPATH"]
-                    os.environ.pop("PYTHONHOME", None)
+            elif not self.project.s.PIPENV_USE_SYSTEM and not os.environ.get(
+                "VIRTUAL_ENV"
+            ):
+                os.environ["PYTHONPATH"] = self.base_paths["PYTHONPATH"]
+                os.environ.pop("PYTHONHOME", None)
             sys.path = self.sys_path
             sys.prefix = self.sys_prefix
             try:

--- a/pipenv/project.py
+++ b/pipenv/project.py
@@ -1430,9 +1430,8 @@ class Project:
         result = next(iter(filter(None, (find(finder) for finder in self.finders))), None)
         if not result:
             result = self._which(search)
-        else:
-            if as_path:
-                result = str(result.path)
+        elif as_path:
+            result = str(result.path)
         return result
 
     def python(self, system=False) -> str:
@@ -1457,9 +1456,8 @@ class Project:
                 p = find_windows_executable(os.path.join(location, "Scripts"), command)
             else:
                 p = os.path.join(location, "bin", command)
-        else:
-            if is_python:
-                p = sys.executable
+        elif is_python:
+            p = sys.executable
         if not os.path.exists(p):
             if is_python:
                 p = sys.executable or system_which("python")

--- a/pipenv/utils/dependencies.py
+++ b/pipenv/utils/dependencies.py
@@ -1261,17 +1261,16 @@ def get_constraints_from_deps(deps):
                 c = f"{canonicalize_name(dep_name)}{dep_version}"
             else:
                 c = canonicalize_name(dep_name)
-        else:
-            if not any(k in dep_version for k in ["path", "file", "uri"]):
-                if dep_version.get("skip_resolver") is True:
-                    continue
-                version = dep_version.get("version", None)
-                if version and not is_star(version):
-                    if COMPARE_OP.match(version) is None:
-                        version = f"=={dep_version}"
-                    c = f"{canonicalize_name(dep_name)}{version}"
-                else:
-                    c = canonicalize_name(dep_name)
+        elif not any(k in dep_version for k in ["path", "file", "uri"]):
+            if dep_version.get("skip_resolver") is True:
+                continue
+            version = dep_version.get("version", None)
+            if version and not is_star(version):
+                if COMPARE_OP.match(version) is None:
+                    version = f"=={dep_version}"
+                c = f"{canonicalize_name(dep_name)}{version}"
+            else:
+                c = canonicalize_name(dep_name)
         if c:
             constraints.add(c)
     return constraints

--- a/pipenv/utils/virtualenv.py
+++ b/pipenv/utils/virtualenv.py
@@ -252,58 +252,57 @@ def ensure_python(project, python=None):
 
         if not installer:
             abort("Neither 'pyenv' nor 'asdf' could be found to install Python.")
-        else:
-            if environments.SESSION_IS_INTERACTIVE or project.s.PIPENV_YES:
-                try:
-                    version = installer.find_version_to_install(python)
-                except ValueError:
-                    abort()
-                except InstallerError as e:
-                    abort(f"Something went wrong while installing Python:\n{e.err}")
-                s = (
-                    "Would you like us to install ",
-                    f"[green]CPython {version}[/green] ",
-                    f"with {installer}?",
-                )
+        elif environments.SESSION_IS_INTERACTIVE or project.s.PIPENV_YES:
+            try:
+                version = installer.find_version_to_install(python)
+            except ValueError:
+                abort()
+            except InstallerError as e:
+                abort(f"Something went wrong while installing Python:\n{e.err}")
+            s = (
+                "Would you like us to install ",
+                f"[green]CPython {version}[/green] ",
+                f"with {installer}?",
+            )
 
-                # Prompt the user to continue...
-                if not (project.s.PIPENV_YES or Confirm.ask("".join(s), default=True)):
-                    abort()
-                else:
-                    # Tell the user we're installing Python.
-                    console.print(
-                        f"[bold]Installing [green]CPython[/green] {version} with {installer.cmd}[/bold]"
-                    )
-                    console.print("(this may take a few minutes)[bold]...[/bold]")
-                    with console.status(
-                        "Installing python...", spinner=project.s.PIPENV_SPINNER
-                    ):
-                        try:
-                            c = installer.install(version)
-                        except InstallerError as e:
-                            err.print(
-                                environments.PIPENV_SPINNER_FAIL_TEXT.format("Failed...")
-                            )
-                            err.print("Something went wrong...")
-                            err.print(f"[cyan]{e.err}[/cyan]")
-                        else:
-                            console.print(
-                                environments.PIPENV_SPINNER_OK_TEXT.format("Success!")
-                            )
-                            # Print the results, in a beautiful blue...
-                            err.print(f"[cyan]{c.stdout}[/cyan]")
-                    # Find the newly installed Python, hopefully.
-                    version = str(version)
-                    path_to_python = find_a_system_python(version)
+            # Prompt the user to continue...
+            if not (project.s.PIPENV_YES or Confirm.ask("".join(s), default=True)):
+                abort()
+            else:
+                # Tell the user we're installing Python.
+                console.print(
+                    f"[bold]Installing [green]CPython[/green] {version} with {installer.cmd}[/bold]"
+                )
+                console.print("(this may take a few minutes)[bold]...[/bold]")
+                with console.status(
+                    "Installing python...", spinner=project.s.PIPENV_SPINNER
+                ):
                     try:
-                        assert python_version(path_to_python) == version
-                    except AssertionError:
+                        c = installer.install(version)
+                    except InstallerError as e:
                         err.print(
-                            "[bold][red]Warning:[/red][/bold]"
-                            " The Python you just installed is not available "
-                            "on your [bold]PATH[/bold], apparently."
+                            environments.PIPENV_SPINNER_FAIL_TEXT.format("Failed...")
                         )
-                        sys.exit(1)
+                        err.print("Something went wrong...")
+                        err.print(f"[cyan]{e.err}[/cyan]")
+                    else:
+                        console.print(
+                            environments.PIPENV_SPINNER_OK_TEXT.format("Success!")
+                        )
+                        # Print the results, in a beautiful blue...
+                        err.print(f"[cyan]{c.stdout}[/cyan]")
+                # Find the newly installed Python, hopefully.
+                version = str(version)
+                path_to_python = find_a_system_python(version)
+                try:
+                    assert python_version(path_to_python) == version
+                except AssertionError:
+                    err.print(
+                        "[bold][red]Warning:[/red][/bold]"
+                        " The Python you just installed is not available "
+                        "on your [bold]PATH[/bold], apparently."
+                    )
+                    sys.exit(1)
     return path_to_python
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,13 +140,9 @@ lint.select = [
   "YTT",
 ]
 lint.ignore = [
-  "B904",
-  "PIE790",
-  "PLR0912", # Too many branches
-  "PLR0913", # Too many arguments
-  "PLR2004", # Magic numbers
-  "PLR5501",
-  "PLW2901",
+  "B904",    # `raise` without `from` inside `except`
+  "PIE790",  # Unnecessary `pass` statement
+  "PLW2901", # `for` loop variable overwritten
   "TID252",  # Relative imports
 ]
 lint.per-file-ignores = { "pipenv/cli/command.py" = [
@@ -182,8 +178,9 @@ lint.per-file-ignores = { "pipenv/cli/command.py" = [
   "B015",
 ] }
 lint.mccabe.max-complexity = 44
-lint.pylint.max-args = 9
-lint.pylint.max-branches = 20
+lint.pylint.allow-magic-value-types = [ "int", "str" ]
+lint.pylint.max-args = 18
+lint.pylint.max-branches = 34
 lint.pylint.max-returns = 38
 lint.pylint.max-statements = 155
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -177,7 +177,7 @@ lint.per-file-ignores = { "pipenv/cli/command.py" = [
 ], "pipenv/vendor/pythonfinder/models/python.py" = [
   "B015",
 ] }
-lint.mccabe.max-complexity = 44
+lint.mccabe = 44
 lint.pylint.allow-magic-value-types = [ "int", "str" ]
 lint.pylint.max-args = 18
 lint.pylint.max-branches = 34

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -177,7 +177,7 @@ lint.per-file-ignores = { "pipenv/cli/command.py" = [
 ], "pipenv/vendor/pythonfinder/models/python.py" = [
   "B015",
 ] }
-lint.mccabe = 44
+lint.mccabe.max-complexity = 44
 lint.pylint.allow-magic-value-types = [ "int", "str" ]
 lint.pylint.max-args = 18
 lint.pylint.max-branches = 34


### PR DESCRIPTION
Thank you for contributing to Pipenv!


### The issue

Disabling ruff rules  PLR0912 and PLR0913 has disabled the limits on code complexity `ruff.lint.pylint.max-args` (which has now doubled) and `ruff.lint.pylint.max-branches` (which has increased by 14).  Using numbers forces discussion in code reviews about why the increase in complexity is good for the project. Disabling the rules blinds maintainers to pull requests that increase code complexity.  Refactoring functions to make them less complex improves the project's maintainability.

Upgrade to ruff to the current v0.9.3 and also enforce [collapsible-else-if (PLR5501)](https://docs.astral.sh/ruff/rules/collapsible-else-if/#collapsible-else-if-plr5501) for fewer lines and less indentation.

### The fix

How does this pull request fix your problem? Did you consider any alternatives? Why is this the *best* solution, in your opinion?


### The checklist

* [ ] Associated issue
* [ ] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

<!--
### If this is a patch to the `vendor` directory...

Please try to refrain from submitting patches directly to `vendor` or `patched`, but raise your issue to the upstream project instead, and inform Pipenv to upgrade when the upstream project accepts the fix.

A pull request to upgrade vendor packages is strongly discouraged, unless there is a very good reason (e.g. you need to test Pipenv’s integration to a new vendor feature). Pipenv audits and performs vendor upgrades regularly, generally before a new release is about to drop.

If your patch is not or cannot be accepted by upstream, but is essential to Pipenv (make sure to discuss this with maintainers!), please remember to attach a patch file in `tasks/vendoring/patched`, so this divergence from upstream can be recorded and replayed afterwards.
-->
