### PR TITLE
docs: fix minor punctuation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,8 @@ Alternatively, some users prefer to use [Pipx](https://pypi.org/p/pipx):
 
     pipx install pipenv
 
-Or, some users prefer to use Python pip module
+Or, some users prefer to use Python pip module.
+
 
     python -m pip install pipenv
 


### PR DESCRIPTION
Fix: Added missing punctuation in the README file

    What was done:
    In the README file, I corrected a minor punctuation issue by adding a period at the end of a sentence that was previously missing one. The sentence affected was:
    "Or, some users prefer to use Python pip module".
    Now it ends with a period: "Or, some users prefer to use Python pip module."

    Why it's important:
    This fix is part of maintaining proper grammar and readability in the documentation, ensuring it adheres to standard punctuation practices.