### PR TITLE
Fix derivation of local package names in Pipfile

### DIFF
--- a/pipenv/utils/dependencies.py
+++ b/pipenv/utils/dependencies.py
@@ -684,9 +684,10 @@ def find_package_name_from_directory(directory):
             directory_path = Path(directory_str[1:])
 
     try:
-        # Sort contents - directories first, then files
+        # Sort contents - files first, then directories to search parent
+        # directories before leaf directories.
         directory_contents = sorted(
-            directory_path.iterdir(), key=lambda x: (x.is_file(), x.name)
+            directory_path.iterdir(), key=lambda x: (x.is_dir(), x.name)
         )
 
         for path in directory_contents:
@@ -844,31 +845,31 @@ def determine_package_name(package: InstallRequirement):
 
 
 def find_package_name_from_filename(filename, file):
-    if filename.endswith("METADATA"):
+    if filename == "METADATA":
         content = file.read().decode()
         possible_name = parse_metadata_file(content)
         if possible_name:
             return possible_name
 
-    if filename.endswith("PKG-INFO"):
+    if filename == "PKG-INFO":
         content = file.read().decode()
         possible_name = parse_pkginfo_file(content)
         if possible_name:
             return possible_name
 
-    if filename.endswith("setup.py"):
+    if filename == "setup.py":
         content = file.read().decode()
         possible_name = parse_setup_file(content)
         if possible_name:
             return possible_name
 
-    if filename.endswith("setup.cfg"):
+    if filename == "setup.cfg":
         content = file.read().decode()
         possible_name = parse_cfg_file(content)
         if possible_name:
             return possible_name
 
-    if filename.endswith("pyproject.toml"):
+    if filename == "pyproject.toml":
         content = file.read().decode()
         possible_name = parse_toml_file(content)
         if possible_name:

--- a/tests/integration/test_install_nested_setup.py
+++ b/tests/integration/test_install_nested_setup.py
@@ -57,5 +57,5 @@ def configure():
 
         # Ensure my_simple_package was not parsed from the setup.py module
         # inside the package.
-        with open(Path(p.path) / "Pipfile", "r") as f:
+        with open(Path(p.path) / "Pipfile") as f:
             assert "my_simple_package" not in f.read()

--- a/tests/integration/test_install_nested_setup.py
+++ b/tests/integration/test_install_nested_setup.py
@@ -1,0 +1,61 @@
+import os
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.install
+@pytest.mark.needs_internet
+@pytest.mark.skipif(
+    os.name == "nt",
+    reason="This test is not for Windows",
+)
+def test_install_path_with_nested_setup_module(pipenv_instance_pypi):
+    with pipenv_instance_pypi() as p:
+        # Create a simple package.
+        package_dir = Path(p.path) / "simple_package"
+        package_dir.mkdir()
+
+        # Create a simple setup.py file
+        with open(package_dir / "setup.py", "w") as f:
+            f.write("""
+from setuptools import setup, find_packages
+
+setup(
+    name="simple-package",
+    version="0.1.0",
+    packages=find_packages(),
+)
+""")
+        module_dir = package_dir / "simple_package"
+        module_dir.mkdir()
+
+        (module_dir / "__init__.py").touch()
+
+        # Create the package module
+        with open(module_dir / "setup.py", "w") as f:
+            f.write("""
+def setup(name = ''):
+    return f'Setup package {name}'
+
+def configure():
+    return setup(name='my_simple_package')
+""")
+
+        # Install the package using a path with spaces
+        # Use both escaped spaces and quoted path to test both scenarios
+        relative_package_dir = package_dir.relative_to(p.path)
+        c = p.pipenv(f'install -e {relative_package_dir}')
+        assert c.returncode == 0
+
+        # Verify the package was installed correctly
+        c = p.pipenv('run python -c "'
+                     'from simple_package import setup; '
+                     'print(setup.configure())"')
+        assert c.returncode == 0
+        assert "Setup package my_simple_package" in c.stdout
+
+        # Ensure my_simple_package was not parsed from the setup.py module
+        # inside the package.
+        with open(Path(p.path) / "Pipfile", "r") as f:
+            assert "my_simple_package" not in f.read()


### PR DESCRIPTION
Fixes https://github.com/pypa/pipenv/issues/6409

Thank you for contributing to Pipenv!


### The issue

Fixes https://github.com/pypa/pipenv/issues/6409

### The fix

Iterates parent directories searching for package metadata files (e.g setup.py etc.) before leaf directories within a package.
