### PR TITLE
fix: pipenv --rm removes wrong venv when .venv dir coexists with workon_home venv

### DIFF
--- a/pipenv/project.py
+++ b/pipenv/project.py
@@ -446,6 +446,15 @@ class Project:
         # If there's no .venv in project root or it is a folder, set location based on config.
         if not dot_venv.exists() or dot_venv.is_dir():
             if self.is_venv_in_project():
+                # When PIPENV_VENV_IN_PROJECT is not explicitly set, the .venv dir
+                # was detected automatically. If a pipenv-managed virtualenv already
+                # exists in WORKON_HOME (e.g. created before the user independently
+                # ran `python -m venv .venv`), prefer that one so that `pipenv --rm`
+                # does not accidentally remove the user-created .venv directory.
+                if not self.s.PIPENV_VENV_IN_PROJECT:
+                    workon_home_venv = get_workon_home() / self.virtualenv_name
+                    if workon_home_venv.exists():
+                        return workon_home_venv
                 return dot_venv
             return get_workon_home().joinpath(self.virtualenv_name)
 

--- a/tests/integration/test_dot_venv.py
+++ b/tests/integration/test_dot_venv.py
@@ -173,6 +173,46 @@ def test_venv_in_project_default_when_venv_exists(pipenv_instance_pypi):
         assert venv_loc == Path(venv_path)
 
 
+@pytest.mark.dotvenv
+def test_rm_prefers_workon_home_venv_over_dot_venv_dir(pipenv_instance_pypi):
+    """Regression test for https://github.com/pypa/pipenv/issues/6331.
+
+    When a pipenv-managed virtualenv already exists in WORKON_HOME and the user
+    independently creates a .venv directory (e.g. via `python -m venv .venv`),
+    `pipenv --rm` must remove the pipenv-managed venv, not the user-created .venv.
+    """
+    with temp_environ(), pipenv_instance_pypi() as p, TemporaryDirectory(
+        prefix="pipenv-", suffix="temp_workon_home"
+    ) as workon_home:
+        os.environ["WORKON_HOME"] = workon_home
+        # Step 1: create the pipenv-managed virtualenv in WORKON_HOME.
+        c = p.pipenv("install")
+        assert c.returncode == 0
+        c = p.pipenv("--venv")
+        assert c.returncode == 0
+        pipenv_venv = Path(c.stdout.strip())
+        assert pipenv_venv.exists()
+        assert str(pipenv_venv).startswith(workon_home)
+
+        # Step 2: user independently creates a .venv dir in the project root.
+        dot_venv = Path(p.path) / ".venv"
+        dot_venv.mkdir()
+
+        # Step 3: `--venv` should still report the pipenv-managed venv.
+        c = p.pipenv("--venv")
+        assert c.returncode == 0
+        reported_venv = Path(c.stdout.strip())
+        assert reported_venv == pipenv_venv, (
+            f"Expected pipenv-managed venv {pipenv_venv}, got {reported_venv}"
+        )
+
+        # Step 4: `--rm` must remove the pipenv-managed venv, not .venv.
+        c = p.pipenv("--rm")
+        assert c.returncode == 0
+        assert not pipenv_venv.exists(), "pipenv-managed venv should have been removed"
+        assert dot_venv.exists(), "user-created .venv dir must NOT be removed"
+
+
 @pytest.mark.dotenv
 def test_venv_name_accepts_custom_name_environment_variable(pipenv_instance_pypi):
     """Tests that virtualenv reads PIPENV_CUSTOM_VENV_NAME and accepts it as a name"""


### PR DESCRIPTION
Fixes #6331

## Problem

When a project has both a pipenv-managed virtualenv in `WORKON_HOME` and a user-created `.venv` directory (e.g. from `python -m venv .venv`), the automatic venv-in-project detection caused `virtualenv_location` to return the project-local `.venv` path instead of the pipenv-managed one. Running `pipenv --rm` would then delete the `.venv` the user created rather than the virtualenv pipenv owns.

**Root cause:** `is_venv_in_project()` returns `True` whenever a `.venv` **directory** exists in the project root, regardless of whether `PIPENV_VENV_IN_PROJECT` was explicitly set. This caused `get_location_for_virtualenv()` to pick `.venv` even when a pipenv-managed venv already existed at the `WORKON_HOME` path.

## Fix

In `get_location_for_virtualenv()`, when `PIPENV_VENV_IN_PROJECT` is **not explicitly set** (the `.venv` directory was auto-detected, not configured by the user), check whether a pipenv-managed virtualenv already exists at `WORKON_HOME / virtualenv_name`. If one exists, return that path instead of `.venv`.

## Behaviour preserved

| Scenario | Before | After |
|---|---|---|
| `PIPENV_VENV_IN_PROJECT=1` | uses `.venv` | uses `.venv` ✓ |
| `PIPENV_VENV_IN_PROJECT=0` | uses workon_home | uses workon_home ✓ |
| auto-detected `.venv`, no workon_home venv | uses `.venv` | uses `.venv` ✓ |
| auto-detected `.venv`, workon_home venv exists | uses `.venv` ❌ | uses workon_home ✓ |

## Test

Added `test_rm_prefers_workon_home_venv_over_dot_venv_dir` in `tests/integration/test_dot_venv.py` that reproduces the exact scenario from the issue:
1. `pipenv install` → creates workon_home venv
2. `mkdir .venv` → user independently creates `.venv` dir  
3. `pipenv --venv` → must still report the workon_home venv
4. `pipenv --rm` → must remove the workon_home venv and leave `.venv` untouched


---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author