### PR TITLE
Fix MD5 usage to support FIPS-enabled Python environments

### DIFF
--- a/pipenv/utils/resolver.py
+++ b/pipenv/utils/resolver.py
@@ -751,7 +751,7 @@ def _generate_resolution_cache_key(
     ]
 
     key_string = "|".join(key_components)
-    return hashlib.md5(key_string.encode()).hexdigest()
+    return hashlib.md5(key_string.encode(), usedforsecurity=False).hexdigest()
 
 
 def _should_use_resolution_cache(cache_key, clear):


### PR DESCRIPTION
In FIPS mode, md5 might be available and approved. It might also be
available, but only on opt-in basis for unapproved usage. And very
strict systems might not have md5 even on opt-in basis.

Python has API to expose this as "usedforsecurity=False" argument, see
python documentation.

The rolling document checksum is not used for cryptograpic protection,
but rather used out of convenience. Hence allow using MD5 on more FIPS
systems.

This is no effective change for regular non-fips python builds.

