### PR TITLE
Fix: Preserve environment markers when importing requirements.txt

### DIFF
--- a/pipenv/project.py
+++ b/pipenv/project.py
@@ -1296,6 +1296,10 @@ class Project:
         elif hasattr(package, "index"):
             entry["index"] = package.index
 
+        # Include markers (e.g., sys_platform == 'win32') if present
+        if package.markers:
+            entry["markers"] = str(package.markers)
+
         if len(entry) == 1 and "version" in entry:
             return name, normalized_name, specifier
         else:


### PR DESCRIPTION
## Summary

When using `pipenv install -r requirements.txt` with packages that have environment markers (e.g., `python-magic-bin; sys_platform == 'win32'`), the markers were being ignored and the package was added to Pipfile without them.

## Problem

The `generate_package_pipfile_entry()` function in `pipenv/project.py` wasn't extracting the `markers` attribute from the `InstallRequirement` object when creating the Pipfile entry.

### Before:
```toml
[packages]
python-magic-bin = "*"
```

### After:
```toml
[packages]
python-magic-bin = {version = "*", markers = "sys_platform == 'win32'"}
```

## Changes

1. **pipenv/project.py**: Added marker extraction in `generate_package_pipfile_entry()` to include the `package.markers` attribute in the Pipfile entry when present.

2. **tests/integration/test_import_requirements.py**: Added a test to verify that environment markers are preserved when importing from requirements.txt.

## Test

```bash
pipenv run pytest tests/integration/test_import_requirements.py::test_import_requirements_preserves_markers -v
```

Fixes #6101

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author