### PR TITLE
Refactor virtualenv `bin/` / `Scripts/` path resolution using `sysconfig` mechanism

### DIFF
--- a/news/6737.bugfix.rst
+++ b/news/6737.bugfix.rst
@@ -1,0 +1,22 @@
+# Improved virtualenv scripts path resolution
+
+## Summary
+
+This PR refactors the logic for determining virtual environment script paths
+by leveraging ``sysconfig``'s built-in mechanisms. By removing
+platform-dependent logic, ``pipenv`` now offers enhanced compatibility with
+POSIX-like environments, including Cygwin and MinGW. The fix also mitigates
+execution inconsistencies in non-native Windows environments, improving
+portability across platforms.
+
+## Motivation
+
+The original logic for determining the scripts path was unable to handle the
+deviations of MSYS2 MinGW CPython identifying as ``nt`` platform, yet using a
+POSIX ``{base}/bin`` path, instead of ``{base}/Scripts``.
+
+## Changes
+
+Removed custom logic for determining virtualenv scripts path in favor of
+retrieving the basename of the path string returned by
+``sysconfig.get_path('scripts')```.

--- a/pipenv/environment.py
+++ b/pipenv/environment.py
@@ -26,6 +26,7 @@ from pipenv.utils.funktools import chunked, unnest
 from pipenv.utils.indexes import prepare_pip_source_args
 from pipenv.utils.processes import subprocess_run
 from pipenv.utils.shell import temp_environ
+from pipenv.utils.virtualenv import virtualenv_scripts_dir
 from pipenv.vendor.importlib_metadata.compat.py39 import normalized_name
 from pipenv.vendor.pythonfinder.utils import is_in_path
 
@@ -246,16 +247,12 @@ class Environment:
     @property
     def python(self) -> str:
         """Path to the environment python"""
-        if self._python is not None:
-            return self._python
-        if os.name == "nt" and not self.is_venv:
-            py = Path(self.prefix).joinpath("python").absolute().as_posix()
-        else:
-            py = Path(self.script_basedir).joinpath("python").absolute().as_posix()
-        if not py:
-            py = Path(sys.executable).as_posix()
-        self._python = py
-        return py
+        if self._python is None:
+            self._python = (
+                (virtualenv_scripts_dir(self.prefix) / "python").absolute().as_posix()
+            )
+
+        return self._python
 
     @cached_property
     def sys_path(self) -> list[str]:

--- a/pipenv/routines/shell.py
+++ b/pipenv/routines/shell.py
@@ -5,6 +5,7 @@ from os.path import expandvars
 
 from pipenv.utils.project import ensure_project
 from pipenv.utils.shell import cmd_list_to_shell, system_which
+from pipenv.utils.virtualenv import virtualenv_scripts_dir
 from pipenv.vendor import click
 
 
@@ -60,7 +61,6 @@ def do_run(project, command, args, python=False, pypi_mirror=None):
 
     Args are appended to the command in [scripts] section of project if found.
     """
-    from pathlib import Path
 
     from pipenv.cmdparse import ScriptEmptyError
 
@@ -79,12 +79,7 @@ def do_run(project, command, args, python=False, pypi_mirror=None):
         # Get the exact string representation of virtualenv_location
         virtualenv_location = str(project.virtualenv_location)
 
-        # Use pathlib for path construction but convert back to string
-        from pathlib import Path
-
-        virtualenv_path = Path(virtualenv_location)
-        bin_dir = "Scripts" if os.name == "nt" else "bin"
-        new_path = str(virtualenv_path / bin_dir)
+        new_path = str(virtualenv_scripts_dir(virtualenv_location))
 
         # Update PATH
         paths = path.split(os.pathsep)

--- a/pipenv/utils/virtualenv.py
+++ b/pipenv/utils/virtualenv.py
@@ -3,6 +3,7 @@ import os
 import re
 import shutil
 import sys
+import sysconfig
 from pathlib import Path
 
 from pipenv import environments, exceptions
@@ -11,6 +12,20 @@ from pipenv.utils.dependencies import python_version
 from pipenv.utils.environment import ensure_environment
 from pipenv.utils.processes import subprocess_run
 from pipenv.utils.shell import find_python, shorten_path
+
+
+def virtualenv_scripts_dir(b):
+    """returns a system-dependent scripts path
+
+    POSIX environments (including Cygwin/MinGW64) will result in
+    `{base}/bin/`, native Windows environments will result in
+    `{base}/Scripts/`.
+
+    :param b: base path
+    :type b: str
+    :returns: pathlib.Path
+    """
+    return Path(f"{b}/{Path(sysconfig.get_path('scripts')).name}")
 
 
 def warn_in_virtualenv(project):

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,10 +1,11 @@
 import os
+import sys
 from unittest import mock
 
 import pytest
 
 from pipenv.exceptions import PipenvUsageError
-from pipenv.utils import dependencies, indexes, internet, shell, toml
+from pipenv.utils import dependencies, indexes, internet, shell, toml, virtualenv
 
 # Pipfile format <-> requirements.txt format.
 DEP_PIP_PAIRS = [
@@ -547,3 +548,17 @@ twine = "*"
         name = "ZZZ"
         monkeypatch.delenv(name, raising=False)
         assert shell.is_env_truthy(name) is False
+
+    @pytest.mark.utils
+    # substring search in version handles special-case of MSYS2 MinGW CPython
+    # https://github.com/msys2/MINGW-packages/blob/master/mingw-w64-python/0017-sysconfig-treat-MINGW-builds-as-POSIX-builds.patch#L24
+    @pytest.mark.skipif(os.name != "nt" or "GCC" in sys.version, reason="Windows test only")
+    def test_virtualenv_scripts_dir_nt(self):
+        """
+        """
+        assert str(virtualenv.virtualenv_scripts_dir('foobar')) == 'foobar\\Scripts'
+
+    @pytest.mark.utils
+    @pytest.mark.skipif(os.name == "nt" and "GCC" not in sys.version, reason="POSIX test only")
+    def test_virtualenv_scripts_dir_posix(self):
+        assert str(virtualenv.virtualenv_scripts_dir('foobar')) == 'foobar/bin'


### PR DESCRIPTION
This pull request refactors the logic for determining the venv's `scripts/`. or `bin/` directory location by leveraging `sysconfig`’s built-in mechanism for retrieving the complete global install directory path of scripts and retrieving its basename. This removes any platform-dependent logic and does not require an additional dependency.

Changes:

    feat: Introduced a new approach for venv scripts path lookup, eliminating reliance on platform identifiers and improving compatibility with POSIX-like environments such as Cygwin and MinGW.

    refactor: Updated both project-wide and routine-specific implementations to use the virtualenv mechanism for dynamic script location lookup, streamlining execution.

These changes mitigate execution inconsistencies in non-native Windows environments and improve portability across platforms.

Fixes:  https://github.com/pypa/pipenv/issues/5978