### PR TITLE
Improve error messages for build wheel failures

### DIFF
--- a/pipenv/exceptions.py
+++ b/pipenv/exceptions.py
@@ -323,10 +323,21 @@ class ResolutionFailure(PipenvException):
             "[yellow]$ pipenv graph[/yellow] to inspect the versions actually installed in the virtualenv.\n"
             "Hint: try [yellow]$ pipenv lock --pre[/yellow] if it is a pre-release dependency."
         )
-        if "no version found at all" in str(message):
+        message_str = str(message)
+        if "no version found at all" in message_str:
             message += (
                 "[cyan]Please check your version specifier and version number. "
                 "See PEP440 for more information.[/cyan]"
+            )
+        # Detect build wheel failures and provide more helpful hints
+        # See: https://github.com/pypa/pipenv/issues/6058
+        if "getting requirements to build wheel" in message_str.lower():
+            extra += (
+                "\n\n[cyan]Hint:[/cyan] The error 'Getting requirements to build wheel' often indicates:\n"
+                "  • Invalid pyproject.toml syntax or configuration\n"
+                "  • Encoding issues in files referenced by pyproject.toml (e.g., README.md with special characters)\n"
+                "  • Missing or incompatible build dependencies\n"
+                "Try running [yellow]$ pip install . -v[/yellow] for more detailed error output."
             )
         PipenvException.__init__(self, message, extra=extra)
 

--- a/pipenv/utils/resolver.py
+++ b/pipenv/utils/resolver.py
@@ -1062,6 +1062,17 @@ def venv_resolve_deps(
                     )
                     err.print(f"Output: {c.stdout.strip()}")
                     err.print(f"Error: {c.stderr.strip()}")
+                    # Provide helpful hints for common build errors
+                    # See: https://github.com/pypa/pipenv/issues/6058
+                    combined_output = (c.stdout + c.stderr).lower()
+                    if "getting requirements to build wheel" in combined_output:
+                        err.print(
+                            "\n[cyan]Hint:[/cyan] The error 'Getting requirements to build wheel' often indicates:\n"
+                            "  • Invalid pyproject.toml syntax or configuration\n"
+                            "  • Encoding issues in files referenced by pyproject.toml (e.g., README.md with special characters)\n"
+                            "  • Missing or incompatible build dependencies\n"
+                            "Try running [yellow]$ pip install . -v[/yellow] in your project directory for more detailed error output."
+                        )
 
     # Cache the results for future use
     if results:


### PR DESCRIPTION
## Summary

When pip fails with "Getting requirements to build wheel exited with 1", the error message is confusing because it appears to be a dependency resolution issue. This change adds helpful hints to guide users toward the actual cause.

## Problem

When running `pipenv install .` with a local package that has issues in its `pyproject.toml` or referenced files (like README.md with encoding problems), users see:

```
Resolving dependencies...
Locking Failed!
ERROR:pip.subprocessor:Getting requirements to build wheel exited with 1
```

This error appears to be about dependency resolution, but the actual problem is often:
- Invalid pyproject.toml syntax or configuration
- Encoding issues in files referenced by pyproject.toml (e.g., README.md with special characters like em-dashes `—` or ellipses `…`)
- Missing or incompatible build dependencies

## Solution

Add helpful hints when the "Getting requirements to build wheel" error is detected:

```
Hint: The error 'Getting requirements to build wheel' often indicates:
  • Invalid pyproject.toml syntax or configuration
  • Encoding issues in files referenced by pyproject.toml (e.g., README.md with special characters)
  • Missing or incompatible build dependencies
Try running $ pip install . -v in your project directory for more detailed error output.
```

## Changes

1. **pipenv/exceptions.py**: Enhanced `ResolutionFailure` exception to detect the error pattern and add hints
2. **pipenv/utils/resolver.py**: Added hint detection in the resolver error output path

Fixes #6058

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author