### PR TITLE
Add pipenv audit command using pip-audit for vulnerability scanning

### DIFF
--- a/pipenv/cli/command.py
+++ b/pipenv/cli/command.py
@@ -532,10 +532,10 @@ def check(
 ):
     """DEPRECATED: Checks for PyUp Safety security vulnerabilities and against PEP 508 markers provided in Pipfile.
 
-    This command has been deprecated and will be replaced beyond 01 June 2025.
+    This command is deprecated. Please use 'pipenv audit' instead, which uses pip-audit
+    for vulnerability scanning and requires no API key.
 
-    Use the --scan option to run the new scan command instead of the deprecated check command.
-    In future versions, the check command will run the scan command by default.
+    Alternatively, use --scan to use Safety's scan command (requires API key).
     """
 
     from pipenv.routines.check import do_check
@@ -560,6 +560,160 @@ def check(
         categories=categories,
         auto_install=auto_install,
         scan=scan,
+    )
+
+
+@cli.command(
+    short_help="Audits packages for security vulnerabilities using pip-audit.",
+    context_settings=subcommand_context,
+)
+@option(
+    "--output",
+    "-f",
+    type=Choice(["columns", "json", "cyclonedx-json", "cyclonedx-xml", "markdown"]),
+    default="columns",
+    help="Output format for audit results.",
+)
+@option(
+    "--vulnerability-service",
+    "-s",
+    type=Choice(["pypi", "osv"]),
+    default="pypi",
+    help="Vulnerability service to query (pypi or osv).",
+)
+@option(
+    "--ignore",
+    "-i",
+    multiple=True,
+    help="Ignore a specific vulnerability by ID (can be used multiple times).",
+)
+@option(
+    "--fix",
+    is_flag=True,
+    default=False,
+    help="Automatically upgrade packages with known vulnerabilities.",
+)
+@option(
+    "--dry-run",
+    is_flag=True,
+    default=False,
+    help="Collect dependencies but do not audit (or with --fix: audit but do not fix).",
+)
+@option(
+    "--strict",
+    is_flag=True,
+    default=False,
+    help="Fail if dependency collection fails on any dependency.",
+)
+@option(
+    "--skip-editable",
+    is_flag=True,
+    default=False,
+    help="Skip auditing editable packages.",
+)
+@option(
+    "--no-deps",
+    is_flag=True,
+    default=False,
+    help="Don't perform dependency resolution (requires pinned requirements).",
+)
+@option(
+    "--local",
+    is_flag=True,
+    default=False,
+    help="Only audit packages in the local environment.",
+)
+@option(
+    "--desc",
+    is_flag=True,
+    default=False,
+    help="Include descriptions for each vulnerability.",
+)
+@option(
+    "--aliases",
+    is_flag=True,
+    default=False,
+    help="Include alias IDs (CVE, GHSA) for each vulnerability.",
+)
+@option(
+    "--output-file",
+    "-o",
+    default=None,
+    help="Output results to the given file.",
+)
+@option(
+    "--quiet",
+    is_flag=True,
+    default=False,
+    help="Quiet mode - minimal output.",
+)
+@option(
+    "--locked",
+    is_flag=True,
+    default=False,
+    help="Audit lockfiles (pyproject.toml/pylock.toml) instead of the environment.",
+)
+@common_options
+@system_option
+@pass_state
+def audit(
+    state,
+    output="columns",
+    vulnerability_service="pypi",
+    ignore=None,
+    fix=False,
+    dry_run=False,
+    strict=False,
+    skip_editable=False,
+    no_deps=False,
+    local=False,
+    desc=False,
+    aliases=False,
+    output_file=None,
+    quiet=False,
+    locked=False,
+    **kwargs,
+):
+    """Audit packages for known security vulnerabilities using pip-audit.
+
+    This command scans your environment for packages with known vulnerabilities
+    using the Python Packaging Advisory Database (PyPI) or Open Source
+    Vulnerabilities (OSV) database.
+
+    Examples:
+
+        pipenv audit
+
+        pipenv audit --fix
+
+        pipenv audit -f json
+
+        pipenv audit --ignore PYSEC-2021-123
+
+        pipenv audit --locked  # Audit pyproject.toml/pylock.toml
+    """
+    from pipenv.routines.audit import do_audit
+
+    do_audit(
+        state.project,
+        python=state.python,
+        system=state.system,
+        output=output,
+        quiet=quiet,
+        verbose=state.verbose,
+        strict=strict,
+        ignore=ignore,
+        fix=fix,
+        dry_run=dry_run,
+        skip_editable=skip_editable,
+        no_deps=no_deps,
+        local_only=local,
+        vulnerability_service=vulnerability_service,
+        descriptions=desc,
+        aliases=aliases,
+        output_file=output_file,
+        pypi_mirror=state.pypi_mirror,
+        use_lockfile=locked,
     )
 
 

--- a/pipenv/routines/audit.py
+++ b/pipenv/routines/audit.py
@@ -1,0 +1,242 @@
+"""
+Audit command implementation using pip-audit for vulnerability scanning.
+
+This module provides the preferred way to audit Python packages for known
+security vulnerabilities using pip-audit, which queries the Python Packaging
+Advisory Database (PyPI) or Open Source Vulnerabilities (OSV) database.
+"""
+
+import logging
+import subprocess
+import sys
+
+from pipenv.utils import console, err
+from pipenv.utils.processes import run_command
+from pipenv.utils.project import ensure_project
+from pipenv.utils.shell import project_python
+
+
+def is_pip_audit_installed(project=None, system=False):
+    """Check if pip-audit is installed by trying to run it."""
+    if project:
+        python = project_python(project, system=system)
+    else:
+        python = sys.executable
+
+    try:
+        result = subprocess.run(
+            [python, "-m", "pip_audit", "--version"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        return result.returncode == 0
+    except Exception:
+        return False
+
+
+def install_pip_audit(project, system=False):
+    """Install pip-audit."""
+    from pipenv.vendor import click
+
+    python = project_python(project, system=system)
+
+    console.print(
+        "[yellow bold]pip-audit is required for vulnerability scanning but not installed.[/yellow bold]"
+    )
+
+    install = click.confirm(
+        "Would you like to install pip-audit? This will not modify your Pipfile/lockfile.",
+        default=True,
+    )
+
+    if not install:
+        console.print(
+            "[yellow]Vulnerability scanning skipped. Install pip-audit with 'pip install pip-audit'[/yellow]"
+        )
+        return False
+
+    console.print("[green]Installing pip-audit...[/green]")
+    cmd = [python, "-m", "pip", "install", "pip-audit>=2.7.0", "--quiet"]
+    c = run_command(cmd)
+
+    if c.returncode != 0:
+        err.print(
+            "[red]Failed to install pip-audit. Please install it manually with 'pip install pip-audit'[/red]"
+        )
+        return False
+
+    console.print("[green]pip-audit installed successfully![/green]")
+    return True
+
+
+def build_audit_options(
+    output="columns",
+    strict=False,
+    ignore=None,
+    fix=False,
+    dry_run=False,
+    skip_editable=False,
+    no_deps=False,
+    local_only=False,
+    vulnerability_service="pypi",
+    descriptions=False,
+    aliases=False,
+    output_file=None,
+    requirements_file=None,
+    use_lockfile=False,
+):
+    """Build command line options for pip-audit."""
+    options = []
+
+    # Output format
+    if output and output != "columns":
+        options.extend(["-f", output])
+
+    # Vulnerability service
+    if vulnerability_service and vulnerability_service != "pypi":
+        options.extend(["-s", vulnerability_service])
+
+    # Flags
+    if strict:
+        options.append("--strict")
+    if fix:
+        options.append("--fix")
+    if dry_run:
+        options.append("--dry-run")
+    if skip_editable:
+        options.append("--skip-editable")
+    if no_deps:
+        options.append("--no-deps")
+    if local_only:
+        options.append("--local")
+    if descriptions:
+        options.append("--desc")
+    if aliases:
+        options.append("--aliases")
+
+    # Use lockfile (pyproject.toml / pylock.toml)
+    if use_lockfile:
+        options.append("--locked")
+
+    # Requirements file
+    if requirements_file:
+        options.extend(["-r", requirements_file])
+
+    # Output file
+    if output_file:
+        options.extend(["-o", output_file])
+
+    # Ignore specific vulnerabilities
+    if ignore:
+        for vuln_id in ignore:
+            options.extend(["--ignore-vuln", vuln_id])
+
+    return options
+
+
+def do_audit(  # noqa: PLR0913
+    project,
+    python=False,
+    system=False,
+    output="columns",
+    quiet=False,
+    verbose=False,
+    strict=False,
+    ignore=None,
+    fix=False,
+    dry_run=False,
+    skip_editable=False,
+    no_deps=False,
+    local_only=False,
+    vulnerability_service="pypi",
+    descriptions=False,
+    aliases=False,
+    output_file=None,
+    pypi_mirror=None,
+    categories="",
+    use_installed=False,
+    use_lockfile=False,
+):
+    """Audit packages for known security vulnerabilities using pip-audit.
+
+    This is the preferred method for vulnerability scanning in pipenv.
+    It uses the Python Packaging Advisory Database (PyPI) or OSV database.
+
+    Supports auditing from:
+    - The current virtualenv (default)
+    - pyproject.toml / pylock.toml files (with --locked flag)
+    """
+    if not verbose:
+        logging.getLogger("pipenv").setLevel(logging.ERROR if quiet else logging.WARN)
+
+    if not system:
+        ensure_project(
+            project,
+            python=python,
+            validate=False,
+            warn=False,
+            pypi_mirror=pypi_mirror,
+        )
+
+    if not quiet and not project.s.is_quiet():
+        if use_lockfile:
+            console.print(
+                "[bold]Auditing lockfile packages for vulnerabilities...[/bold]"
+            )
+        else:
+            console.print("[bold]Auditing packages for vulnerabilities...[/bold]")
+
+    # Check if pip-audit is installed
+    if not is_pip_audit_installed(project, system=system):
+        if not install_pip_audit(project, system=system):
+            console.print("[yellow]Vulnerability audit aborted.[/yellow]")
+            return
+
+        # Check again after installation
+        if not is_pip_audit_installed(project, system=system):
+            err.print(
+                "[red]pip-audit installation was reported successful but module not found. "
+                "Please try again or install manually with 'pip install pip-audit'[/red]"
+            )
+            return
+
+    # Build options for pip-audit
+    options = build_audit_options(
+        output=output,
+        strict=strict,
+        ignore=ignore,
+        fix=fix,
+        dry_run=dry_run,
+        skip_editable=skip_editable,
+        no_deps=no_deps,
+        local_only=local_only,
+        vulnerability_service=vulnerability_service,
+        descriptions=descriptions,
+        aliases=aliases,
+        output_file=output_file,
+        use_lockfile=use_lockfile,
+    )
+
+    # Build the command
+    python_path = project_python(project, system=system)
+    cmd = [python_path, "-m", "pip_audit"] + options
+
+    # If using lockfile mode, add the project directory path
+    if use_lockfile:
+        cmd.append(project.project_directory)
+
+    if not quiet and not project.s.is_quiet() and verbose:
+        console.print(f"[dim]Running: {' '.join(cmd)}[/dim]")
+
+    # Run pip-audit
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=False,  # Let output go directly to terminal
+            check=False,
+        )
+        sys.exit(result.returncode)
+    except Exception as e:
+        err.print(f"[red]Error running pip-audit: {str(e)}[/red]")
+        sys.exit(1)

--- a/pipenv/routines/check.py
+++ b/pipenv/routines/check.py
@@ -25,7 +25,9 @@ def build_safety_options(
         "--audit-and-monitor" if audit_and_monitor else "--disable-audit-and-monitor",
         "--exit-code" if exit_code else "--continue-on-error",
     ]
-    formats = {"full-report": "--full-report", "minimal": "--json"}
+    # Map output formats to safety CLI options
+    # "minimal" maps to --short-report for concise output
+    formats = {"full-report": "--full-report", "minimal": "--short-report"}
 
     if output in formats:
         options.append(formats.get(output, ""))
@@ -292,10 +294,10 @@ def do_check(  # noqa: PLR0913
     elif not quiet and not project.s.is_quiet():
         err.print(
             "[yellow bold]DEPRECATION WARNING:[/yellow bold] "
-            "The 'check' command is deprecated and will be unsupported beyond 01 June 2025.\n"
-            "In future versions, 'check' will run the 'scan' command by default.\n"
-            "Use [green]--scan[/green] option to run the new scan command now, or switch to [green]pipenv scan[/green].\n"
-            "The scan command requires an API key which you can obtain from https://pyup.io"
+            "The 'check' command using Safety is deprecated and will be removed in a future release.\n"
+            "Please migrate to [green]pipenv audit[/green] which uses pip-audit for vulnerability scanning.\n"
+            "pip-audit uses the Python Packaging Advisory Database and requires no API key.\n"
+            "Alternatively, use [green]--scan[/green] to use Safety's scan command (requires API key from https://pyup.io)"
         )
 
     if not system:

--- a/pipenv/routines/scan.py
+++ b/pipenv/routines/scan.py
@@ -42,10 +42,13 @@ def build_safety_check_options(
         options.append("--disable-audit-and-monitor")
 
     # Map output formats to safety CLI options
+    # "minimal" maps to --short-report for concise output
     if output == "full-report":
         options.append("--full-report")
-    elif output in ["json", "minimal"]:
+    elif output == "json":
         options.append("--json")
+    elif output == "minimal":
+        options.append("--short-report")
     elif output not in ["screen", "default"]:
         options.append(f"--output={output}")
 


### PR DESCRIPTION
## Summary

This PR introduces a new `pipenv audit` command that uses [pip-audit](https://github.com/pypa/pip-audit) for vulnerability scanning. This is the preferred method for auditing packages, replacing the deprecated Safety-based `check` command.

## Changes

### New `pipenv audit` Command
- Uses pip-audit (PyPA maintained tool) for vulnerability scanning
- Queries Python Packaging Advisory Database (PyPI) or OSV database
- **No API key required** (unlike Safety)
- Multiple output formats: `columns`, `json`, `cyclonedx-json`, `cyclonedx-xml`, `markdown`
- `--fix` flag to automatically upgrade vulnerable packages
- `--locked` flag to audit `pyproject.toml`/`pylock.toml` files (PEP 751 support)
- `--ignore` to skip specific vulnerabilities by ID
- `--strict` mode for CI environments
- `--desc` and `--aliases` for detailed vulnerability info

### Bug Fix (Issue #6374)
- Fixed `--output minimal` which incorrectly mapped to `--json` instead of `--short-report`
- Fixed in both `check.py` and `scan.py`

### Updated Deprecation Warning
- The `check` command now recommends `pipenv audit` as the migration path

## Usage Examples

```bash
# Basic audit
pipenv audit

# Auto-fix vulnerabilities
pipenv audit --fix

# JSON output
pipenv audit -f json

# Ignore specific vulnerability
pipenv audit --ignore PYSEC-2021-123

# Audit lockfiles (pyproject.toml/pylock.toml)
pipenv audit --locked
```

## Related Issues
- Fixes #6374 (`--output minimal` produces JSON instead of short report)
- Addresses #6434 (Safety module issues - now users can use pip-audit instead)

## Testing
- [ ] CI tests should pass
- Manual testing of `pipenv audit` command
- Manual testing of `--locked` flag with pylock.toml files

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author