### PR TITLE
Docs: expand platform marker support & platform_machine examples (#6356)

### DIFF
--- a/docs/pipfile.md
+++ b/docs/pipfile.md
@@ -334,6 +334,19 @@ waitress = {version = "*", markers = "sys_platform == 'win32'"}
 colorama = {version = "*", markers = "python_version >= '3.7'"}
 ```
 
+Pipenv also supports shorthand keys for common markers. These are equivalent to using the full `markers` syntax:
+
+```toml
+[packages]
+# Shorthand form — these marker keys are recognized directly:
+gunicorn = {version = "*", sys_platform = "== 'linux'"}
+arm-optimized = {version = "*", platform_machine = "== 'arm64'"}
+```
+
+All [PEP 508 environment marker](https://peps.python.org/pep-0508/#environment-markers) keys are supported, including `sys_platform`, `platform_machine`, `platform_system`, `os_name`, `python_version`, `python_full_version`, `platform_python_implementation`, and `implementation_name`.
+
+For more details and architecture-specific examples, see [Platform-Specific Dependencies](specifiers.md#platform-specific-dependencies).
+
 ### Package Extras
 
 Many packages provide optional features as "extras":

--- a/docs/specifiers.md
+++ b/docs/specifiers.md
@@ -217,6 +217,53 @@ This will be reflected in your `Pipfile`:
 pywinusb = {version = "*", markers = "sys_platform == 'win32'"}
 ```
 
+#### Shorthand Marker Keys
+
+In addition to the full `markers` syntax, Pipenv supports shorthand keys for common markers directly in Pipfile entries:
+
+```toml
+[packages]
+# These two forms are equivalent:
+pywinusb = {version = "*", markers = "sys_platform == 'win32'"}
+pywinusb = {version = "*", sys_platform = "== 'win32'"}
+
+# Platform-specific using platform_machine:
+special-arm-lib = {version = "*", platform_machine = "== 'arm64'"}
+
+# macOS-only dependency:
+pyobjc = {version = "*", sys_platform = "== 'darwin'"}
+```
+
+Any key from the [PEP 508 environment markers](https://peps.python.org/pep-0508/#environment-markers) can be used as a shorthand.
+
+#### Architecture-Specific Dependencies
+
+Use the `platform_machine` marker to target specific CPU architectures:
+
+```toml
+[packages]
+# Only install on ARM64 (e.g., Apple Silicon Macs, ARM Linux)
+arm-optimized = {version = "*", platform_machine = "== 'arm64'"}
+
+# Only install on x86_64 systems
+x86-optimized = {version = "*", platform_machine = "== 'x86_64'"}
+
+# macOS on Apple Silicon only
+macos-arm = {version = "*", markers = "sys_platform == 'darwin' and platform_machine == 'arm64'"}
+```
+
+Common `platform_machine` values:
+- `x86_64` — 64-bit Intel/AMD (Linux, macOS)
+- `arm64` — ARM 64-bit (Apple Silicon macOS)
+- `aarch64` — ARM 64-bit (Linux)
+- `AMD64` — 64-bit Intel/AMD (Windows)
+
+> **Note:** `platform_machine` controls *whether* a package is installed based on the
+> current machine's architecture. It does not control *which wheel variant* pip selects
+> (e.g., it cannot force pip to choose a `universal2` wheel over an `arm64` wheel).
+> To install a specific wheel file, use the `file` or `path` attribute instead — see
+> [Local and Remote File Dependencies](pipfile.md#local-and-remote-file-dependencies).
+
 ### Python Version-Specific Dependencies
 
 You can specify dependencies that are only needed for certain Python versions:
@@ -240,7 +287,8 @@ Common markers include:
 - `python_version`: Python version in 'X.Y' format
 - `python_full_version`: Python version in 'X.Y.Z' format
 - `sys_platform`: Platform name (e.g., 'win32', 'linux', 'darwin')
-- `platform_machine`: Machine type (e.g., 'x86_64', 'i386')
+- `platform_machine`: Machine type (e.g., 'x86_64', 'arm64', 'aarch64', 'AMD64')
+- `platform_system`: Operating system name (e.g., 'Linux', 'Darwin', 'Windows')
 - `platform_python_implementation`: Python implementation (e.g., 'CPython', 'PyPy')
 - `os_name`: Name of the operating system (e.g., 'posix', 'nt')
 


### PR DESCRIPTION
## Summary

Addresses #6356 — Documents the existing support for platform-specific markers in Pipfile entries, especially `platform_machine`.

## Changes

### `docs/specifiers.md`
- Added **Shorthand Marker Keys** section showing that `sys_platform`, `platform_machine`, etc. can be used directly as Pipfile keys (equivalent to the full `markers` syntax)
- Added **Architecture-Specific Dependencies** section with examples for `arm64`, `x86_64`, `aarch64`, and `AMD64`
- Added a note clarifying that `platform_machine` markers control *whether* a package is installed, not *which wheel variant* pip selects (e.g., universal2 vs arm64) — and points users to `file`/`path` attributes for installing specific wheel files
- Added `platform_system` to the common markers list

### `docs/pipfile.md`
- Expanded Package Markers section with shorthand key examples
- Listed all supported PEP 508 marker keys
- Cross-referenced the detailed specifiers documentation

## Context

The feature requested in #6356 (forcing universal2 wheel selection) cannot be solved by PEP 508 markers alone, since markers control conditional installation — not wheel variant selection. However, the existing `platform_machine` marker support was undocumented, making it hard for users to discover. This PR closes the documentation gap and provides clear guidance on what markers can and cannot do.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author