### PR TITLE
Fix: Unset COLUMNS and LINES before spawning pipenv shell

### DIFF
--- a/pipenv/shells.py
+++ b/pipenv/shells.py
@@ -166,6 +166,12 @@ class Shell:
         # dimensions of pexpect.
         dims = get_terminal_size()
         with temp_environ():
+            # Unset COLUMNS and LINES so the spawned shell can manage them.
+            # When these are exported, Bash treats them as read-only inherited
+            # values and doesn't update them on terminal resize, even with
+            # checkwinsize enabled. See: https://github.com/pypa/pipenv/issues/6169
+            os.environ.pop("COLUMNS", None)
+            os.environ.pop("LINES", None)
             c = pexpect.spawn(self.cmd, ["-i"], dimensions=(dims.lines, dims.columns))
         c.sendline(_get_activate_script(self.cmd, venv))
 


### PR DESCRIPTION
## Summary

When `COLUMNS` and `LINES` are exported as environment variables before running `pipenv shell`, Bash treats them as read-only inherited values and doesn't update them when the terminal is resized, even with `checkwinsize` enabled. This causes issues with terminal-based programs (vim, less, etc.) and shell prompts when the terminal window is resized.

## Problem

Steps to reproduce:
1. Run `export COLUMNS`
2. Run `pipenv shell`
3. Resize the terminal window
4. Run `echo $COLUMNS` - value remains unchanged

## Root Cause

In the `fork_compat` method, when pexpect spawns a new shell, the `COLUMNS` and `LINES` environment variables from the parent process are inherited. Bash interprets these as user-set values and doesn't update them on resize signals.

Note: The `sigwinch_passthrough` handler correctly updates pexpect's window size, but that doesn't affect Bash's internal `COLUMNS`/`LINES` variables when they were inherited as exported values.

## Fix

Unset `COLUMNS` and `LINES` environment variables before spawning the shell. This allows Bash to manage these variables normally based on the terminal's actual dimensions. The terminal dimensions are still correctly set via pexpect's `dimensions` parameter.

## Related Issues

This is the same issue that affected Poetry:
- https://github.com/python-poetry/poetry/issues/4121
- https://github.com/python-poetry/poetry/issues/4165  
- https://github.com/python-poetry/poetry/issues/6351

Fixes #6169

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author