### PR TITLE
Fix pipenv check --quiet not working properly

### DIFF
--- a/news/6414.bugfix.rst
+++ b/news/6414.bugfix.rst
@@ -1,0 +1,5 @@
+Fix ``pipenv check --quiet`` not working properly. The ``--quiet`` flag now
+correctly suppresses informational output and forces JSON output format for
+safety so that results can be parsed correctly.
+
+Fixes #6414


### PR DESCRIPTION
## Summary

Fixes #6414 - The `--quiet` flag for `pipenv check` was not working properly. Running `pipenv check --quiet` would fail with "Failed to parse Safety output" because:

1. Informational messages were still being printed (e.g., "Created temporary requirements file", "Using requirements file")
2. The `--quiet` flag didn't force JSON output format, so safety's output couldn't be parsed by `parse_safety_output()`

## Changes

1. **Add `quiet` parameter to `build_safety_options()`** - When quiet mode is enabled, force `--output=json` so we can parse the output
2. **Suppress console output in `build_safety_options()`** - Don't print "Using requirements file" when quiet
3. **Add `quiet` parameter to `create_temp_requirements()`** - Don't print "Created temporary requirements file" when quiet
4. **Add `quiet` parameter to `install_safety()`** - Suppress installation messages when quiet and auto_install is used
5. **Suppress "Vulnerability scanning aborted" message when quiet**

## Testing

Manually tested that `pipenv check --quiet` now properly parses safety output.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author