### PR TITLE
Fix path being printed with additional leading forward slash

### DIFF
--- a/pipenv/utils/shell.py
+++ b/pipenv/utils/shell.py
@@ -547,7 +547,7 @@ def shorten_path(location, bold=False):
     short_parts.append(path_parts[-1])
     if bold:
         short_parts[-1] = f"[bold]{short_parts[-1]}[/bold]"
-    return os.sep.join(short_parts)
+    return os.path.join(*short_parts)
 
 
 def isatty(stream):


### PR DESCRIPTION
## Summary 
Fixes #6515 

## Problem
Path being printed with additional forward slash during Python version compatibility error message.

```
Warning: Your Pipfile requires "python_version" 3.11, but you are using 3.13.10 
from //usr/local/bin/python3.
``` 
Should print path `/usr/local/bin/python3` not `//usr/local/bin/python3`

## Solution
Change `os.sep.join(short_parts)` with `os.path.join(*short_parts)` in `shorten_path()`

Now path is printed without any additional forward slash:
```
Warning: Your Pipfile requires "python_version" 3.11, but you are using 3.13.10 
from /usr/local/bin/python3.
``` 