### PR TITLE
Fix zsh parse error in pipenv shell command

### DIFF
--- a/pipenv/shells.py
+++ b/pipenv/shells.py
@@ -105,8 +105,14 @@ def _get_deactivate_wrapper_script(cmd):
             "function deactivate { & $_pipenv_old_deactivate; "
             "Remove-Item Env:PIPENV_ACTIVE -ErrorAction SilentlyContinue }"
         )
-    elif cmd.endswith(("bash", "zsh")):
-        # Bash and zsh support 'declare -f' to copy function definitions
+    elif cmd.endswith("zsh"):
+        # Zsh uses 'functions -c' to copy function definitions
+        return (
+            "functions -c deactivate _pipenv_old_deactivate; "
+            "deactivate() { _pipenv_old_deactivate; unset PIPENV_ACTIVE; }"
+        )
+    elif cmd.endswith("bash"):
+        # Bash uses 'declare -f' to copy function definitions
         return (
             'eval "_pipenv_old_deactivate() { $(declare -f deactivate | tail -n +2) }"; '
             "deactivate() { _pipenv_old_deactivate; unset PIPENV_ACTIVE; }"


### PR DESCRIPTION
## Summary

Fixes #6503

#6462 introduced a regression where `pipenv shell` fails on ZSH with a parse error:

```
eval "_pipenv_old_deactivate() { $(declare -f deactivate | tail -n +2) }";
zsh: parse error near `}'
```

## Root Cause

The previous implementation used `declare -f` inside an `eval` statement for both bash and zsh. However, zsh handles command substitution differently - it expands `$()` before parsing the function definition, causing a parse error.

## Solution

This fix separates the zsh and bash cases:
- **zsh**: Uses `functions -c` to copy function definitions (same approach as fish)
- **bash**: Continues using `declare -f` which works correctly in bash

## Testing

Enhanced the existing unit test to verify zsh uses `functions -c` (not `declare -f`) to prevent future regressions.

## Test Results

```
tests/unit/test_core.py::test_deactivate_wrapper_script_includes_unset_pipenv_active PASSED
```

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author