### PR TITLE
Fix pipenv-resolver CLI not working

### DIFF
--- a/news/5862.bugfix.rst
+++ b/news/5862.bugfix.rst
@@ -1,0 +1,3 @@
+Fix ``pipenv-resolver`` CLI not working. The command now properly handles
+package arguments from the command line, sets a default category of "default",
+and correctly loads the pipenv module with all submodules.


### PR DESCRIPTION
## Summary

Fixes the `pipenv-resolver` command-line tool which was completely broken.

## Issues Fixed

1. **Package arguments format**: Command line packages were passed as a list but the resolver code expected a dict. Now properly converts the list to dict format using the package name as key.

2. **Module import error**: `'pipenv' doesn't have module 'patched'` - The `_ensure_modules()` function only loaded `pipenv/__init__.py` but didn't set up submodules. Now properly imports pipenv as a package so all submodules are accessible.

3. **Category argument validation**: The `--category` argument defaulted to `None` which caused a `TypeError` deeper in the code. Now defaults to `'default'` category if not specified.

4. **Empty package validation**: Added validation that at least one package is required.

## Testing

Before (broken):
```bash
$ pipenv-resolver requests
AttributeError: module 'pipenv' has no attribute 'patched'
```

After (working):
```bash
$ pipenv-resolver -v --write /tmp/output.json requests
# Successfully resolves dependencies and writes JSON output
```

Fixes #5862

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author