### PR TITLE
Fix PermissionError on Windows restricted PATH entries (#6093)

### DIFF
--- a/pipenv/utils/virtualenv.py
+++ b/pipenv/utils/virtualenv.py
@@ -455,6 +455,14 @@ def find_a_system_python(line):
 
     from pipenv.vendor.pythonfinder import Finder
 
+    # Short-circuit: if an absolute path was given and it exists, use it
+    # directly without scanning PATH (avoids PermissionError on restricted
+    # Windows system directories such as C:\WINDOWS\system32\config\...).
+    if line and os.path.isabs(line):
+        path_obj = Path(line)
+        if path_obj.is_file() and os.access(str(path_obj), os.X_OK):
+            return str(path_obj)
+
     finder = Finder(system=True, global_search=True)
     if not line:
         return next(iter(finder.find_all_python_versions()), None)

--- a/pipenv/vendor/pythonfinder/finders/system_finder.py
+++ b/pipenv/vendor/pythonfinder/finders/system_finder.py
@@ -57,7 +57,12 @@ class SystemFinder(PathFinder):
         venv = os.environ.get("VIRTUAL_ENV")
         if venv:
             bin_dir = "Scripts" if os.name == "nt" else "bin"
-            venv_path = Path(venv).resolve() / bin_dir
+            try:
+                venv_path = Path(venv).resolve() / bin_dir
+            except (PermissionError, OSError):
+                # resolve() can raise PermissionError on Windows for restricted
+                # system directories; fall back to a non-resolving join.
+                venv_path = Path(venv) / bin_dir
 
             # For Windows tests with Unix-style paths
             if os.name == "nt" and str(venv).startswith("/"):

--- a/pipenv/vendor/pythonfinder/utils/path_utils.py
+++ b/pipenv/vendor/pythonfinder/utils/path_utils.py
@@ -238,11 +238,14 @@ def exists_and_is_accessible(path: Path) -> bool:
     """
     try:
         return path.exists()
-    except PermissionError as pe:
-        if pe.errno == errno.EACCES:  # Permission denied
-            return False
-        else:
-            raise
+    except PermissionError:
+        # Treat any permission-denied error (including Windows WinError 5) as
+        # inaccessible rather than crashing.
+        return False
+    except OSError:
+        # Catch other OS-level errors (e.g. Windows ERROR_ACCESS_DENIED variants
+        # that may surface as OSError rather than PermissionError).
+        return False
 
 
 def is_in_path(path: str | Path, parent_path: str | Path) -> bool:


### PR DESCRIPTION
## Summary

Fixes #6093.

When a user passes an absolute Python path via `--python` (e.g. `--python=C:\toolbase\python\...\python.exe`), pipenv was still constructing `Finder(system=True, global_search=True)`, which eagerly scanned every entry in `PATH`. That scan hits restricted Windows system directories such as `C:\WINDOWS\system32\config\systemprofile`, causing `Path.resolve()` to raise `PermissionError (WinError 5)` before any existence guard could run.

## Changes

### `pipenv/utils/virtualenv.py`
`find_a_system_python()` now **short-circuits** when `line` is an absolute path pointing to an existing, executable file: the path is returned immediately and `Finder` is never constructed, avoiding all PATH scanning. This directly addresses the reported scenario.

### `pipenv/vendor/pythonfinder/finders/system_finder.py`
Wrap the `Path(venv).resolve()` call in `try/except (PermissionError, OSError)` with a fallback to a plain `Path` join. `resolve()` itself can raise on Windows before any existence check runs, so the guard needs to be here too.

### `pipenv/vendor/pythonfinder/utils/path_utils.py`
Simplify `exists_and_is_accessible()` to catch **all** `PermissionError` and `OSError` instead of re-raising when `errno != errno.EACCES`. Windows surfaces some access-denied errors via `winerror` codes that do not always map cleanly to `errno.EACCES`, so catching broadly is the right defensive posture.

## Testing

The primary fix (`find_a_system_python` short-circuit) can be verified by running:
```
pipenv sync --python=C:\path\to\python.exe
```
on a Windows machine where `C:\WINDOWS\system32\config\systemprofile` is not accessible to the current user. Previously this crashed immediately; with this fix the absolute path is validated and used without any PATH scan.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author