### PR TITLE
Fix pipenv shell --quiet to actually suppress output

### DIFF
--- a/pipenv/routines/shell.py
+++ b/pipenv/routines/shell.py
@@ -27,6 +27,9 @@ def do_shell(
     from pipenv.shells import choose_shell
 
     shell = choose_shell(project)
+    # Respect both --quiet flag and PIPENV_QUIET environment variable
+    # See: https://github.com/pypa/pipenv/issues/5954
+    quiet = quiet or project.s.is_quiet()
     if not quiet:
         err.print("Launching subshell in virtual environment...")
 
@@ -51,7 +54,7 @@ def do_shell(
         return
 
     try:
-        shell.fork_compat(*fork_args)
+        shell.fork_compat(*fork_args, quiet=quiet)
     except (AttributeError, ImportError):
         err.print(
             "Compatibility mode not supported. "


### PR DESCRIPTION
## Summary

Fixes #5954

The `--quiet` flag and `PIPENV_QUIET` environment variable now properly suppress all shell activation output.

## Problem

When running `pipenv shell`, users see 3 lines of output:

```
❯ pipenv shell
Launching subshell in virtual environment...
 . /home/user/.local/share/virtualenvs/project-xxxx/bin/activate
❯  . /home/user/.local/share/virtualenvs/project-xxxx/bin/activate
```

The `--quiet` flag was documented but didn't fully suppress the output - specifically, it didn't suppress the activation command echo in pexpect-based compat mode.

## Solution

1. **Pass `quiet` parameter to `fork_compat()`**: The shell's compat mode now receives the quiet setting.

2. **Use `setecho(False)` in quiet mode**: When quiet mode is enabled, the pexpect session disables echo before sending the activation command, then re-enables it after. This prevents the activation command from being displayed.

3. **Respect `PIPENV_QUIET` environment variable**: The shell command now checks `project.s.is_quiet()` in addition to the `--quiet` flag, so users can set `PIPENV_QUIET=1` globally.

## Usage

```bash
# Using the --quiet flag
$ pipenv shell --quiet

# Using the environment variable
$ export PIPENV_QUIET=1
$ pipenv shell
```

## Changes

- `pipenv/shells.py`: Added `quiet` parameter to `fork_compat()`, uses `setecho(False)` to suppress activation command output
- `pipenv/routines/shell.py`: Pass `quiet` to `fork_compat()`, also respect `PIPENV_QUIET` environment variable via `project.s.is_quiet()`

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author