### PR TITLE
Add support for Python Install Manager (pymanager) on Windows

### DIFF
--- a/pipenv/environments.py
+++ b/pipenv/environments.py
@@ -150,6 +150,14 @@ class Setting:
         Default is to install Python automatically via asdf when needed, if possible.
         """
 
+        self.PIPENV_DONT_USE_PYMANAGER = bool(
+            get_from_env("DONT_USE_PYMANAGER", check_for_negation=False)
+        )
+        """If set, Pipenv does not attempt to install Python with the Python Install Manager (pymanager) on Windows.
+
+        Default is to install Python automatically via pymanager when needed on Windows, if possible.
+        """
+
         self.PIPENV_PYENV_AUTO_INSTALL = bool(get_from_env("PYENV_AUTO_INSTALL"))
         """If set, Pipenv automatically installs missing Python versions via pyenv/asdf
         without prompting the user.

--- a/pipenv/installers.py
+++ b/pipenv/installers.py
@@ -1,3 +1,4 @@
+import json
 import operator
 import os
 import re
@@ -231,3 +232,117 @@ class Asdf(Installer):
             timeout=self.project.s.PIPENV_INSTALL_TIMEOUT,
         )
         return c
+
+
+class PyManager(Installer):
+    """Python Install Manager (pymanager) - the official Windows Python installer.
+
+    This is the tool recommended by the Python documentation for installing and
+    managing Python versions on Windows. It is available via the ``pymanager``
+    command after installation from python.org or the Microsoft Store.
+
+    See: https://docs.python.org/3/using/windows.html#python-install-manager
+    See: https://www.python.org/downloads/release/pymanager-260/
+    See: https://github.com/python/pymanager (PEP 773)
+    """
+
+    def _find_installer(self):
+        """Find the pymanager executable on Windows.
+
+        The ``pymanager`` command is unambiguous and only available when the
+        Python Install Manager (pymanager) is installed. This is distinct from
+        the legacy ``py.exe`` launcher.
+
+        Installation locations (in order of preference):
+            1. On PATH (normal case after MSIX/MSI install).
+            2. In the WindowsApps directory (MSIX install without PATH update).
+        """
+        if os.name != "nt":
+            raise InstallerNotFound()
+
+        # The pymanager command is the unambiguous alias for Python Install Manager.
+        # Unlike ``py``, ``pymanager`` is not provided by the legacy py.exe launcher,
+        # so finding it is sufficient to confirm pymanager is available.
+        candidate = find_windows_executable("", "pymanager")
+        if (
+            candidate is not None
+            and os.path.isfile(str(candidate))
+            and os.access(str(candidate), os.X_OK)
+        ):
+            return str(candidate)
+
+        # pymanager may be installed as an MSIX but not on PATH yet.
+        # Check the WindowsApps directory where MSIX apps are registered.
+        local_app_data = os.environ.get("LOCALAPPDATA", "")
+        if local_app_data:
+            windows_apps = os.path.join(local_app_data, "Microsoft", "WindowsApps")
+            candidate = find_windows_executable(windows_apps, "pymanager")
+            if (
+                candidate is not None
+                and os.path.isfile(str(candidate))
+                and os.access(str(candidate), os.X_OK)
+            ):
+                return str(candidate)
+
+        raise InstallerNotFound()
+
+    def __str__(self):
+        return "Python Install Manager (pymanager)"
+
+    def iter_installable_versions(self):
+        """Iterate through CPython versions available for pymanager to install.
+
+        Uses ``pymanager list --online --format=jsonl`` to fetch available
+        runtimes from the online index. Each line of output is a JSON object.
+        Only standard CPython releases (PythonCore, no free-threaded or
+        architecture-specific suffixes) are yielded.
+
+        Expected JSON fields per line (based on pymanager list --format=jsonl):
+            - ``tag``: runtime tag, e.g. "3.14", "3.13t", "3.14-arm64"
+            - ``company``: publisher, e.g. "PythonCore" for official CPython
+        """
+        try:
+            c = self._run("list", "--online", "--format=jsonl")
+        except InstallerError:
+            return
+
+        for line in c.stdout.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                data = json.loads(line)
+            except (ValueError, json.JSONDecodeError):
+                continue
+
+            # Only consider PythonCore (official CPython) releases.
+            company = data.get("company", "PythonCore")
+            if company and company.lower() not in ("pythoncore", ""):
+                continue
+
+            # The "tag" field holds the version identifier (e.g., "3.14", "3.13").
+            # Skip free-threaded builds ("3.13t") and arch-specific tags ("3.14-arm64")
+            # since Version.parse will reject those non-standard suffixes.
+            tag = data.get("tag", "")
+            try:
+                version = Version.parse(tag)
+                yield version
+            except ValueError:
+                continue
+
+    def install(self, version):
+        """Install the given version with pymanager.
+
+        The version must be a ``Version`` instance representing a version
+        found in iter_installable_versions().
+        A InstallerError is raised if the pymanager command fails.
+
+        After installation, the runtime is registered via PEP 514 and is
+        discoverable by ``py --list-paths`` and pythonfinder's PyLauncherFinder
+        and WindowsRegistryFinder.
+        """
+        return self._run(
+            "install",
+            str(version),
+            timeout=self.project.s.PIPENV_INSTALL_TIMEOUT,
+        )

--- a/pipenv/utils/virtualenv.py
+++ b/pipenv/utils/virtualenv.py
@@ -284,7 +284,13 @@ def ensure_python(project, python=None):
             "was not found on your system..."
         )
         # check for python installers
-        from pipenv.installers import Asdf, InstallerError, InstallerNotFound, Pyenv
+        from pipenv.installers import (
+            Asdf,
+            InstallerError,
+            InstallerNotFound,
+            Pyenv,
+            PyManager,
+        )
 
         # prefer pyenv if both pyenv and asdf are installed as it's
         # dedicated to python installs so probably the preferred
@@ -298,10 +304,24 @@ def ensure_python(project, python=None):
             with contextlib.suppress(InstallerNotFound):
                 installer = Asdf(project)
 
+        # On Windows, fall back to the Python Install Manager (pymanager) if
+        # neither pyenv nor asdf are available. pymanager is the tool recommended
+        # by the Python documentation for installing Python on Windows.
+        # See: https://docs.python.org/3/using/windows.html#python-install-manager
+        if (
+            installer is None
+            and os.name == "nt"
+            and not project.s.PIPENV_DONT_USE_PYMANAGER
+        ):
+            with contextlib.suppress(InstallerNotFound):
+                installer = PyManager(project)
+
         if not installer:
             if os.name == "nt":
                 abort(
-                    "Python was not found on your system and neither 'pyenv' nor 'asdf' could be found to install Python."
+                    "Python was not found on your system and none of 'pyenv', 'asdf', "
+                    "or 'pymanager' (Python Install Manager) could be found to install Python. "
+                    "Install pymanager from https://www.python.org/downloads/ or via the Microsoft Store."
                 )
             else:
                 abort("Neither 'pyenv' nor 'asdf' could be found to install Python.")


### PR DESCRIPTION
Closes #6522

## Summary

The [Python documentation](https://docs.python.org/3/using/windows.html#python-install-manager) now recommends the **Python Install Manager** (`pymanager`, [PEP 773](https://peps.python.org/pep-0773/)) for installing and managing Python versions on Windows — superseding the legacy `py.exe` launcher. Released as [pymanager 26.0](https://www.python.org/downloads/release/pymanager-260/) (Feb 2026), it is available from python.org or the Microsoft Store.

This PR adds a `PyManager` installer class analogous to the existing `Pyenv` and `Asdf` installers, so Pipenv can automatically download missing Python versions via `pymanager` on Windows.

## Changes

### `pipenv/installers.py`
New `PyManager(Installer)` class:
- **Detection**: looks for the `pymanager` executable on `PATH`, then falls back to `%LOCALAPPDATA%\Microsoft\WindowsApps\` (where MSIX apps land before PATH is updated). Uses `pymanager` (not `py`) because it is the unambiguous command that only exists with the new tool — not the legacy `py.exe` launcher.
- **Listing**: runs `pymanager list --online --format=jsonl` and parses each JSON line, filtering for `company == "PythonCore"` and standard version tags (rejects free-threaded `3.13t` and arch-specific `3.14-arm64` tags via `Version.parse`).
- **Installing**: runs `pymanager install <version>`.

### `pipenv/environments.py`
Adds `PIPENV_DONT_USE_PYMANAGER` opt-out environment variable, consistent with `PIPENV_DONT_USE_PYENV` and `PIPENV_DONT_USE_ASDF`.

### `pipenv/utils/virtualenv.py`
Integrates `PyManager` into the `ensure_python()` fallback chain:
- On Windows (`os.name == 'nt'`), after pyenv and asdf are tried, `PyManager` is attempted before aborting.
- The Windows-specific abort message is updated to mention `pymanager` and its install URL.

## Installer preference order on Windows

```
pyenv  →  asdf  →  pymanager  →  abort
```

## No pythonfinder changes needed

After `pymanager install 3.14`, the runtime is registered via [PEP 514](https://peps.python.org/pep-0514/), so the existing `WindowsRegistryFinder` and `PyLauncherFinder` in pythonfinder already discover it (via `py --list-paths`, which pymanager preserves for compatibility). No pythonfinder changes are required.

## Testing note

The exact JSON schema produced by `pymanager list --online --format=jsonl` should be verified against a real Windows + pymanager install. The implementation targets `tag` and `company` fields based on the pymanager documentation and source structure, but field names should be confirmed before merging.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author