### PR TITLE
Correct check/scan command documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,7 +84,7 @@ Bug Fixes
 - Update ``check`` command to support the new ``scan`` functionality
   ---------------------------------------------------------------
 
-  The ``check`` command has been deprecated and will be unsupported beyond June 1, 2024.
+  The ``check`` command has been deprecated and will be unsupported beyond June 1, 2025.
   Instead of adding a separate ``scan`` command, we've updated the ``check`` command to include a ``--scan`` option.
 
   Key changes:

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -36,7 +36,7 @@ Options:
 --scan                          Use the new scan command instead of the deprecated check command.
 ```
 
-**Note**: The check command is deprecated and will be unsupported beyond 01 June 2024. In future versions, the check command will run the scan command by default. Use the `--scan` option to run the new scan command now.
+**Note**: The check command is deprecated and will be unsupported beyond 01 June 2025. In future versions, the check command will run the scan command by default. Use the `--scan` option to run the new scan command now.
 
 When using the `--scan` option, you'll need to obtain an API key from https://pyup.io to access the full vulnerability database.
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -83,14 +83,7 @@ The user can provide these additional parameters:
 The user can provide these additional parameters:
 
     --auto-install — Automatically install safety if not already installed.
-
-## scan
-
-``$ pipenv scan`` scans for security vulnerabilities and checks PEP 508 markers. This is the newer version of the check command with improved functionality.
-
-The user can provide these additional parameters:
-
-    --auto-install — Automatically install safety if not already installed.
+    --scan - Enable the newer version of the check command with improved functionality.
 
 ## scripts
 ``$ pipenv scripts`` will list the scripts in the current environment config.

--- a/pipenv/cli/command.py
+++ b/pipenv/cli/command.py
@@ -530,8 +530,7 @@ def check(
 ):
     """DEPRECATED: Checks for PyUp Safety security vulnerabilities and against PEP 508 markers provided in Pipfile.
 
-    This command has been deprecated and will be unsupported beyond 01 June 2024.
-    Please use the 'scan' command instead, which is easier to use and more powerful.
+    This command has been deprecated and will be replaced beyond 01 June 2025.
 
     Use the --scan option to run the new scan command instead of the deprecated check command.
     In future versions, the check command will run the scan command by default.


### PR DESCRIPTION
In commit 56d45354e12fd9a3b8cd13dc64ac8566225a29a8 the new `--scan` option for the `check` command was introduced, and a deprecation warning was added. The deprecation warning is misleading since it has the wrong date and references a `scan` command which does not exist. This will remove the `scan` command from the documentation and update the deprecation warning.

Reference-to: https://github.com/pypa/pipenv/issues/6396
