### PR TITLE
Fix: Auto-enable fancy shell mode when Oh My Posh is detected

### DIFF
--- a/pipenv/cli/command.py
+++ b/pipenv/cli/command.py
@@ -391,11 +391,14 @@ def shell(state, fancy=False, shell_args=None, anyway=False, quiet=False):
             )
             sys.exit(1)
 
-    # Use fancy mode for Windows or pwsh on *nix.
+    # Use fancy mode for Windows, pwsh, or when Oh My Posh is detected.
+    # Oh My Posh interferes with the VIRTUAL_ENV variable when using the
+    # pexpect-based compat mode. See: https://github.com/pypa/pipenv/issues/6226
     if (
         os.name == "nt"
         or Path(os.environ.get("PIPENV_SHELL") or "").name == "pwsh"
         or Path(os.environ.get("SHELL") or "").name == "pwsh"
+        or os.environ.get("POSH_THEME")  # Oh My Posh detected
     ):
         fancy = True
     do_shell(


### PR DESCRIPTION
## Summary

Fixes #6226 - `pipenv shell` doesn't set `VIRTUAL_ENV` when using Oh My Posh.

## Problem

When using `pipenv shell` in zsh with Oh My Posh, the `VIRTUAL_ENV` environment variable is not being set. This only occurs with the default shell activation mode (using pexpect). Using `pipenv shell --fancy` works correctly.

## Root Cause

The default shell activation mode (compat mode) uses pexpect to spawn a shell and then sends the activate script as a command. Oh My Posh hooks into shell initialization and interferes with the `VIRTUAL_ENV` variable set by the activate script.

In contrast, `--fancy` mode sets `VIRTUAL_ENV` directly in the environment before spawning the shell with `os.execvp`, so Oh My Posh sees it from the start.

## Solution

Automatically enable fancy mode when Oh My Posh is detected (via the `POSH_THEME` environment variable). This is similar to how Windows and pwsh already force fancy mode.

## Changes

- Modified `pipenv/cli/command.py` to detect Oh My Posh via the `POSH_THEME` environment variable and automatically enable fancy mode.

## Testing

Users with Oh My Posh can test by running:
```bash
pipenv shell
echo $VIRTUAL_ENV  # Should now show the virtualenv path
```

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author