### PR TITLE
Add --no-lock flag to 'pipenv requirements' command

### DIFF
--- a/pipenv/cli/command.py
+++ b/pipenv/cli/command.py
@@ -928,7 +928,14 @@ def verify(state):
     "--from-pipfile",
     is_flag=True,
     default=False,
-    help="Only include dependencies from Pipfile.",
+    help="Only include dependencies from Pipfile (excludes transitive deps).",
+)
+@option(
+    "--no-lock",
+    is_flag=True,
+    default=False,
+    help="Use version specifiers from Pipfile instead of locked versions. "
+    "Useful for generating flexible requirements for libraries.",
 )
 @pass_state
 def requirements(
@@ -939,8 +946,13 @@ def requirements(
     exclude_markers=False,
     categories="",
     from_pipfile=False,
+    no_lock=False,
 ):
     from pipenv.routines.requirements import generate_requirements
+
+    # --no-lock implies --from-pipfile (only direct deps make sense without lock)
+    if no_lock:
+        from_pipfile = True
 
     generate_requirements(
         project=state.project,
@@ -950,6 +962,7 @@ def requirements(
         include_markers=not exclude_markers,
         categories=categories,
         from_pipfile=from_pipfile,
+        no_lock=no_lock,
     )
 
 

--- a/pipenv/routines/requirements.py
+++ b/pipenv/routines/requirements.py
@@ -2,7 +2,10 @@ import re
 import sys
 
 from pipenv.utils.dependencies import get_lockfile_section_using_pipfile_category
-from pipenv.utils.requirements import requirements_from_lockfile
+from pipenv.utils.requirements import (
+    requirements_from_lockfile,
+    requirements_from_pipfile,
+)
 
 
 def generate_requirements(
@@ -13,7 +16,19 @@ def generate_requirements(
     include_markers=True,
     categories="",
     from_pipfile=False,
+    no_lock=False,
 ):
+    # If --no-lock, generate from Pipfile directly without using lockfile versions
+    if no_lock:
+        _generate_requirements_from_pipfile(
+            project=project,
+            dev=dev,
+            dev_only=dev_only,
+            include_markers=include_markers,
+            categories=categories,
+        )
+        return
+
     lockfile = project.load_lockfile(expand_env_vars=False)
     pipfile_package_names = project.pipfile_package_names
 
@@ -67,5 +82,53 @@ def generate_requirements(
     # Print each requirement on its own line
     for line in pip_installable_lines:
         print(line)  # Use print instead of console.print
+
+    sys.exit(0)
+
+
+def _generate_requirements_from_pipfile(
+    project,
+    dev=False,
+    dev_only=False,
+    include_markers=True,
+    categories="",
+):
+    """Generate requirements directly from Pipfile using flexible version specifiers.
+
+    This is useful for libraries that need looser version constraints than
+    the strictly pinned versions in Pipfile.lock.
+    """
+    parsed_pipfile = project.parsed_pipfile
+
+    # Print index URLs from Pipfile sources
+    sources = parsed_pipfile.get("source", [])
+    for i, source in enumerate(sources):
+        url = source.get("url", "")
+        if url:
+            prefix = "-i" if i == 0 else "--extra-index-url"
+            print(f"{prefix} {url}")
+
+    deps = {}
+    categories_list = re.split(r", *| ", categories) if categories else []
+
+    if categories_list:
+        for category in categories_list:
+            category_deps = project.get_pipfile_section(category.strip())
+            deps.update(category_deps)
+    else:
+        if dev or dev_only:
+            dev_deps = project.get_pipfile_section("dev-packages")
+            deps.update(dev_deps)
+        if not dev_only:
+            default_deps = project.get_pipfile_section("packages")
+            deps.update(default_deps)
+
+    pip_installable_lines = requirements_from_pipfile(
+        deps, include_markers=include_markers
+    )
+
+    # Print each requirement on its own line
+    for line in pip_installable_lines:
+        print(line)
 
     sys.exit(0)


### PR DESCRIPTION
## Summary

Adds a new `--no-lock` flag to the `pipenv requirements` command that generates requirements using version specifiers from the Pipfile instead of locked versions from Pipfile.lock.

## Motivation

This addresses issue #5482 where users requested the ability to generate requirements.txt with flexible version constraints suitable for Python libraries.

Python libraries typically need looser version constraints (like `>=1.0`, `*`) in their `install_requires` rather than strictly pinned versions (like `==1.2.3`) that come from the lockfile. Strictly pinned dependencies can cause conflicts when the library is installed alongside other packages.

## Usage

```bash
# Generate requirements with Pipfile version specifiers
pipenv requirements --no-lock

# Include dev dependencies
pipenv requirements --no-lock --dev

# Specific categories
pipenv requirements --no-lock --categories="packages,extras"
```

## Examples

Given a Pipfile:
```toml
[packages]
requests = ">=2.0"
flask = "*"
django = "~=4.0"
```

**With `--no-lock`:**
```
requests>=2.0
flask
django~=4.0
```

**Without `--no-lock` (current behavior):**
```
requests==2.32.3
flask==3.0.0
django==4.2.7
```

## Implementation Details

- The `--no-lock` flag implies `--from-pipfile` since only direct dependencies make sense without the lockfile
- Supports all Pipfile dependency types: simple versions, VCS, paths, editable installs
- Preserves extras (e.g., `package[extra1,extra2]`)
- Preserves markers (e.g., `sys_platform == 'win32'`)
- Hashes are not supported with `--no-lock` (they require locked versions)

## Files Changed

- `pipenv/cli/command.py` - Added `--no-lock` option
- `pipenv/routines/requirements.py` - Added Pipfile-based generation logic
- `pipenv/utils/requirements.py` - Added `requirements_from_pipfile()` function

Fixes #5482

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author