### PR TITLE
Fix --lock-only flag for pipenv upgrade command

### DIFF
--- a/news/6131.bugfix.rst
+++ b/news/6131.bugfix.rst
@@ -1,0 +1,1 @@
+Fix ``--lock-only`` flag for ``pipenv upgrade`` command to properly skip adding package specifiers to Pipfile when set.

--- a/pipenv/routines/update.py
+++ b/pipenv/routines/update.py
@@ -391,6 +391,7 @@ def _process_package_args(
     category,
     has_package_args,
     requested_packages,
+    lock_only=False,
 ):
     """Process package arguments and update requested_packages."""
     for package in package_args[:]:
@@ -401,9 +402,14 @@ def _process_package_args(
         )
 
         # Only add to Pipfile if this category was explicitly requested for this package
-        if has_package_args and (
-            normalized_name not in explicitly_requested
-            or category in explicitly_requested.get(normalized_name, [])
+        # and lock_only is not set
+        if (
+            not lock_only
+            and has_package_args
+            and (
+                normalized_name not in explicitly_requested
+                or category in explicitly_requested.get(normalized_name, [])
+            )
         ):
             project.add_pipfile_entry_to_pipfile(
                 name, normalized_name, pipfile_entry, category=pipfile_category
@@ -615,6 +621,7 @@ def upgrade(
                 category,
                 has_package_args,
                 requested_packages,
+                lock_only=lock_only,
             )
 
         # Resolve dependencies and update lockfile


### PR DESCRIPTION
## Summary

The `--lock-only` flag was defined in CLI options but not implemented. This fix passes the `lock_only` parameter to `_process_package_args` and skips adding package specifiers to Pipfile when the flag is set.

## Changes

- Added `lock_only` parameter to `_process_package_args` function
- Updated the condition to skip `add_pipfile_entry_to_pipfile` when `lock_only=True`
- Passed `lock_only` from `upgrade()` to `_process_package_args()`

## Testing

When using `pipenv upgrade package --lock-only`, the package will be resolved and added to `Pipfile.lock` but not to `Pipfile`.

Fixes #6131

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author