### PR TITLE
Fix SSH git username being incorrectly redacted

### DIFF
--- a/news/5599.bugfix.rst
+++ b/news/5599.bugfix.rst
@@ -1,0 +1,2 @@
+Fix SSH ``git`` username being incorrectly redacted to ``****`` when importing
+from requirements.txt, which caused lockfile generation to fail.

--- a/pipenv/utils/requirements.py
+++ b/pipenv/utils/requirements.py
@@ -23,13 +23,17 @@ def redact_netloc(netloc: str) -> str:
         - "user:pass@example.com" returns "user:****@example.com"
         - "accesstoken@example.com" returns "****@example.com"
         - "${ENV_VAR}:pass@example.com" returns "${ENV_VAR}:****@example.com" if ${ENV_VAR} is an environment variable
+        - "git@github.com" returns "git@github.com" (standard SSH username preserved)
     """
+    # Standard SSH usernames that should not be redacted
+    STANDARD_SSH_USERNAMES = ("git",)
+
     netloc, (user, password) = split_auth_from_netloc(netloc)
     if user is None:
         return netloc
     if password is None:
-        # Check if user is an environment variable
-        if not re.match(r"\$\{\w+\}", user):
+        # Check if user is an environment variable or a standard SSH username
+        if not re.match(r"\$\{\w+\}", user) and user not in STANDARD_SSH_USERNAMES:
             # If not, redact the user
             user = "****"
         password = ""


### PR DESCRIPTION
## Summary

Fixes #5599

When importing from `requirements.txt`, the standard SSH username `git` (used by GitHub, GitLab, Bitbucket, etc.) was being redacted to `****`, which caused the lockfile generation to fail with exit code 128.

## Problem

The `redact_netloc()` function in `pipenv/utils/requirements.py` was designed to redact sensitive credentials from URLs. However, it was incorrectly treating the `git` username in SSH URLs like `git+ssh://git@github.com/...` as a credential and redacting it to `****`.

This resulted in URLs like:
```
ssh://****@github.com/user/repo.git
```

Which are invalid and cause git operations to fail.

## Solution

The fix preserves the `git` username since it's a standard, non-sensitive SSH username used by all major Git hosting services. The `redact_netloc()` function now checks if the username is in a list of standard SSH usernames before redacting.

## Testing

- All existing unit tests pass
- The fix specifically addresses the case where `git` is used as the SSH username

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author