### PR TITLE
Exclude docs directory from package distribution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ scripts.pipenv-resolver = "pipenv.resolver:main"
 
 [tool.setuptools.packages.find]
 where = [ "." ]
-exclude = [ "tests*", "tests.*", "tasks*", "tasks.*" ]
+exclude = [ "tests*", "tests.*", "tasks*", "tasks.*", "docs*", "docs.*" ]
 
 [tool.setuptools.package-data]
 "*" = [ "LICENSE", "NOTICES" ]


### PR DESCRIPTION
## Summary

Fixes #5937

## Problem

The `docs/` directory was being installed to `site-packages/` root instead of being excluded from the package distribution. This causes conflicts with other packages that have a `docs/` directory.

For example, installing both `pipenv` and another package with `docs/conf.py` would result in one overwriting the other's file, or cause package manager conflicts.

This is similar to the previously fixed `examples/` directory issue in #6315.

## Solution

Added `"docs*"` and `"docs.*"` to the exclude pattern in `[tool.setuptools.packages.find]` section of `pyproject.toml` to prevent the documentation files from being included in the wheel distribution.

## Changes

- `pyproject.toml`: Added `docs*` and `docs.*` to the package exclude list

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author