### PR TITLE
Fix broken version comparison in system Python version compatibility check

### DIFF
--- a/pipenv/utils/project.py
+++ b/pipenv/utils/project.py
@@ -19,6 +19,44 @@ else:
     import importlib.metadata as importlib_metadata
 
 
+def _python_version_matches_required(actual_ver_str, required_ver_str):
+    """Return True if *actual_ver_str* satisfies *required_ver_str*.
+
+    ``required_ver_str`` comes from the Pipfile ``[requires]`` section and may
+    be either a ``python_version`` (``"X.Y"``, major.minor only) or a
+    ``python_full_version`` (``"X.Y.Z"``).
+
+    ``actual_ver_str`` is the full version string reported by the Python
+    interpreter (e.g. ``"3.13.11"``).
+
+    A simple substring/``in`` check is **wrong** here: ``"3.11" in "3.13.11"``
+    is ``True`` because ``"3.11"`` happens to appear as a substring of
+    ``"3.13.11"``, causing an incompatible Python version to be silently
+    accepted.  See https://github.com/pypa/pipenv/issues/6514.
+
+    Instead, this function:
+    * When *required_ver_str* has fewer than three dot-separated components
+      (i.e. only ``major.minor``), compares just the ``major`` and ``minor``
+      fields of both parsed versions.
+    * When *required_ver_str* has three or more components (``major.minor.patch``),
+      requires an exact match of the parsed versions.
+    """
+    if not actual_ver_str or not required_ver_str:
+        return False
+    try:
+        actual = parse_version(actual_ver_str)
+        required = parse_version(required_ver_str)
+        if len(required_ver_str.split(".")) >= 3:
+            # python_full_version specified — must match exactly.
+            return actual == required
+        else:
+            # python_version (major.minor only) — compare only those components.
+            return actual.major == required.major and actual.minor == required.minor
+    except Exception:
+        # Fallback for any unparseable version strings.
+        return actual_ver_str == required_ver_str
+
+
 def ensure_project(
     project,
     python=None,
@@ -73,8 +111,8 @@ def ensure_project(
         else:
             path_to_python = project._which("python") or project._which("py")
 
-        if path_to_python and project.required_python_version not in (
-            python_version(path_to_python) or ""
+        if path_to_python and not _python_version_matches_required(
+            python_version(path_to_python) or "", project.required_python_version
         ):
             err.print(
                 f"[red][bold]Warning[/bold][/red]: Your Pipfile requires "

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -779,3 +779,51 @@ class TestPipConfigurationParsing:
             assert project.default_source["url"] in [primary_index, extra_index]
         finally:
             os.chdir(original_dir)
+
+
+
+class TestPythonVersionMatchesRequired:
+    """Tests for _python_version_matches_required.
+
+    Regression coverage for https://github.com/pypa/pipenv/issues/6514:
+    the old `not in` substring check incorrectly accepted e.g. actual="3.13.11"
+    when required="3.11", because "3.11" is a substring of "3.13.11".
+    """
+
+    @pytest.mark.parametrize(
+        "actual, required, expected",
+        [
+            # --- python_version (major.minor) cases ---
+            # Exact major.minor match with a patch suffix on actual
+            ("3.11.0", "3.11", True),
+            ("3.11.5", "3.11", True),
+            # The substring-false-positive that triggered the bug report:
+            # "3.11" is a substring of "3.13.11" but they are NOT compatible.
+            ("3.13.11", "3.11", False),
+            # Additional substring traps
+            ("3.9.1", "3.9", True),
+            ("3.9.10", "3.9", True),
+            ("3.10.0", "3.1", False),   # "3.1" would match "3.1x.y" as substring
+            ("3.13.1", "3.1", False),
+            ("3.11.0", "3.1", False),
+            # Major version mismatch
+            ("2.7.18", "3.7", False),
+            ("3.7.0", "2.7", False),
+            # Same major, different minor
+            ("3.10.0", "3.11", False),
+            ("3.12.0", "3.11", False),
+            # --- python_full_version (major.minor.patch) cases ---
+            ("3.11.0", "3.11.0", True),
+            ("3.11.0", "3.11.1", False),
+            ("3.13.11", "3.11.0", False),
+            ("3.11.10", "3.11.1", False),  # "3.11.1" is substring of "3.11.10"
+            # --- Edge / guard cases ---
+            ("", "3.11", False),
+            ("3.11.0", "", False),
+            ("", "", False),
+        ],
+    )
+    def test_version_match(self, actual, required, expected):
+        from pipenv.utils.project import _python_version_matches_required
+
+        assert _python_version_matches_required(actual, required) is expected


### PR DESCRIPTION
Fixes #6514

## Root cause

The check introduced in #6453 used Python's `in` operator to test whether `required_python_version` is a substring of the actual version string:

```python
# before
if path_to_python and project.required_python_version not in (
    python_version(path_to_python) or ""
):
```

`in` on strings is a **substring** test, not a version component comparison. This silently accepts an incompatible interpreter whenever the required version string happens to appear as a substring of the actual version string.

### Concrete failure from the issue

| | value |
|---|---|
| `python_version` in Pipfile/lock | `"3.11"` |
| system Python (Docker image) | `"3.13.11"` |

```python
"3.11" in "3.13.11"  # True — "3.11" is at characters 3–6 of "3.13.11"
```

So `not in` evaluated to `False`, the mismatch warning/error was silently skipped, and `pipenv install --deploy --system` succeeded when it should have raised `DeployException`.

The same class of bug exists for other version pairs, e.g. `required="3.1"` vs `actual="3.11.0"` or `actual="3.13.1"`.

## Fix

Replace the substring check with proper semantic version comparison using `packaging.version.parse` (already imported in the module).

The logic is extracted into a module-level helper `_python_version_matches_required(actual, required)`:

- If `required_python_version` has **two** dot-separated parts (i.e. `python_version = "X.Y"`), compare only `major` and `minor`.
- If it has **three or more** parts (`python_full_version = "X.Y.Z"`), require an exact match.

```python
# after
if path_to_python and not _python_version_matches_required(
    python_version(path_to_python) or "", project.required_python_version
):
```

## Tests

19 parametrised cases added in `TestPythonVersionMatchesRequired` covering:
- The exact substring-trap from the issue: `("3.13.11", "3.11")` → `False`
- Other ambiguous substring pairs: `"3.1"`/`"3.11.0"`, `"3.9"`/`"3.9.10"`, `"3.11.1"`/`"3.11.10"`
- Normal compatible pairs: `("3.11.5", "3.11")` → `True`
- Major version mismatches, `python_full_version` exact match/mismatch cases
- Empty-string guard cases

All 19 pass.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author