### PR TITLE
Fix typo in documentation for PIPENV_CACHE_DIR

### DIFF
--- a/pipenv/environments.py
+++ b/pipenv/environments.py
@@ -108,7 +108,7 @@ class Setting:
         self.USING_DEFAULT_PYTHON = True
         """Use the default Python"""
 
-        #: Location for Pipenv to store it's package cache.
+        #: Location for Pipenv to store its package cache.
         #: Default is to use appdir's user cache directory.
         self.PIPENV_CACHE_DIR = get_from_env(
             "CACHE_DIR", check_for_negation=False, default=user_cache_dir("pipenv")


### PR DESCRIPTION
Thank you for contributing to Pipenv!


### The issue

There is a small typo in the documentation where "it's" is incorrectly used instead of "its" in a comment. 

This is not associated with an open issue, but it's a minor fix to improve clarity and correctness in the documentation.


### The fix

This pull request corrects the typo by replacing: 

```
#: Location for Pipenv to store it's package cache.
```

with

```
#: Location for Pipenv to store its package cache.
```

Since "it's" is a contraction of "it is," the correct possessive form "its" should be used. This fix ensures grammatical correctness in the comment.


### The checklist

* [ ] Associated issue
* [ ] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.
