### PR TITLE
Fix: Respect PIPENV_VERBOSITY=-1 for .env loading message

### DIFF
--- a/pipenv/utils/environment.py
+++ b/pipenv/utils/environment.py
@@ -29,7 +29,7 @@ def load_dot_env(project, as_dict=False, quiet=False):
         if as_dict:
             return dotenv.dotenv_values(str(dotenv_file))
         elif dotenv_file.is_file():
-            if not quiet:
+            if not quiet and not project.s.is_quiet():
                 err.print("[bold]Loading .env environment variables...[/bold]")
 
             dotenv.load_dotenv(str(dotenv_file), override=True)


### PR DESCRIPTION
## Summary

Fixes #6111

The `Loading .env environment variables...` message was not being suppressed when `PIPENV_VERBOSITY=-1` was set via environment variable. Only the `--quiet` CLI flag worked to suppress it.

## Problem

The `load_dot_env()` function only checked the `quiet` parameter (which comes from the CLI `--quiet` flag via `state.quiet`), but it didn't check `project.s.is_quiet()` which respects the `PIPENV_VERBOSITY` environment variable.

## Solution

Modified `load_dot_env()` to check both:
- The `quiet` parameter (from CLI `--quiet` flag)
- `project.s.is_quiet()` (from `PIPENV_VERBOSITY` environment variable)

## Changes

- `pipenv/utils/environment.py`: Added check for `project.s.is_quiet()` in addition to the `quiet` parameter
- `tests/unit/test_core.py`: Added two new tests:
  - `test_load_dot_env_quiet_with_verbosity` - verifies `PIPENV_VERBOSITY=-1` suppresses the message
  - `test_load_dot_env_shows_message_without_quiet` - verifies the message is shown when not in quiet mode

## Testing

All unit tests pass:
```
tests/unit/test_core.py::test_suppress_nested_venv_warning PASSED
tests/unit/test_core.py::test_load_dot_env_from_environment_variable_location PASSED
tests/unit/test_core.py::test_doesnt_load_dot_env_if_disabled PASSED
tests/unit/test_core.py::test_load_dot_env_warns_if_file_doesnt_exist PASSED
tests/unit/test_core.py::test_load_dot_env_quiet_with_verbosity PASSED
tests/unit/test_core.py::test_load_dot_env_shows_message_without_quiet PASSED
tests/unit/test_core.py::test_deactivate_wrapper_script_includes_unset_pipenv_active PASSED
```

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author