### PR TITLE
Fix: SSH VCS URLs without branch ref being corrupted

### DIFF
--- a/pipenv/project.py
+++ b/pipenv/project.py
@@ -1277,10 +1277,16 @@ class Project:
                         vcs_part = pip_line.split("@ ", 1)[1]
                     else:
                         vcs_part = pip_line
-                    vcs_parts = vcs_part.rsplit("@", 1)
-                    if len(vcs_parts) > 1:
+                    # Only split on @ if it's in the path part of the URL
+                    # (i.e., it's a branch/ref), not if it's in the netloc
+                    # (e.g., git@github.com in SSH URLs)
+                    parsed_vcs = urllib.parse.urlparse(vcs_part)
+                    if "@" in parsed_vcs.path:
+                        vcs_parts = vcs_part.rsplit("@", 1)
                         entry["ref"] = vcs_parts[1].split("#", 1)[0].strip()
-                    vcs_url = vcs_parts[0].strip()
+                        vcs_url = vcs_parts[0].strip()
+                    else:
+                        vcs_url = vcs_part.strip()
                     vcs_url = extract_vcs_url(vcs_url)
                     entry[vcs] = vcs_url
 


### PR DESCRIPTION
## Summary

Fixes #6076

## Problem

When installing a git dependency over SSH without specifying a branch/ref (e.g., `git+ssh://git@github.com/user/repo.git#egg=package`), the URL was being incorrectly parsed. The `@` symbol in `git@github.com` was being treated as a branch/ref separator, resulting in corrupted Pipfile.lock entries like:

```json
"git": "git+ssh://git"
```

instead of the correct:

```json
"git": "git+ssh://git@github.com/user/repo.git"
```

This caused pip to fail with errors like:
```
fatal: 'github.com/user/repo.git' does not appear to be a git repository
```

## Root Cause

In `pipenv/project.py`, the `generate_package_pipfile_entry()` function was using `rsplit("@", 1)` to extract the branch/ref from VCS URLs. This incorrectly split on the `@` in SSH URLs like `git@github.com`, treating `github.com/user/repo.git` as the ref and `git+ssh://git` as the URL.

## Solution

The fix checks if the `@` symbol is in the **path** part of the URL (indicating a branch/ref) rather than in the **netloc** (hostname) part before splitting. This matches the behavior of the existing `normalize_vcs_url()` function in `pipenv/utils/dependencies.py`.

## Changes

1. **`pipenv/project.py`**: Updated `generate_package_pipfile_entry()` to use `urllib.parse.urlparse()` to check if `@` is in the path before treating it as a ref separator.

2. **`tests/unit/test_vcs.py`**: Added regression tests for SSH URL handling with and without branch refs.

## Testing

- All existing VCS tests pass (27 tests)
- Added 5 new parametrized test cases specifically for SSH URL handling

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author