### PR TITLE
Fix Windows CI failures and validate --index argument

### DIFF
--- a/news/6168.bugfix.rst
+++ b/news/6168.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed ``pipenv install --index=xxx`` where ``xxx`` is not a valid URL or known index name now raises a clear error instead of creating a malformed source entry in the Pipfile.

--- a/tests/integration/test_editable_vcs.py
+++ b/tests/integration/test_editable_vcs.py
@@ -43,6 +43,7 @@ gunicorn = {git = "https://github.com/benoitc/gunicorn", ref = "23.0.0", editabl
         assert c.returncode == 0, f"Failed to import gunicorn: {c.stderr}"
 
         # Remove the src directory to simulate the issue
+        # Note: shutil.rmtree is patched by the fixture to handle Windows read-only files
         shutil.rmtree(src_dir)
         assert not src_dir.exists(), "Failed to remove src directory"
 


### PR DESCRIPTION
## Summary

This PR fixes three Windows CI test failures and adds validation for the `--index` argument.

## Changes

### 1. Fix Windows path handling in `find_package_name_from_directory` (regression from #6465)

On Windows, `urlparse()` interprets paths like `C:\Users\...` as having `scheme='c'` and `path='\Users\...'`, causing the drive letter to be lost. This caused:
- `test_find_package_name_from_directory_ignores_subdirectory_setup` - FAILED
- `test_find_package_name_from_directory_finds_egg_info_metadata` - FAILED

**Fix:** Detect single-letter schemes on Windows (which are drive letters like C:, D:) and use the original path string instead of the parsed path.

### 2. Fix `test_editable_vcs_reinstall` PermissionError on Windows

The test was failing with:
```
PermissionError: [WinError 5] Access is denied: '.git\objects\pack\...'
```

The test uses `shutil.rmtree()` to delete a git repository's src directory, but on Windows, git pack files are often read-only or locked.

**Fix:** Updated `tests/integration/conftest.py` to always use the `handle_remove_readonly` error handler on Windows (not just for Python 3.8 as before). The fix also properly handles the Python 3.12+ API change where `onerror` was replaced with `onexc`.

### 3. Validate `--index` argument is a valid URL or known source name

When using `pipenv install --index=xxx`, if `xxx` is not found in Pipfile sources and is not a valid URL, pipenv would silently create a malformed source entry in the Pipfile. Now it raises a clear error message:

```
ERROR:: Index 'nonexistent-index' was not found in Pipfile sources and is not a valid URL.
Available sources: 'pypi'
Hint: Use a valid URL or add the index to your Pipfile [[source]] section.
```

**Fixes #6168**

## Testing

- All affected unit tests pass locally
- New integration test `test_install_invalid_index_name` added
- Existing tests `test_install_named_index_alias` and `test_install_specifying_index_url` continue to pass

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author