### PR TITLE
Add PIPENV_PROJECT_DIR environment variable

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -97,6 +97,25 @@ To disable a boolean option, set it to a false value: `"0"`, `"false"`, `"no"`, 
 |----------|-------------|---------|
 | `PIPENV_PYUP_API_KEY` | PyUp.io API key for security checks | None |
 
+#### Runtime Environment Variables
+
+These variables are automatically set by Pipenv when running `pipenv run` or `pipenv shell`:
+
+| Variable | Description |
+|----------|-------------|
+| `PIPENV_ACTIVE` | Set to `1` when inside a Pipenv-managed environment |
+| `PIPENV_PROJECT_DIR` | Path to the project root directory (where Pipfile is located) |
+| `VIRTUAL_ENV` | Path to the virtualenv directory |
+
+The `PIPENV_PROJECT_DIR` variable is particularly useful for scripts that need to reference project-relative paths regardless of the current working directory:
+
+```toml
+# Pipfile
+[scripts]
+test = "pytest $PIPENV_PROJECT_DIR/tests"
+mypy = "mypy --config-file=$PIPENV_PROJECT_DIR/mypy.ini $PIPENV_PROJECT_DIR/src"
+```
+
 ### Examples
 
 #### Store virtualenvs in the project directory

--- a/pipenv/routines/shell.py
+++ b/pipenv/routines/shell.py
@@ -41,6 +41,11 @@ def do_shell(
     # otherwise its value will be changed
     os.environ["PIPENV_ACTIVE"] = "1"
 
+    # Set PIPENV_PROJECT_DIR to the project root directory.
+    # This allows scripts to reference project-relative paths regardless of
+    # the current working directory. See: https://github.com/pypa/pipenv/issues/2241
+    os.environ["PIPENV_PROJECT_DIR"] = str(project.project_directory)
+
     if fancy:
         shell.fork(*fork_args)
         return
@@ -105,6 +110,11 @@ def do_run(project, command, args, python=False, pypi_mirror=None, system=False)
     # such as in inline_activate_virtual_environment
     # otherwise its value will be changed
     env["PIPENV_ACTIVE"] = "1"
+
+    # Set PIPENV_PROJECT_DIR to the project root directory.
+    # This allows scripts to reference project-relative paths regardless of
+    # the current working directory. See: https://github.com/pypa/pipenv/issues/2241
+    env["PIPENV_PROJECT_DIR"] = str(project.project_directory)
 
     try:
         script = project.build_script(command, args)


### PR DESCRIPTION
## Summary

Adds a new `PIPENV_PROJECT_DIR` environment variable that is automatically set when running `pipenv run` or `pipenv shell`. This variable contains the path to the project root directory (where the Pipfile is located).

## Motivation

This addresses a long-standing feature request (#2241) from 2018. Users needed a way to consistently run scripts that require project root relative paths, regardless of their current working directory.

### Use Cases

1. **Running scripts from subdirectories:**
   ```bash
   cd project/src
   pipenv run test  # Now works because script can use $PIPENV_PROJECT_DIR
   ```

2. **Scripts in [scripts] section:**
   ```toml
   [scripts]
   test = "pytest $PIPENV_PROJECT_DIR/tests"
   mypy = "mypy --config-file=$PIPENV_PROJECT_DIR/mypy.ini $PIPENV_PROJECT_DIR/src"
   ```

3. **Django projects with src layout:**
   ```toml
   [scripts]
   manage = "python $PIPENV_PROJECT_DIR/src/manage.py"
   ```

## Changes

1. **pipenv/routines/shell.py:**
   - Set `PIPENV_PROJECT_DIR` in both `do_shell()` and `do_run()`

2. **docs/configuration.md:**
   - Added new "Runtime Environment Variables" section
   - Documents `PIPENV_ACTIVE`, `PIPENV_PROJECT_DIR`, and `VIRTUAL_ENV`
   - Provides usage examples

## Testing

```bash
# From project root
$ pipenv run bash -c 'echo $PIPENV_PROJECT_DIR'
/home/user/myproject

# From subdirectory
$ cd src && pipenv run bash -c 'echo $PIPENV_PROJECT_DIR'
/home/user/myproject
```

## Related Environment Variables

| Variable | Description |
|----------|-------------|
| `PIPENV_ACTIVE` | Set to `1` when inside a Pipenv environment |
| `PIPENV_PROJECT_DIR` | Path to project root (NEW) |
| `PIPENV_PIPFILE` | Full path to Pipfile (user-configurable) |
| `VIRTUAL_ENV` | Path to the virtualenv |

Fixes #2241

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author