### PR TITLE
Update Docker docs to clarify --system flag usage

### DIFF
--- a/docs/docker.md
+++ b/docs/docker.md
@@ -55,6 +55,30 @@ This approach:
 - `--deploy`: Ensures the Pipfile.lock is up-to-date and fails if it isn't
 - `--ignore-pipfile`: Uses only the lock file for installation, ignoring the Pipfile
 
+### System Installation vs. Virtual Environments in Docker
+
+Docker containers provide isolated environments, which raises the question: should you use `--system` to install packages globally, or create a virtual environment inside the container?
+
+**Using `--system` (Recommended for most Docker use cases)**
+
+- Simpler setup with no nested isolation
+- Smaller image size (no virtualenv overhead)
+- Packages are directly accessible without activation
+- Works well with `pipenv run` for executing scripts defined in Pipfile
+- Best for single-application containers following the "one process per container" principle
+
+**Using a Virtual Environment**
+
+- Provides an extra layer of isolation from system Python packages
+- Useful if your container runs multiple Python applications or system tools that depend on Python
+- Preferred when extending base images that have Python-based system utilities (e.g., `add-apt-repository` in Ubuntu)
+- Consider this approach if you use `apt-get install python3-*` packages alongside your application
+
+For most production containers that run a single Python application, `--system` is the simpler and more efficient choice. The concerns about breaking system Python tools (raised in older guidance) are less relevant when:
+- Your container runs only your application
+- You're using slim/minimal base images
+- You're not installing Python-based system packages via apt/yum
+
 ## Optimized Docker Builds
 
 ### Multi-Stage Builds
@@ -591,7 +615,7 @@ RUN pipenv install --deploy --system --extra-pip-args="--use-feature=fast-deps"
 
 4. **Use `--deploy` flag** to ensure Pipfile.lock is up-to-date
 
-5. **Install dependencies system-wide** with `--system` to avoid unnecessary virtual environments
+5. **Use `--system` for single-application containers** to install dependencies system-wide, or use a virtual environment if your container runs multiple Python applications
 
 6. **Include only necessary files** in your Docker image
 


### PR DESCRIPTION
## Summary

Addresses #6438 by clarifying the Docker documentation on when to use the `--system` flag vs. a virtual environment.

## Changes

1. Added a new section "System Installation vs. Virtual Environments in Docker" that explains:
   - **When to use `--system`**: Single-application containers following the "one process per container" principle, slim base images, simpler setup
   - **When to use a virtual environment**: Containers with multiple Python applications, containers that use Python-based system tools (e.g., `add-apt-repository`)

2. Updated the Best Practices summary (#5) to reflect this nuanced guidance.

## Context

In 2018 (PR #2762), it was recommended NOT to use `--system` due to concerns about breaking system Python tools. However:
- Modern container best practices favor single-application containers
- Slim/minimal base images don't include Python-based system tools
- Recent improvements to `--system` support (#6454, #6453, #6297) make it more robust

For most production containers, `--system` is now the simpler and more efficient choice.

Closes #6438

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author