### PR TITLE
Validate Python version when using --system flag

### DIFF
--- a/news/6403.bugfix.rst
+++ b/news/6403.bugfix.rst
@@ -1,0 +1,3 @@
+Validate Python version when using ``--system`` flag.
+Previously, ``pipenv install --system --deploy`` would silently proceed even if the system Python version didn't match the ``python_version`` specified in Pipfile/Pipfile.lock.
+Now it properly raises a DeployException when the versions don't match.

--- a/pipenv/utils/project.py
+++ b/pipenv/utils/project.py
@@ -49,27 +49,27 @@ def ensure_project(
             site_packages=site_packages,
             pypi_mirror=pypi_mirror,
         )
-        if warn:
-            # Warn users if they are using the wrong version of Python.
-            if project.required_python_version:
-                path_to_python = project._which("python") or project._which("py")
-                if path_to_python and project.required_python_version not in (
-                    python_version(path_to_python) or ""
-                ):
-                    err.print(
-                        f"[red][bold]Warning[/bold][/red]: Your Pipfile requires "
-                        f'[bold]"python_version"[/bold] [cyan]{project.required_python_version}[/cyan], '
-                        f"but you are using [cyan]{python_version(path_to_python)}[/cyan] "
-                        f"from [green]{shorten_path(path_to_python)}[/green]."
-                    )
-                    err.print(
-                        "[green]$ pipenv --rm[/green] and rebuilding the virtual environment "
-                        "may resolve the issue."
-                    )
-                    if not deploy:
-                        err.print("[yellow]$ pipenv check[/yellow] will surely fail.")
-                    else:
-                        raise exceptions.DeployException
+    # Always check Python version when warn is True (for both virtualenv and --system)
+    if warn and project.required_python_version:
+        path_to_python = project._which("python") or project._which("py")
+        if path_to_python and project.required_python_version not in (
+            python_version(path_to_python) or ""
+        ):
+            err.print(
+                f"[red][bold]Warning[/bold][/red]: Your Pipfile requires "
+                f'[bold]"python_version"[/bold] [cyan]{project.required_python_version}[/cyan], '
+                f"but you are using [cyan]{python_version(path_to_python)}[/cyan] "
+                f"from [green]{shorten_path(path_to_python)}[/green]."
+            )
+            if not system_or_exists:
+                err.print(
+                    "[green]$ pipenv --rm[/green] and rebuilding the virtual environment "
+                    "may resolve the issue."
+                )
+            if not deploy:
+                err.print("[yellow]$ pipenv check[/yellow] will surely fail.")
+            else:
+                raise exceptions.DeployException
     # Ensure the Pipfile exists.
     ensure_pipfile(
         project,


### PR DESCRIPTION
## Summary

Fixes #6403

Previously, `pipenv install --system --deploy` would silently proceed even if the system Python version didn't match the `python_version` specified in Pipfile/Pipfile.lock. This was a significant gap in the `--deploy` safety checks.

## The Problem

The Python version validation code was only executed inside the `if not system_or_exists:` block, which means it was skipped entirely when using `--system`. This allowed installations to proceed with an incompatible Python version without any warning or error.

## The Fix

This PR moves the Python version check outside of the virtualenv creation block so it runs for both:
- Standard virtualenv installations
- `--system` installations

When `--deploy` is used with an incompatible Python version, a `DeployException` is now properly raised.

The fix also adjusts the warning message: the suggestion to use `pipenv --rm` is only shown for virtualenv installations (not `--system`).

## Testing

Before this fix (using the Dockerfile from the issue):
```dockerfile
FROM python:3.13-slim
# Pipfile requires python_version = "3.12"
RUN pipenv install --system --deploy
# ✓ Succeeds (should fail!)
```

After this fix:
```
RUN pipenv install --system --deploy
# ✗ Raises DeployException (expected behavior)
```

## Checklist

- [x] Associated issue: #6403
- [x] News fragment: `news/6403.bugfix.rst`

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author