### PR TITLE
Fix typo in get_constraints_from_deps version formatting

### DIFF
--- a/news/6354.bugfix.rst
+++ b/news/6354.bugfix.rst
@@ -1,0 +1,1 @@
+Fix typo in ``get_constraints_from_deps`` where version string was incorrectly formatted using the entire dependency dict instead of the version string.

--- a/pipenv/utils/dependencies.py
+++ b/pipenv/utils/dependencies.py
@@ -1343,7 +1343,7 @@ def get_constraints_from_deps(deps):
             version = dep_version.get("version", None)
             if version and not is_star(version):
                 if COMPARE_OP.match(version) is None:
-                    version = f"=={dep_version}"
+                    version = f"=={version}"
                 c = f"{canonicalize_name(dep_name)}{version}"
             else:
                 c = canonicalize_name(dep_name)


### PR DESCRIPTION
## Summary

Fixes a typo in `get_constraints_from_deps()` where the version string was incorrectly formatted using the entire dependency dict instead of the extracted version string.

## The Bug

In `pipenv/utils/dependencies.py` line 1346, when a version string doesn't start with a comparison operator, the code was doing:

```python
version = f"=={dep_version}"  # dep_version is a dict!
```

Instead of:

```python
version = f"=={version}"  # version is the extracted string
```

This would produce malformed constraint strings like `cffi=={'version': '*', 'markers': "sys_platform == 'win32'"}` instead of proper constraints.

## Fix

Simply use the correct variable (`version`) that was already extracted from the dict.

## Related

Related to #6354 which was already fixed by #6391 and #6460, but this typo could still cause issues in edge cases.

---

## Checklist

- [x] Associated issue (#6354)
- [x] A news fragment in the `news/` directory

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author