### PR TITLE
fix: recreate virtualenv when --python version differs from existing venv

### DIFF
--- a/pipenv/utils/project.py
+++ b/pipenv/utils/project.py
@@ -89,6 +89,35 @@ def ensure_project(
                 "Please ensure Python is installed and available in PATH.",
             )
 
+    # If --python was explicitly specified and the existing virtualenv uses a different
+    # Python version, allow ensure_virtualenv to handle recreation.
+    if (
+        python
+        and project.virtualenv_exists
+        and not system
+        and not project.s.PIPENV_USE_SYSTEM
+    ):
+        try:
+            venv_python_path = project._which("python") or project._which("py")
+            if venv_python_path:
+                venv_python_ver = python_version(str(venv_python_path))
+                if os.path.isabs(python):
+                    # python is an absolute path; get its version for comparison.
+                    requested_ver = python_version(python)
+                else:
+                    # python is a version specifier like "3.12".
+                    requested_ver = python
+                if (
+                    venv_python_ver
+                    and requested_ver
+                    and not _python_version_matches_required(
+                        venv_python_ver, requested_ver
+                    )
+                ):
+                    system_or_exists = False
+        except Exception:
+            pass  # If version detection fails, fall through to default behavior
+
     # Skip virtualenv creation when --system was used.
     if not system_or_exists:
         ensure_virtualenv(

--- a/pipenv/utils/virtualenv.py
+++ b/pipenv/utils/virtualenv.py
@@ -184,15 +184,18 @@ def ensure_virtualenv(project, python=None, site_packages=None, pypi_mirror=None
             else:  # It's a Path object
                 python = python.as_posix()
 
-        err.print("[red]Virtualenv already exists![/red]")
+        err.print(
+            "[bold yellow]Virtualenv already exists but Python version differs. "
+            "Recreating virtualenv...[/bold yellow]"
+        )
         # If VIRTUAL_ENV is set, there is a possibility that we are
         # going to remove the active virtualenv that the user cares
         # about, so confirm first.
         if "VIRTUAL_ENV" in os.environ and not (
-            project.s.PIPENV_YES or Confirm.ask("Use existing virtualenv?", default=True)
+            project.s.PIPENV_YES
+            or Confirm.ask("Recreate existing virtualenv?", default=True)
         ):
             sys.exit(1)
-        err.print("[bold]Using existing virtualenv...[/bold]")
         # Remove the virtualenv.
         cleanup_virtualenv(project, bare=True)
         # Call this function again.

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -782,6 +782,117 @@ class TestPipConfigurationParsing:
 
 
 
+class TestEnsureProjectPythonVersionMismatch:
+    """Tests for ensure_project detecting Python version mismatch (GitHub issue #6141).
+
+    When --python is passed and an existing virtualenv uses a different Python
+    version, ensure_project should call ensure_virtualenv so the virtualenv is
+    recreated with the correct Python version.
+    """
+
+    def _make_project(self, monkeypatch):
+        """Return a minimal mock project object."""
+        project = mock.MagicMock()
+        project.s.PIPENV_USE_SYSTEM = False
+        project.s.PIPENV_YES = False
+        project.virtualenv_exists = True
+        project.pipfile_exists = True
+        # required_python_version=None skips the version warning block
+        project.required_python_version = None
+        # python() must return a str for os.environ assignment
+        project.python.return_value = "/usr/bin/python3"
+        return project
+
+    @pytest.mark.utils
+    def test_python_version_mismatch_triggers_ensure_virtualenv(self, monkeypatch):
+        """When --python 3.12 is given but the venv uses 3.10, ensure_virtualenv
+        should be called so the venv is recreated."""
+        project = self._make_project(monkeypatch)
+        project._which.return_value = "/fake/venv/bin/python"
+
+        monkeypatch.setattr(
+            "pipenv.utils.project.python_version",
+            lambda path: "3.10.5",
+        )
+        monkeypatch.setattr(
+            "pipenv.utils.project.find_a_system_python",
+            lambda x: None,
+        )
+        ensure_virtualenv_calls = []
+        monkeypatch.setattr(
+            "pipenv.utils.project.ensure_virtualenv",
+            lambda *a, **kw: ensure_virtualenv_calls.append((a, kw)),
+        )
+        monkeypatch.setattr(
+            "pipenv.utils.project.ensure_pipfile",
+            lambda *a, **kw: None,
+        )
+
+        from pipenv.utils.project import ensure_project
+
+        ensure_project(project, python="3.12", system=False)
+
+        assert len(ensure_virtualenv_calls) == 1, (
+            "ensure_virtualenv should be called when Python version mismatches"
+        )
+
+    @pytest.mark.utils
+    def test_python_version_match_skips_ensure_virtualenv(self, monkeypatch):
+        """When --python 3.10 is given and the venv already uses 3.10, ensure_virtualenv
+        should NOT be called (no recreation needed)."""
+        project = self._make_project(monkeypatch)
+        project._which.return_value = "/fake/venv/bin/python"
+
+        monkeypatch.setattr(
+            "pipenv.utils.project.python_version",
+            lambda path: "3.10.5",
+        )
+        monkeypatch.setattr(
+            "pipenv.utils.project.find_a_system_python",
+            lambda x: None,
+        )
+        ensure_virtualenv_calls = []
+        monkeypatch.setattr(
+            "pipenv.utils.project.ensure_virtualenv",
+            lambda *a, **kw: ensure_virtualenv_calls.append((a, kw)),
+        )
+        monkeypatch.setattr(
+            "pipenv.utils.project.ensure_pipfile",
+            lambda *a, **kw: None,
+        )
+
+        from pipenv.utils.project import ensure_project
+
+        ensure_project(project, python="3.10", system=False)
+
+        assert len(ensure_virtualenv_calls) == 0, (
+            "ensure_virtualenv should NOT be called when Python version already matches"
+        )
+
+    @pytest.mark.utils
+    def test_no_python_arg_skips_version_check(self, monkeypatch):
+        """When --python is not specified, no version-mismatch check should be done."""
+        project = self._make_project(monkeypatch)
+
+        ensure_virtualenv_calls = []
+        monkeypatch.setattr(
+            "pipenv.utils.project.ensure_virtualenv",
+            lambda *a, **kw: ensure_virtualenv_calls.append((a, kw)),
+        )
+        monkeypatch.setattr(
+            "pipenv.utils.project.ensure_pipfile",
+            lambda *a, **kw: None,
+        )
+
+        from pipenv.utils.project import ensure_project
+
+        ensure_project(project, python=None, system=False)
+
+        assert len(ensure_virtualenv_calls) == 0, (
+            "ensure_virtualenv should not be called when no --python is given and venv exists"
+        )
+
+
 class TestPythonVersionMatchesRequired:
     """Tests for _python_version_matches_required.
 


### PR DESCRIPTION
Fixes #6141

## Summary

When `pipenv install --python X.Y` is called and a virtualenv already exists using a different Python version, pipenv previously skipped `ensure_virtualenv` entirely because `virtualenv_exists=True` caused `system_or_exists=True`, leaving the mismatched venv in place silently with return code 0.

## Root Cause

In `ensure_project()`, the virtualenv existence check short-circuited to `system_or_exists = True` regardless of whether the existing venv's Python version matched what was requested, so `ensure_virtualenv` was never called and no recreation occurred.

## Changes

### pipenv/utils/project.py
- After setting `system_or_exists`, check: if `--python` was explicitly provided AND the existing virtualenv uses a different Python version, reset `system_or_exists = False` so `ensure_virtualenv()` is invoked and handles removal + recreation.
- Absolute-path python arguments have their version extracted via `python_version()`; version-string arguments (e.g. `3.12`) are compared directly via the existing `_python_version_matches_required()` helper.
- Version detection failures are caught silently so default behaviour is preserved.

### pipenv/utils/virtualenv.py
- Fix confusing contradictory messages in `ensure_virtualenv()`'s `elif python` branch: the old messages said 'Virtualenv already exists!' then 'Using existing virtualenv...' immediately before deleting the virtualenv. Replaced with a clear 'Recreating virtualenv...' message and renamed the confirmation prompt to 'Recreate existing virtualenv?'.

### tests/unit/test_utils.py
- Add `TestEnsureProjectPythonVersionMismatch` with three unit tests:
  - version mismatch triggers `ensure_virtualenv`
  - matching version skips `ensure_virtualenv`
  - no `--python` arg skips the version check

## Reproduction (from the issue)

```sh
pipenv install --python 3.12
mv Pipfile Pipfile.bak && pipenv --rm
pipenv install --python 3.10
mv Pipfile.bak Pipfile
pipenv install --python 3.12   # previously: no-op; now: recreates venv as 3.12
pipenv run python -V           # previously: 3.10.x; now: 3.12.x
```

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author