### PR TITLE
Support PIPENV_DEFAULT_CATEGORIES for category-aware commands

### DIFF
--- a/pipenv/cli/command.py
+++ b/pipenv/cli/command.py
@@ -12,6 +12,7 @@ from pipenv.cli.options import (
     general_options,
     install_options,
     lock_options,
+    parse_categories,
     pass_state,
     pypi_mirror_option,
     python_option,
@@ -27,6 +28,7 @@ from pipenv.utils.environment import load_dot_env
 from pipenv.utils.processes import subprocess_run
 from pipenv.vendor.click import (
     Choice,
+    Context,
     argument,
     edit,
     group,
@@ -34,6 +36,7 @@ from pipenv.vendor.click import (
     pass_context,
     version_option,
 )
+from pipenv.vendor.click.core import ParameterSource
 
 with console.capture() as capture:
     console.print("[bold]pipenv[/bold]", end="")
@@ -44,6 +47,26 @@ subcommand_context = CONTEXT_SETTINGS.copy()
 subcommand_context.update({"ignore_unknown_options": True, "allow_extra_args": True})
 subcommand_context_no_interspersion = subcommand_context.copy()
 subcommand_context_no_interspersion["allow_interspersed_args"] = False
+
+
+def _apply_default_categories(ctx: Context, state) -> None:
+    categories_source = ctx.get_parameter_source("categories")
+    dev_source = ctx.get_parameter_source("dev")
+
+    explicit_sources = {
+        ParameterSource.COMMANDLINE,
+        ParameterSource.ENVIRONMENT,
+        ParameterSource.DEFAULT_MAP,
+    }
+    if categories_source in explicit_sources or dev_source in explicit_sources:
+        return
+
+    if state.installstate.categories:
+        return
+
+    default_categories = parse_categories(state.project.s.PIPENV_DEFAULT_CATEGORIES)
+    if default_categories:
+        state.installstate.categories = default_categories
 
 
 @group(cls=PipenvGroup, invoke_without_command=True, context_settings=CONTEXT_SETTINGS)
@@ -200,10 +223,13 @@ def cli(
 @site_packages_option
 @install_options
 @pass_state
-def install(state, **kwargs):
+@pass_context
+def install(ctx, state, **kwargs):
     """Installs provided packages and adds them to Pipfile,
     or (if no packages are given), installs all packages from Pipfile."""
     from pipenv.routines.install import do_install
+
+    _apply_default_categories(ctx, state)
 
     do_install(
         state.project,
@@ -234,9 +260,12 @@ def install(state, **kwargs):
 @install_options
 @upgrade_options
 @pass_state
-def upgrade(state, **kwargs):
+@pass_context
+def upgrade(ctx, state, **kwargs):
     from pipenv.routines.update import upgrade
     from pipenv.utils.project import ensure_project
+
+    _apply_default_categories(ctx, state)
 
     ensure_project(
         state.project,
@@ -284,6 +313,8 @@ def uninstall(ctx, state, all_dev=False, all=False, **kwargs):
     """Uninstalls a provided package and removes it from Pipfile."""
     from pipenv.routines.uninstall import do_uninstall
 
+    _apply_default_categories(ctx, state)
+
     pre = state.installstate.pre
 
     retcode = do_uninstall(
@@ -328,6 +359,8 @@ def lock(ctx, state, **kwargs):
     """Generates Pipfile.lock."""
     from pipenv.routines.lock import do_lock
     from pipenv.utils.project import ensure_project
+
+    _apply_default_categories(ctx, state)
 
     # Ensure that virtualenv is available.
     # Note that we don't pass clear on to ensure_project as it is also
@@ -792,6 +825,8 @@ def update(ctx, state, bare=False, dry_run=None, outdated=False, **kwargs):
     """Runs lock when no packages are specified, or upgrade, and then sync."""
     from pipenv.routines.update import do_update
 
+    _apply_default_categories(ctx, state)
+
     do_update(
         state.project,
         python=state.python,
@@ -889,6 +924,8 @@ def run_open(state, module, *args, **kwargs):
 def sync(ctx, state, bare=False, user=False, unused=False, **kwargs):
     """Installs all packages specified in Pipfile.lock."""
     from pipenv.routines.sync import do_sync
+
+    _apply_default_categories(ctx, state)
 
     retcode = do_sync(
         state.project,

--- a/pipenv/cli/options.py
+++ b/pipenv/cli/options.py
@@ -89,6 +89,12 @@ class LockOptions:
 pass_state = make_pass_decorator(State, ensure=True)
 
 
+def parse_categories(value):
+    if not value:
+        return []
+    return [category for category in re.split(r", *| ", value) if category]
+
+
 def index_option(f):
     def callback(ctx, param, value):
         state = ctx.ensure_object(State)
@@ -164,7 +170,7 @@ def categories_option(f):
     def callback(ctx, param, value):
         state = ctx.ensure_object(State)
         if value:
-            state.installstate.categories += re.split(r", *| ", value)
+            state.installstate.categories += parse_categories(value)
         return value
 
     return option(

--- a/pipenv/environments.py
+++ b/pipenv/environments.py
@@ -126,6 +126,15 @@ class Setting:
         this configuration.
         """
 
+        self.PIPENV_DEFAULT_CATEGORIES = get_from_env(
+            "DEFAULT_CATEGORIES", check_for_negation=False
+        )
+        """Comma- or space-delimited default dependency categories.
+
+        When set, category-aware commands can use these categories when neither
+        ``--categories`` nor ``--dev`` was explicitly provided.
+        """
+
         self.PIPENV_DONT_LOAD_ENV = bool(
             get_from_env("DONT_LOAD_ENV", check_for_negation=False)
         )

--- a/tests/integration/test_install_basic.py
+++ b/tests/integration/test_install_basic.py
@@ -90,6 +90,50 @@ tablib = "*"
         assert c.returncode == 0
 
 
+@pytest.mark.dev
+@pytest.mark.basic
+@pytest.mark.install
+def test_install_uses_default_categories_envvar(pipenv_instance_private_pypi, monkeypatch):
+    monkeypatch.setenv("PIPENV_DEFAULT_CATEGORIES", "packages,dev-packages")
+    with pipenv_instance_private_pypi() as p:
+        with open(p.pipfile_path, "w") as f:
+            contents = """
+[packages]
+six = "*"
+
+[dev-packages]
+tablib = "*"
+            """.strip()
+            f.write(contents)
+        c = p.pipenv("install")
+        assert c.returncode == 0
+        c = p.pipenv('run python -c "import tablib, six"')
+        assert c.returncode == 0
+
+
+@pytest.mark.dev
+@pytest.mark.basic
+@pytest.mark.install
+def test_install_explicit_dev_overrides_default_categories_envvar(
+    pipenv_instance_private_pypi, monkeypatch
+):
+    monkeypatch.setenv("PIPENV_DEFAULT_CATEGORIES", "packages")
+    with pipenv_instance_private_pypi() as p:
+        with open(p.pipfile_path, "w") as f:
+            contents = """
+[packages]
+six = "*"
+
+[dev-packages]
+tablib = "*"
+            """.strip()
+            f.write(contents)
+        c = p.pipenv("install --dev")
+        assert c.returncode == 0
+        c = p.pipenv('run python -c "import tablib, six"')
+        assert c.returncode == 0
+
+
 @pytest.mark.basic
 @pytest.mark.install
 def test_install_with_version_req_default_operator(pipenv_instance_private_pypi):

--- a/tests/integration/test_update.py
+++ b/tests/integration/test_update.py
@@ -1,7 +1,9 @@
 import pytest
 
+from pipenv.cli import cli
 from pipenv.project import Project
 from pipenv.routines.update import get_modified_pipfile_entries
+from pipenv.vendor.click.testing import CliRunner
 
 
 @pytest.mark.parametrize("cmd_option", ["", "--dev"])
@@ -17,6 +19,23 @@ def test_update_outdated_with_outdated_package(pipenv_instance_private_pypi, cmd
         p.pipenv(f"install {cmd_option} {package_name}==1.11")
         c = p.pipenv(f"update {package_name} {cmd_option} --outdated")
         assert f"Package '{package_name}' out-of-date:" in c.stdout
+
+
+@pytest.mark.update
+def test_update_uses_default_categories_envvar(pipenv_instance_private_pypi, monkeypatch):
+    captured = {}
+
+    def fake_do_update(project, **kwargs):
+        captured["categories"] = kwargs["categories"]
+
+    monkeypatch.setattr("pipenv.routines.update.do_update", fake_do_update)
+    monkeypatch.setenv("PIPENV_DEFAULT_CATEGORIES", "packages,dev-packages")
+    with pipenv_instance_private_pypi() as p:
+        cli_runner = CliRunner()
+        result = cli_runner.invoke(cli, ["update", "six"])
+
+    assert result.exit_code == 0, result.output
+    assert captured["categories"] == ["packages", "dev-packages"]
 
 
 def test_get_modified_pipfile_entries_new_package(pipenv_instance_pypi):

--- a/tests/unit/test_environments.py
+++ b/tests/unit/test_environments.py
@@ -103,3 +103,13 @@ def test_pipenv_venv_in_project_set_false(monkeypatch):
 def test_pipenv_venv_in_project_unset(monkeypatch):
     monkeypatch.delenv("PIPENV_VENV_IN_PROJECT", raising=False)
     assert environments.Setting().PIPENV_VENV_IN_PROJECT is None
+
+
+def test_pipenv_default_categories_set(monkeypatch):
+    monkeypatch.setenv("PIPENV_DEFAULT_CATEGORIES", "packages,dev-packages")
+    assert environments.Setting().PIPENV_DEFAULT_CATEGORIES == "packages,dev-packages"
+
+
+def test_pipenv_default_categories_unset(monkeypatch):
+    monkeypatch.delenv("PIPENV_DEFAULT_CATEGORIES", raising=False)
+    assert environments.Setting().PIPENV_DEFAULT_CATEGORIES is None


### PR DESCRIPTION
## Summary

- add `PIPENV_DEFAULT_CATEGORIES` to settings
- use it as the fallback category selection for category-aware commands when neither `--categories` nor `--dev` is explicitly provided
- cover the new behavior with focused env/install/update tests

Fixes #6089.

## Testing

- `pipenv run pytest tests/unit/test_environments.py tests/integration/test_install_basic.py -k 'default_categories or explicit_dev_overrides_default_categories_envvar' tests/integration/test_update.py -k 'default_categories'`

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author