### PR TITLE
Add back ignore_compatibility option to pip package finder for comprehensive lock file generation

### DIFF
--- a/news/6426.bugfix.rst
+++ b/news/6426.bugfix.rst
@@ -1,0 +1,1 @@
+Restored ignore compatibility finder patch to enable comprehensive cross-platform hash collection in lock files.

--- a/pipenv/patched/pip/_internal/index/package_finder.py
+++ b/pipenv/patched/pip/_internal/index/package_finder.py
@@ -135,6 +135,7 @@ class LinkEvaluator:
         target_python: TargetPython,
         allow_yanked: bool,
         ignore_requires_python: Optional[bool] = None,
+        ignore_compatibility: Optional[bool] = None,
     ) -> None:
         """
         :param project_name: The user supplied package name.
@@ -152,6 +153,8 @@ class LinkEvaluator:
         :param ignore_requires_python: Whether to ignore incompatible
             PEP 503 "data-requires-python" values in HTML links. Defaults
             to False.
+        :param ignore_compatibility: Whether to ignore
+            compatibility of python versions and allow all versions of packages.
         """
         if ignore_requires_python is None:
             ignore_requires_python = False
@@ -161,7 +164,7 @@ class LinkEvaluator:
         self._ignore_requires_python = ignore_requires_python
         self._formats = formats
         self._target_python = target_python
-
+        self._ignore_compatibility = ignore_compatibility
         self.project_name = project_name
 
     def evaluate_link(self, link: Link) -> Tuple[LinkType, str]:
@@ -191,10 +194,10 @@ class LinkEvaluator:
                     LinkType.format_unsupported,
                     f"unsupported archive format: {ext}",
                 )
-            if "binary" not in self._formats and ext == WHEEL_EXTENSION:
+            if "binary" not in self._formats and ext == WHEEL_EXTENSION and not self._ignore_compatibility:
                 reason = f"No binaries permitted for {self.project_name}"
                 return (LinkType.format_unsupported, reason)
-            if "macosx10" in link.path and ext == ".zip":
+            if "macosx10" in link.path and ext == ".zip" and not self._ignore_compatibility:
                 return (LinkType.format_unsupported, "macosx10 one")
             if ext == WHEEL_EXTENSION:
                 try:
@@ -209,7 +212,7 @@ class LinkEvaluator:
                     return (LinkType.different_project, reason)
 
                 supported_tags = self._target_python.get_unsorted_tags()
-                if not wheel.supported(supported_tags):
+                if not wheel.supported(supported_tags) and not self._ignore_compatibility:
                     # Include the wheel's tags in the reason string to
                     # simplify troubleshooting compatibility issues.
                     file_tags = ", ".join(wheel.get_formatted_file_tags())
@@ -250,7 +253,7 @@ class LinkEvaluator:
             version_info=self._target_python.py_version_info,
             ignore_requires_python=self._ignore_requires_python,
         )
-        if not supports_python:
+        if not supports_python and not self._ignore_compatibility:
             reason = f"{version} Requires-Python {link.requires_python}"
             return (LinkType.requires_python_mismatch, reason)
 
@@ -473,7 +476,11 @@ class CandidateEvaluator:
 
         return sorted(filtered_applicable_candidates, key=self._sort_key)
 
-    def _sort_key(self, candidate: InstallationCandidate) -> CandidateSortingKey:
+    def _sort_key(
+        self,
+        candidate: InstallationCandidate,
+        ignore_compatibility: bool = True,
+    ) -> CandidateSortingKey:
         """
         Function to pass as the `key` argument to a call to sorted() to sort
         InstallationCandidates by preference.
@@ -518,10 +525,12 @@ class CandidateEvaluator:
                     )
                 )
             except ValueError:
-                raise UnsupportedWheel(
-                    f"{wheel.filename} is not a supported wheel for this platform. It "
-                    "can't be sorted."
-                )
+                if not ignore_compatibility:
+                    raise UnsupportedWheel(
+                        f"{wheel.filename} is not a supported wheel for this platform. It "
+                        "can't be sorted."
+                    )
+                pri = -support_num
             if self._prefer_binary:
                 binary_preference = 1
             build_tag = wheel.build_tag
@@ -584,6 +593,7 @@ class PackageFinder:
         format_control: Optional[FormatControl] = None,
         candidate_prefs: Optional[CandidatePreferences] = None,
         ignore_requires_python: Optional[bool] = None,
+        ignore_compatibility: Optional[bool] = False,
     ) -> None:
         """
         This constructor is primarily meant to be used by the create() class
@@ -605,7 +615,7 @@ class PackageFinder:
         self._ignore_requires_python = ignore_requires_python
         self._link_collector = link_collector
         self._target_python = target_python
-
+        self._ignore_compatibility = ignore_compatibility
         self.format_control = format_control
 
         # These are boring links that have already been logged somehow.
@@ -730,6 +740,7 @@ class PackageFinder:
             target_python=self._target_python,
             allow_yanked=self._allow_yanked,
             ignore_requires_python=self._ignore_requires_python,
+            ignore_compatibility=self._ignore_compatibility,
         )
 
     def _sort_links(self, links: Iterable[Link]) -> List[Link]:

--- a/tasks/vendoring/patches/patched/pip_finder_ignore_compatability.patch
+++ b/tasks/vendoring/patches/patched/pip_finder_ignore_compatability.patch
@@ -1,0 +1,114 @@
+--- a/pipenv/patched/pip/_internal/index/package_finder.py
++++ b/pipenv/patched/pip/_internal/index/package_finder.py
+@@ -135,6 +135,7 @@ class LinkEvaluator:
+         target_python: TargetPython,
+         allow_yanked: bool,
+         ignore_requires_python: Optional[bool] = None,
++        ignore_compatibility: Optional[bool] = None,
+     ) -> None:
+         """
+         :param project_name: The user supplied package name.
+@@ -152,6 +153,8 @@ class LinkEvaluator:
+         :param ignore_requires_python: Whether to ignore incompatible
+             PEP 503 "data-requires-python" values in HTML links. Defaults
+             to False.
++        :param ignore_compatibility: Whether to ignore
++            compatibility of python versions and allow all versions of packages.
+         """
+         if ignore_requires_python is None:
+             ignore_requires_python = False
+@@ -161,7 +164,7 @@ class LinkEvaluator:
+         self._ignore_requires_python = ignore_requires_python
+         self._formats = formats
+         self._target_python = target_python
+-
++        self._ignore_compatibility = ignore_compatibility
+         self.project_name = project_name
+
+     def evaluate_link(self, link: Link) -> Tuple[LinkType, str]:
+@@ -191,10 +194,10 @@ class LinkEvaluator:
+                     LinkType.format_unsupported,
+                     f"unsupported archive format: {ext}",
+                 )
+-            if "binary" not in self._formats and ext == WHEEL_EXTENSION:
++            if "binary" not in self._formats and ext == WHEEL_EXTENSION and not self._ignore_compatibility:
+                 reason = f"No binaries permitted for {self.project_name}"
+                 return (LinkType.format_unsupported, reason)
+-            if "macosx10" in link.path and ext == ".zip":
++            if "macosx10" in link.path and ext == ".zip" and not self._ignore_compatibility:
+                 return (LinkType.format_unsupported, "macosx10 one")
+             if ext == WHEEL_EXTENSION:
+                 try:
+@@ -209,7 +212,7 @@ class LinkEvaluator:
+                     return (LinkType.different_project, reason)
+
+                 supported_tags = self._target_python.get_unsorted_tags()
+-                if not wheel.supported(supported_tags):
++                if not wheel.supported(supported_tags) and not self._ignore_compatibility:
+                     # Include the wheel's tags in the reason string to
+                     # simplify troubleshooting compatibility issues.
+                     file_tags = ", ".join(wheel.get_formatted_file_tags())
+@@ -250,7 +253,7 @@ class LinkEvaluator:
+             version_info=self._target_python.py_version_info,
+             ignore_requires_python=self._ignore_requires_python,
+         )
+-        if not supports_python:
++        if not supports_python and not self._ignore_compatibility:
+             reason = f"{version} Requires-Python {link.requires_python}"
+             return (LinkType.requires_python_mismatch, reason)
+
+@@ -473,7 +476,11 @@ class PackageFinder:
+
+         return sorted(filtered_applicable_candidates, key=self._sort_key)
+
+-    def _sort_key(self, candidate: InstallationCandidate) -> CandidateSortingKey:
++    def _sort_key(
++        self,
++        candidate: InstallationCandidate,
++        ignore_compatibility: bool = True,
++    ) -> CandidateSortingKey:
+         """
+         Function to pass as the `key` argument to a call to sorted() to sort
+         InstallationCandidates by preference.
+@@ -518,10 +525,12 @@ class PackageFinder:
+                     )
+                 )
+             except ValueError:
+-                raise UnsupportedWheel(
+-                    f"{wheel.filename} is not a supported wheel for this platform. It "
+-                    "can't be sorted."
+-                )
++                if not ignore_compatibility:
++                    raise UnsupportedWheel(
++                        f"{wheel.filename} is not a supported wheel for this platform. It "
++                        "can't be sorted."
++                    )
++                pri = -support_num
+             if self._prefer_binary:
+                 binary_preference = 1
+             build_tag = wheel.build_tag
+@@ -584,6 +593,7 @@ class PackageFinder:
+         format_control: Optional[FormatControl] = None,
+         candidate_prefs: Optional[CandidatePreferences] = None,
+         ignore_requires_python: Optional[bool] = None,
++        ignore_compatibility: Optional[bool] = False,
+     ) -> None:
+         """
+         This constructor is primarily meant to be used by the create() class
+@@ -605,7 +615,7 @@ class PackageFinder:
+         self._ignore_requires_python = ignore_requires_python
+         self._link_collector = link_collector
+         self._target_python = target_python
+-
++        self._ignore_compatibility = ignore_compatibility
+         self.format_control = format_control
+
+         # These are boring links that have already been logged somehow.
+@@ -730,6 +740,7 @@ class PackageFinder:
+             target_python=self._target_python,
+             allow_yanked=self._allow_yanked,
+             ignore_requires_python=self._ignore_requires_python,
++            ignore_compatibility=self._ignore_compatibility,
+         )
+
+     def _sort_links(self, links: Iterable[Link]) -> List[Link]:


### PR DESCRIPTION
### The issue

This patch was mistakenly dropped during the last pip vendoring update, which caused #6423 


## Add ignore_compatibility option to pip package finder for comprehensive lock file generation

### Summary
This PR restores and formalizes the `ignore_compatibility` patch for pip's package finder, enabling Pipenv to include all relevant package hashes in lock files regardless of platform compatibility constraints.

### Problem
Currently, pip's package finder filters out packages based on platform compatibility (wheel tags, Python version requirements, etc.), which prevents Pipenv from generating comprehensive lock files that include hashes for all platforms. This creates issues when:

- Lock files are generated on one platform but used on another
- Cross-platform deployments require packages for different architectures
- Complete hash verification is needed for security across all supported platforms

### Solution
This patch adds an `ignore_compatibility` parameter to both `LinkEvaluator` and `PackageFinder` classes that:

1. **Bypasses binary format restrictions** - Allows wheels even when `"binary"` is not in accepted formats
2. **Ignores wheel platform tags** - Includes wheels regardless of platform compatibility 
3. **Skips Python version checks** - Includes packages that don't match the current Python version
4. **Handles unsupported wheels gracefully** - Prevents crashes when sorting incompatible wheels

### Changes
- Added `ignore_compatibility` parameter to `LinkEvaluator.__init__()`
- Modified `evaluate_link()` to conditionally skip compatibility checks
- Updated `_sort_key()` to handle unsupported wheels without raising exceptions
- Added `ignore_compatibility` parameter to `PackageFinder.__init__()`
- Created formal patch file for vendoring process

### Impact
This enables Pipenv to generate lock files with comprehensive hash coverage across all platforms while maintaining backward compatibility (defaults to `False`).

**Files changed:**
- `pipenv/patched/pip/_internal/index/package_finder.py`
- `tasks/vendoring/patches/patched/pip_finder_ignore_compatability.patch`

### The checklist

* [X] Associated issue
* [ ] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.
