### PR TITLE
Fix VCS dependencies not reinstalling when ref/commit changes

### DIFF
--- a/news/5791.bugfix.rst
+++ b/news/5791.bugfix.rst
@@ -1,0 +1,3 @@
+Fix VCS dependencies (git, etc.) not being reinstalled when the ref/commit changes in the lockfile.
+Previously, ``pipenv update`` would update the lockfile with the new commit hash but the installed
+package in the virtualenv would remain unchanged, requiring ``pipenv --rm`` to force a reinstall.

--- a/pipenv/environment.py
+++ b/pipenv/environment.py
@@ -734,24 +734,12 @@ class Environment:
             None,
         )
         if match is not None:
-            # For editable VCS dependencies, check if the source directory exists first
-            # This ensures we reinstall if the source checkout is missing
-            if req.editable and req.link and req.link.is_vcs:
-                # Use the environment's prefix to get the src directory
-                # (get_src_prefix() uses sys.prefix which is pipenv's venv, not the project's)
-                src_dir = os.path.join(str(self.prefix), "src")
-
-                # If the src directory doesn't exist, the requirement is not satisfied
-                if not os.path.exists(src_dir):
-                    return False
-
-                # If we have a specific package directory, check that too
-                if req.name:
-                    pkg_dir = os.path.join(src_dir, req.name)
-                    if not os.path.exists(pkg_dir):
-                        return False
-
-                return True
+            # For VCS dependencies (editable or not), we cannot reliably determine
+            # if the installed version matches the requested ref/commit. Always return
+            # False to force reinstall, which will ensure the correct commit is checked out.
+            # See: https://github.com/pypa/pipenv/issues/5791
+            if req.link and req.link.is_vcs:
+                return False
             if req.specifier is not None:
                 return SpecifierSet(str(req.specifier)).contains(
                     match.version, prereleases=True
@@ -766,10 +754,10 @@ class Environment:
                     parsed_url = urlparse(requested_path)
                     local_path = parsed_url.path
                 return requested_path and os.path.samefile(local_path, match.location)
-            elif match.has_metadata("direct_url.json") or (req.link and req.link.is_vcs):
-                # Direct URL installs and VCS installs we assume are not satisfied
-                # since due to skip-lock we may be installing from Pipfile we have insufficient
-                # information to determine if a branch or ref has actually changed.
+            elif match.has_metadata("direct_url.json"):
+                # Direct URL installs we assume are not satisfied since we may be
+                # installing from Pipfile and have insufficient information to determine
+                # if the content has changed.
                 return False
             return True
         return False


### PR DESCRIPTION
## Summary

Fixes #5791 - VCS dependencies (git, etc.) were not being reinstalled when the ref/commit changed in the lockfile. `pipenv update` would update the lockfile with the new commit hash but the installed package in the virtualenv remained unchanged.

## Problem

The `is_satisfied()` method in `environment.py` had logic for editable VCS dependencies that returned `True` (satisfied) as long as the source directory existed, **without checking if the commit hash matched the lockfile**.

```python
# Old problematic code:
if req.editable and req.link and req.link.is_vcs:
    # ... check source directory exists ...
    return True  # <-- Always returned True if src dir exists!
```

This caused the issue where:
1. User updates a VCS dependency (new commit on branch)
2. `pipenv update` correctly updates the lockfile with new commit hash
3. But `is_satisfied()` returns `True` because the src dir exists
4. So pip doesn't reinstall, leaving old code in the virtualenv
5. User has to `pipenv --rm` and recreate environment to get the update

## Solution

Move the VCS check to the top of `is_satisfied()` to **always return `False` for VCS dependencies**. This forces pip to reinstall and check out the correct commit.

```python
# New code:
if req.link and req.link.is_vcs:
    # For VCS dependencies (editable or not), we cannot reliably determine
    # if the installed version matches the requested ref/commit.
    return False
```

This is consistent with the original intent documented in the existing code comment:
> "VCS installs we assume are not satisfied since due to skip-lock we may be installing from Pipfile we have insufficient information to determine if a branch or ref has actually changed."

## Testing

- All unit tests pass
- The fix addresses the exact regression identified by @myii in the issue comments

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author