### PR TITLE
Handle venv_resolve_deps exception

### DIFF
--- a/news/6166.bugfix.rst
+++ b/news/6166.bugfix.rst
@@ -1,0 +1,2 @@
+Improve error handling in ``do_lock`` by properly catching and handling exceptions from ``venv_resolve_deps``.
+RuntimeError now exits cleanly, and other exceptions display a full traceback for debugging.

--- a/pipenv/routines/lock.py
+++ b/pipenv/routines/lock.py
@@ -1,4 +1,6 @@
 import contextlib
+import sys
+import traceback
 
 from pipenv.utils import err
 from pipenv.utils.dependencies import (
@@ -58,21 +60,27 @@ def do_lock(
 
         from pipenv.utils.resolver import venv_resolve_deps
 
-        # Mutates the lockfile
-        venv_resolve_deps(
-            packages,
-            which=project._which,
-            project=project,
-            pipfile_category=pipfile_category,
-            clear=clear,
-            pre=pre,
-            allow_global=system,
-            pypi_mirror=pypi_mirror,
-            pipfile=packages,
-            lockfile=lockfile,
-            old_lock_data=old_lock_data,
-            extra_pip_args=extra_pip_args,
-        )
+        try:
+            # Mutates the lockfile
+            venv_resolve_deps(
+                packages,
+                which=project._which,
+                project=project,
+                pipfile_category=pipfile_category,
+                clear=clear,
+                pre=pre,
+                allow_global=system,
+                pypi_mirror=pypi_mirror,
+                pipfile=packages,
+                lockfile=lockfile,
+                old_lock_data=old_lock_data,
+                extra_pip_args=extra_pip_args,
+            )
+        except RuntimeError:
+            sys.exit(1)
+        except Exception:
+            err.print(traceback.format_exc())
+            sys.exit(1)
 
     # Overwrite any category packages with default packages.
     for category in lockfile_categories:


### PR DESCRIPTION
### The issue

This is an enhancement of error handling regards to https://github.com/pypa/pipenv/issues/6073.

Inside `do_lock` method, exceptions in `venv_resolve_deps` weren't properly handled. This PR handles exceptions to improve this problem.

### The fix

- Add try-catch exception handling around `venv_resolve_deps` in `do_lock`
- RuntimeError exits cleanly (since the error message is already displayed by the resolver)
- Other exceptions display a full traceback for debugging before exiting

### The checklist

* [x] Associated issue
* [x] A news fragment in the `news/` directory

Closes #6073
Supersedes #6166

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author