### PR TITLE
Improve resolver error display for end users

### DIFF
--- a/news/6388.bugfix.rst
+++ b/news/6388.bugfix.rst
@@ -1,0 +1,1 @@
+Resolver errors now display clean, user-friendly messages instead of confusing stacktraces in non-verbose mode.

--- a/pipenv/exceptions.py
+++ b/pipenv/exceptions.py
@@ -40,9 +40,17 @@ KNOWN_EXCEPTIONS = [
 def handle_exception(exc_type, exception, traceback, hook=sys.excepthook):
     from pipenv import environments
 
-    if environments.Setting().is_verbose() or not issubclass(exc_type, ClickException):
+    is_verbose = environments.Setting().is_verbose()
+
+    if is_verbose or not issubclass(exc_type, ClickException):
         hook(exc_type, exception, traceback)
+    elif issubclass(exc_type, PipenvException):
+        # For PipenvException and subclasses (ResolutionFailure, etc.),
+        # just show the clean error message without any traceback.
+        # The exception's show() method provides user-friendly output.
+        exception.show()
     else:
+        # For other ClickExceptions, show a minimal traceback
         tb = format_tb(traceback, limit=-6)
         lines = itertools.chain.from_iterable([frame.splitlines() for frame in tb])
         formatted_lines = []


### PR DESCRIPTION
## Summary

This PR improves the error display when dependency resolution fails. In non-verbose mode, users now see clean, user-friendly error messages instead of confusing stacktraces.

## Problem

When resolution fails (e.g., "Getting requirements to build wheel exited with 1"), users currently see output like:

```
[ResolutionFailure]:   File "/path/to/resolver.py", line 451, in main
[ResolutionFailure]:       _main(
[ResolutionFailure]:       ~~~~~^
[ResolutionFailure]:       parsed.pre,
[ResolutionFailure]:       ^^^^^^^^^^^
... (many more lines of confusing stacktrace)
Your dependencies could not be resolved...
ERROR: Getting requirements to build wheel exited with 1
```

This is confusing for end users who don't need to see the internal stacktrace.

## Solution

For `PipenvException` subclasses (including `ResolutionFailure`), in non-verbose mode, we now only show the exception's `show()` output which provides:

1. Helpful hints about what might be wrong
2. The actual error message

```
Your dependencies could not be resolved. You likely have a mismatch in your sub-dependencies.
You can use $ pipenv run pip install <requirement_name> to bypass this mechanism, then run $ pipenv graph to inspect the versions actually installed in the virtualenv.
Hint: try $ pipenv lock --pre if it is a pre-release dependency.
ERROR: Getting requirements to build wheel exited with 1
```

Users can still use `--verbose` flag to see the full stacktrace for debugging purposes.

**Fixes #6388**

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author