### PR TITLE
Fix platform-specific packages causing resolution errors

### DIFF
--- a/pipenv/utils/dependencies.py
+++ b/pipenv/utils/dependencies.py
@@ -519,6 +519,10 @@ def convert_deps_to_pip(
     if indexes is None:
         indexes = []
     for dep_name, dep in deps.items():
+        # Translate platform-specific keys (sys_platform, platform_machine, etc.)
+        # to the unified 'markers' key before conversion
+        if isinstance(dep, dict):
+            dep = translate_markers(dep)
         req = dependency_as_pip_install_line(
             dep_name, dep, include_hashes, include_markers, include_index, indexes
         )

--- a/pipenv/utils/resolver.py
+++ b/pipenv/utils/resolver.py
@@ -217,6 +217,12 @@ class Resolver:
                     ]
             if install_req.markers:
                 markers_lookup[package_name] = install_req.markers
+                # Skip adding constraint if markers don't evaluate on current platform
+                # This prevents resolution errors for platform-specific packages
+                # See: https://github.com/pypa/pipenv/issues/6028
+                if not install_req.markers.evaluate():
+                    is_constraint = False
+                    skipped[package_name] = dep
             if is_constraint:
                 constraints.add(dep)
         lockfile_category = get_lockfile_section_using_pipfile_category(pipfile_category)

--- a/tests/integration/test_lock.py
+++ b/tests/integration/test_lock.py
@@ -165,6 +165,27 @@ def test_resolve_skip_unmatched_requirements(pipenv_instance_pypi):
 
 
 @pytest.mark.lock
+def test_resolve_skip_unmatched_sys_platform(pipenv_instance_pypi):
+    """Test that packages with non-matching sys_platform markers are skipped.
+
+    This tests the sys_platform key syntax (not markers key) which should
+    be properly converted and evaluated before resolution.
+
+    Fixes: https://github.com/pypa/pipenv/issues/6028
+    """
+    with pipenv_instance_pypi() as p:
+        # Use sys_platform key syntax (not markers key)
+        # This should be skipped on non-matching platforms without causing resolution errors
+        p._pipfile.add("missing-package", {"version": "*", "sys_platform": "== 'FakePlatform'"})
+        c = p.pipenv("lock")
+        assert c.returncode == 0
+        assert (
+            'Could not find a matching version of missing-package; sys_platform == "FakePlatform"'
+            in c.stderr
+        )
+
+
+@pytest.mark.lock
 @pytest.mark.complex
 @pytest.mark.needs_internet
 def test_complex_lock_with_vcs_deps(pipenv_instance_private_pypi):


### PR DESCRIPTION
## Summary

Fixes #6028

When a package has a `sys_platform` or other marker that doesn't match the current platform, skip adding it to the constraint set before resolution. This prevents pip from trying to resolve packages that don't exist for the current platform.

## Problem

Previously, packages like:
```toml
[packages]
pywin32 = {version = "*", sys_platform = "== 'win32'"}
```

Would cause resolution failures on Linux because the constraint was added to pip's resolver even though the marker didn't match. The error would be:
```
ERROR: No matching distribution found for pywin32
```

## Solution

Now, packages with non-matching markers are:
1. Skipped from the constraint set before resolution
2. Added to the skipped packages dict
3. Still recorded in the lockfile with their markers

This allows cross-platform Pipfiles to work correctly - packages that don't apply to the current platform are simply skipped during resolution rather than causing errors.

## Changes

- `pipenv/utils/resolver.py`: Check marker evaluation before adding to constraints
- `tests/integration/test_lock.py`: Add test for `sys_platform` key syntax

## Testing

Added a new test `test_resolve_skip_unmatched_sys_platform` that verifies packages with non-matching `sys_platform` markers are properly skipped during resolution.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author