### PR TITLE
Fix: Allow shell builtins to work with pipenv run

### DIFF
--- a/tests/integration/test_run.py
+++ b/tests/integration/test_run.py
@@ -175,3 +175,30 @@ requests = "==2.14.0"
             c = p.pipenv("run pip freeze")
         assert c.returncode == 0
         assert "requests==2.14.0" in c.stdout
+
+
+@pytest.mark.run
+@pytest.mark.skip_windows
+def test_run_shell_builtins(pipenv_instance_pypi):
+    """Test that shell builtins work with pipenv run.
+
+    Shell builtins like 'echo', 'cd', 'pwd' don't have a path in the filesystem.
+    They should still work with pipenv run by falling back to shell execution.
+    See: https://github.com/pypa/pipenv/issues/6186
+    """
+    with pipenv_instance_pypi() as p:
+        p.pipenv("install")
+
+        # Test 'echo' builtin
+        c = p.pipenv('run echo "Hello World"')
+        assert c.returncode == 0
+        assert "Hello World" in c.stdout
+
+        # Test 'pwd' builtin
+        c = p.pipenv("run pwd")
+        assert c.returncode == 0
+        assert p.path in c.stdout
+
+        # Test 'cd' builtin (should succeed even though it doesn't change parent dir)
+        c = p.pipenv("run cd /tmp")
+        assert c.returncode == 0


### PR DESCRIPTION
## Summary

Shell builtins (cd, echo, pwd, export, etc.) don't exist as files in the PATH - they're built into the shell itself. Previously, `pipenv run cd` would fail with:

```
Error: the command cd could not be found within PATH or Pipfile's [scripts].
```

## Changes

Modifies `do_run_posix` in `pipenv/routines/shell.py` to fall back to running commands through the shell when they're not found in PATH, similar to the Windows behavior that already existed in `_launch_windows_subprocess`.

### Before (POSIX)
1. Try to find command in PATH using `system_which`
2. If not found → error and exit

### After (POSIX)
1. Try to find command in PATH using `system_which`
2. If found → use `os.execve` for direct execution (unchanged)
3. If not found → fall back to `subprocess.run` with `shell=True` (allows shell builtins to work)

## Testing

- Added integration test `test_run_shell_builtins` that tests `echo`, `pwd`, and `cd` builtins
- Manual testing confirms that `pipenv run echo`, `pipenv run pwd`, and `pipenv run cd` now work correctly

Fixes #6186

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author