### PR TITLE
Add PIPENV_PYENV_AUTO_INSTALL environment variable

### DIFF
--- a/news/6408.feature.rst
+++ b/news/6408.feature.rst
@@ -1,0 +1,1 @@
+Add ``PIPENV_PYENV_AUTO_INSTALL`` environment variable to automatically install missing Python versions via pyenv or asdf without prompting the user.

--- a/pipenv/environments.py
+++ b/pipenv/environments.py
@@ -150,6 +150,13 @@ class Setting:
         Default is to install Python automatically via asdf when needed, if possible.
         """
 
+        self.PIPENV_PYENV_AUTO_INSTALL = bool(get_from_env("PYENV_AUTO_INSTALL"))
+        """If set, Pipenv automatically installs missing Python versions via pyenv/asdf
+        without prompting the user.
+
+        Default is to prompt the user for confirmation before installing Python.
+        """
+
         self.PIPENV_DOTENV_LOCATION = get_from_env(
             "DOTENV_LOCATION", check_for_negation=False
         )

--- a/pipenv/utils/virtualenv.py
+++ b/pipenv/utils/virtualenv.py
@@ -320,11 +320,13 @@ def ensure_python(project, python=None):
             )
 
             # Prompt the user to continue...
+            # PIPENV_PYENV_AUTO_INSTALL allows automatic installation without prompting
+            auto_install = project.s.PIPENV_YES or project.s.PIPENV_PYENV_AUTO_INSTALL
             if environments.SESSION_IS_INTERACTIVE:
-                if not (project.s.PIPENV_YES or Confirm.ask("".join(s), default=True)):
+                if not (auto_install or Confirm.ask("".join(s), default=True)):
                     abort()
-            elif not project.s.PIPENV_YES:
-                # Non-interactive session without PIPENV_YES, aborting installation
+            elif not auto_install:
+                # Non-interactive session without auto-install enabled, aborting
                 abort()
 
             # Tell the user we're installing Python.


### PR DESCRIPTION
## Summary

Adds a new environment variable `PIPENV_PYENV_AUTO_INSTALL` that allows automatic installation of missing Python versions via pyenv/asdf without prompting the user.

Fixes #6408

## Problem

As described in issue #6408, users running pipenv in CI/CD environments or automation scripts often need to install Python versions automatically without user interaction. The existing `PIPENV_YES` option is too broad as it affects all prompts, not just Python installation.

## Solution

Introduce a new environment variable `PIPENV_PYENV_AUTO_INSTALL` that specifically controls automatic Python installation behavior:

- When set, Pipenv will automatically install missing Python versions via pyenv/asdf without prompting
- Works in both interactive and non-interactive sessions
- Does not affect other prompts (unlike `PIPENV_YES`)

## Usage

```bash
export PIPENV_PYENV_AUTO_INSTALL=1
pipenv install
```

## Changes

1. **`pipenv/environments.py`**: Added `PIPENV_PYENV_AUTO_INSTALL` environment variable definition
2. **`pipenv/utils/virtualenv.py`**: Updated `ensure_python` to check for the new variable alongside `PIPENV_YES`

## Testing

This feature is primarily for automation environments and doesn't change the default behavior. When the variable is not set, pipenv behaves exactly as before.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author