### PR TITLE
Fix: Suppress duplicate .env loading message in nested pipenv invocations

### DIFF
--- a/pipenv/utils/environment.py
+++ b/pipenv/utils/environment.py
@@ -29,7 +29,12 @@ def load_dot_env(project, as_dict=False, quiet=False):
         if as_dict:
             return dotenv.dotenv_values(str(dotenv_file))
         elif dotenv_file.is_file():
-            if not quiet and not project.s.is_quiet():
+            # Skip message if already in a pipenv environment (nested invocation)
+            if (
+                not quiet
+                and not project.s.is_quiet()
+                and not os.environ.get("PIPENV_ACTIVE")
+            ):
                 err.print("[bold]Loading .env environment variables...[/bold]")
 
             dotenv.load_dotenv(str(dotenv_file), override=True)


### PR DESCRIPTION
## Summary

Fixes #6328

When running `pipenv run <script>` where the script itself calls additional pipenv commands (e.g., `pipenv sync`, `pipenv lock`), the "Loading .env environment variables..." message was being printed multiple times.

## Changes

- Modified `pipenv/utils/environment.py` to check for `PIPENV_ACTIVE` environment variable before printing the .env loading message
- When `PIPENV_ACTIVE` is set (indicating we're already inside a pipenv environment), the message is suppressed
- The `.env` file is **still loaded** (in case contents have changed), only the message is suppressed
- Added unit test to verify the behavior

## Example

Before:
```
$ pipenv run prod
Loading .env environment variables...
Loading .env environment variables...
Installing dependencies from Pipfile.lock...
```

After:
```
$ pipenv run prod
Loading .env environment variables...
Installing dependencies from Pipfile.lock...
```

## Testing

All 8 unit tests in `tests/unit/test_core.py` pass, including the new test `test_load_dot_env_suppresses_message_when_pipenv_active`.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author