### PR TITLE
Fix: Use sys.executable -m pipenv instead of bare pipenv command

### DIFF
--- a/pipenv/routines/check.py
+++ b/pipenv/routines/check.py
@@ -101,13 +101,18 @@ def get_requirements(project, use_installed, categories):
             _cmd + ["-m", "pip", "list", "--format=freeze"],
             is_verbose=project.s.is_verbose(),
         )
+    # Use sys.executable -m pipenv to ensure pipenv is found even if not on PATH
+    # See: https://github.com/pypa/pipenv/issues/6042
     elif categories:
         return run_command(
-            ["pipenv", "requirements", "--categories", categories],
+            [sys.executable, "-m", "pipenv", "requirements", "--categories", categories],
             is_verbose=project.s.is_verbose(),
         )
     else:
-        return run_command(["pipenv", "requirements"], is_verbose=project.s.is_verbose())
+        return run_command(
+            [sys.executable, "-m", "pipenv", "requirements"],
+            is_verbose=project.s.is_verbose(),
+        )
 
 
 def create_temp_requirements(project, requirements, quiet=False):

--- a/pipenv/routines/scan.py
+++ b/pipenv/routines/scan.py
@@ -188,13 +188,18 @@ def get_requirements(project, use_installed, categories):
             _cmd + ["-m", "pip", "list", "--format=freeze"],
             is_verbose=project.s.is_verbose(),
         )
+    # Use sys.executable -m pipenv to ensure pipenv is found even if not on PATH
+    # See: https://github.com/pypa/pipenv/issues/6042
     elif categories:
         return run_command(
-            ["pipenv", "requirements", "--categories", categories],
+            [sys.executable, "-m", "pipenv", "requirements", "--categories", categories],
             is_verbose=project.s.is_verbose(),
         )
     else:
-        return run_command(["pipenv", "requirements"], is_verbose=project.s.is_verbose())
+        return run_command(
+            [sys.executable, "-m", "pipenv", "requirements"],
+            is_verbose=project.s.is_verbose(),
+        )
 
 
 def create_temp_requirements_file(requirements_content):


### PR DESCRIPTION
## Summary

When running `python -m pipenv check` in an environment where `pipenv` is not on `$PATH`, the check and scan commands would fail with:

```
FileNotFoundError: [Errno 2] No such file or directory: 'pipenv'
```

## Problem

The `get_requirements()` function in both `check.py` and `scan.py` invoked `pipenv requirements` as a subprocess using the bare `pipenv` command:

```python
run_command(["pipenv", "requirements"], ...)
```

This assumes `pipenv` is on the system's `$PATH`, which may not be true when:
- Running with `python -m pipenv` directly
- Using a non-standard installation
- Running in restricted environments (e.g., Docker containers with minimal PATH)

## Fix

Update `get_requirements()` to use `sys.executable` to invoke pipenv as a module:

```python
run_command([sys.executable, "-m", "pipenv", "requirements"], ...)
```

This ensures the command works regardless of whether `pipenv` is on the PATH.

## Files Changed

- `pipenv/routines/check.py` - Updated `get_requirements()` function
- `pipenv/routines/scan.py` - Updated `get_requirements()` function

Fixes #6042

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author