### PR TITLE
fix: uninstall --all no longer wipes Pipfile.lock

### DIFF
--- a/pipenv/routines/uninstall.py
+++ b/pipenv/routines/uninstall.py
@@ -85,22 +85,11 @@ def do_uninstall(
             "Un-installing all packages...",
             style="bold",
         )
-        # Uninstall all packages from all groups
-        for category in project.get_package_categories():
-            if category in ["source", "requires"]:
-                continue
-            for package in project.get_pipfile_section(category):
-                _uninstall_from_environment(project, package, system=system)
-
-        # Clear all categories in the lockfile
-        for category in list(lockfile_content.keys()):
-            if category != "_meta":
-                lockfile_content[category] = {}
-
-        lockfile_content.update({"_meta": project.get_lockfile_meta()})
-        project.write_lockfile(lockfile_content)
-
-        # Call do_purge to remove all packages from the environment
+        # Purge all packages from the virtualenv without touching Pipfile or
+        # Pipfile.lock.  The --all flag is documented as "Purge all package(s)
+        # from virtualenv. Does not edit Pipfile." — the lockfile must also be
+        # left intact so that a subsequent `pipenv install` (or `pipenv sync`)
+        # can restore exactly the same environment from the existing lock data.
         do_purge(project, bare=False, downloads=False, allow_global=system)
         return
 

--- a/tests/integration/test_uninstall.py
+++ b/tests/integration/test_uninstall.py
@@ -95,12 +95,22 @@ def test_uninstall_all_local_files(pipenv_instance_private_pypi, testsroot):
         ).as_uri()
         c = p.pipenv(f"install {file_uri}")
         assert c.returncode == 0
+        # Capture the lockfile content *before* the purge so we can compare after.
+        lockfile_before = p.lockfile
+        assert "tablib" in lockfile_before["default"], "tablib should be locked before --all"
+
         c = p.pipenv("uninstall --all")
         assert c.returncode == 0
         assert "tablib" in c.stdout
         # Uninstall --all is not supposed to remove things from the pipfile
         # Note that it didn't before, but that instead local filenames showed as hashes
         assert "tablib" in p.pipfile["packages"]
+        # Pipfile.lock must be left completely intact so that a subsequent
+        # `pipenv install` / `pipenv sync` can restore the same environment.
+        # Regression test for https://github.com/pypa/pipenv/issues/6510
+        assert p.lockfile["default"] == lockfile_before["default"], (
+            "uninstall --all must not wipe Pipfile.lock"
+        )
 
 
 @pytest.mark.install


### PR DESCRIPTION
Closes #6510

## Problem

`pipenv uninstall --all` is documented as:
> Purge all package(s) from virtualenv. Does not edit Pipfile.

It correctly left the Pipfile alone, but it was silently zeroing out every dependency section in `Pipfile.lock` and writing the empty file to disk. A subsequent `pipenv install` or `pipenv sync` would install nothing because the lockfile reported an empty dependency set.

## Root Cause

In `do_uninstall()` (`pipenv/routines/uninstall.py`), the `all=True` branch was clearing every non-`_meta` key in the in-memory lockfile dict and then calling `project.write_lockfile()` before delegating to `do_purge()`.

## Fix

Remove the lockfile-clearing block entirely from the `--all` branch. The function now goes straight to `do_purge()`, which handles all virtualenv uninstallation. Neither `Pipfile` nor `Pipfile.lock` is touched.

```diff
-        # Clear all categories in the lockfile
-        for category in list(lockfile_content.keys()):
-            if category != "_meta":
-                lockfile_content[category] = {}
-
-        lockfile_content.update({"_meta": project.get_lockfile_meta()})
-        project.write_lockfile(lockfile_content)
-
         # Call do_purge to remove all packages from the environment
         do_purge(project, bare=False, downloads=False, allow_global=system)
```

## Test

Extended the existing integration test `test_uninstall_all_local_files` to snapshot the lockfile before the purge and assert it is identical after `uninstall --all`.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author