### PR TITLE
Fix Windows shutil.rmtree error on Python 3.12+

### DIFF
--- a/news/6474.bugfix.rst
+++ b/news/6474.bugfix.rst
@@ -1,0 +1,4 @@
+Fix ``TypeError: cannot unpack non-iterable PermissionError object`` on Windows with Python 3.12+
+when removing read-only files (e.g., git pack files). The ``handle_remove_readonly`` error handler
+now properly handles both the deprecated ``onerror`` callback signature (tuple) and the new
+``onexc`` callback signature (exception instance) introduced in Python 3.12.

--- a/pipenv/routines/clear.py
+++ b/pipenv/routines/clear.py
@@ -1,4 +1,5 @@
 import shutil
+import sys
 
 from pipenv import environments
 from pipenv.utils import console
@@ -10,13 +11,23 @@ def do_clear(project):
 
     console.print("Clearing caches...", style="bold")
     try:
-        shutil.rmtree(project.s.PIPENV_CACHE_DIR, onerror=handle_remove_readonly)
-        # Other processes may be writing into this directory simultaneously.
-        shutil.rmtree(
-            locations.USER_CACHE_DIR,
-            ignore_errors=environments.PIPENV_IS_CI,
-            onerror=handle_remove_readonly,
-        )
+        # Use onexc for Python 3.12+ and onerror for earlier versions
+        if sys.version_info >= (3, 12):
+            shutil.rmtree(project.s.PIPENV_CACHE_DIR, onexc=handle_remove_readonly)
+            # Other processes may be writing into this directory simultaneously.
+            shutil.rmtree(
+                locations.USER_CACHE_DIR,
+                ignore_errors=environments.PIPENV_IS_CI,
+                onexc=handle_remove_readonly,
+            )
+        else:
+            shutil.rmtree(project.s.PIPENV_CACHE_DIR, onerror=handle_remove_readonly)
+            # Other processes may be writing into this directory simultaneously.
+            shutil.rmtree(
+                locations.USER_CACHE_DIR,
+                ignore_errors=environments.PIPENV_IS_CI,
+                onerror=handle_remove_readonly,
+            )
     except OSError as e:
         # Ignore FileNotFoundError. This is needed for Python 2.7.
         import errno

--- a/pipenv/utils/funktools.py
+++ b/pipenv/utils/funktools.py
@@ -394,7 +394,8 @@ def handle_remove_readonly(func, path, exc):
 
     :param function func: The caller function
     :param path: The target path for removal (string or Path)
-    :param Exception exc: The raised exception
+    :param Exception exc: The raised exception (Python 3.12+ onexc) or
+        tuple of (exc_type, exc_value, exc_tb) (Python 3.11- onerror)
 
     This function will call check :func:`is_readonly_path` before attempting to call
     :func:`set_write_bit` on the target path and try again.
@@ -405,8 +406,13 @@ def handle_remove_readonly(func, path, exc):
     # Convert to Path object for consistent handling
     path_obj = Path(path)
 
-    # Split the initial exception out into its type, exception, and traceback
-    exc_type, exc_exception, exc_tb = exc
+    # Handle both Python 3.12+ (onexc with exception) and earlier (onerror with tuple)
+    if isinstance(exc, tuple):
+        # Python 3.11 and earlier: exc is (exc_type, exc_value, exc_tb)
+        exc_exception = exc[1]
+    else:
+        # Python 3.12+: exc is the exception instance directly
+        exc_exception = exc
 
     if is_readonly_path(path_obj):
         # Apply to write permission and call original function

--- a/pipenv/utils/shell.py
+++ b/pipenv/utils/shell.py
@@ -437,8 +437,15 @@ def handle_remove_readonly(func, path, exc):
     attempts to set them as writeable and then proceed with deletion."""
     # Check for read-only attribute
     default_warning_message = "Unable to remove file due to permissions restriction: {!r}"
-    # split the initial exception out into its type, exception, and traceback
-    exc_type, exc_exception, exc_tb = exc
+
+    # Handle both Python 3.12+ (onexc with exception) and earlier (onerror with tuple)
+    if isinstance(exc, tuple):
+        # Python 3.11 and earlier: exc is (exc_type, exc_value, exc_tb)
+        exc_exception = exc[1]
+    else:
+        # Python 3.12+: exc is the exception instance directly
+        exc_exception = exc
+
     if is_readonly_path(path):
         # Apply write permission and call original function
         set_write_bit(path)
@@ -455,7 +462,7 @@ def handle_remove_readonly(func, path, exc):
         warnings.warn(default_warning_message.format(path), ResourceWarning, stacklevel=1)
         return
 
-    raise exc
+    raise exc_exception
 
 
 def style_no_color(text, fg=None, bg=None, **kwargs) -> str:


### PR DESCRIPTION
## Summary

Fixes the Windows CI failure: `TypeError: cannot unpack non-iterable PermissionError object` in `tests/integration/test_editable_vcs.py::test_editable_vcs_reinstall`.

## Problem

In Python 3.12, `shutil.rmtree` deprecated the `onerror` callback parameter and introduced `onexc` instead. The key difference:

- **`onerror` (Python 3.11 and earlier)**: Callback receives `(func, path, exc_info)` where `exc_info` is a 3-tuple `(exc_type, exc_value, exc_tb)`
- **`onexc` (Python 3.12+)**: Callback receives `(func, path, exc)` where `exc` is just the exception instance

The `handle_remove_readonly` functions in both `pipenv/utils/funktools.py` and `pipenv/utils/shell.py` were trying to unpack `exc` as a tuple, which failed on Python 3.12+ when the callback was used with `onexc`.

## Changes

1. **`pipenv/utils/funktools.py`**: Updated `handle_remove_readonly` to handle both callback signatures by checking if `exc` is a tuple or an exception instance

2. **`pipenv/utils/shell.py`**: Same fix applied to the duplicate `handle_remove_readonly` function

3. **`pipenv/routines/clear.py`**: Updated to use `onexc` on Python 3.12+ and `onerror` on earlier versions

## Testing

This should fix the failing Windows CI test `test_editable_vcs_reinstall` which was encountering PermissionError when removing read-only git pack files.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author