### PR TITLE
fix: improve dependency conflict error messages (#5823)

### DIFF
--- a/pipenv/exceptions.py
+++ b/pipenv/exceptions.py
@@ -335,7 +335,8 @@ class ResolutionFailure(PipenvException):
             "mismatch in your sub-dependencies.\n"
             "You can use [yellow]$ pipenv run pip install <requirement_name>[/yellow] to bypass this mechanism, then run "
             "[yellow]$ pipenv graph[/yellow] to inspect the versions actually installed in the virtualenv.\n"
-            "Hint: try [yellow]$ pipenv lock --pre[/yellow] if it is a pre-release dependency."
+            "Hint: try [yellow]$ pipenv lock --pre[/yellow] if it is a pre-release dependency.\n"
+            "Hint: try [yellow]$ pipenv lock --verbose[/yellow] to see the full dependency resolution output."
         )
         message_str = str(message)
         if "no version found at all" in message_str:

--- a/pipenv/patched/pip/_internal/resolution/resolvelib/factory.py
+++ b/pipenv/patched/pip/_internal/resolution/resolvelib/factory.py
@@ -847,7 +847,7 @@ class Factory:
             + "the dependency conflict\n"
         )
 
-        logger.info(msg)
+        logger.critical(msg)
 
         return DistributionNotFound(
             "ResolutionImpossible: for help visit "

--- a/pipenv/utils/resolver.py
+++ b/pipenv/utils/resolver.py
@@ -98,6 +98,59 @@ class HashCacheMixin:
         return hash_value.decode("utf8")
 
 
+def _format_resolution_error(install_error):
+    """Extract and format conflict details from an InstallationError exception chain.
+
+    When pip raises an InstallationError due to a ResolutionImpossible, the original
+    ResolutionImpossible exception (with its ``causes`` list) is attached as
+    ``install_error.__cause__``. This helper traverses that chain and builds a
+    human-readable summary of the conflicting requirements so users can diagnose
+    the problem without needing to re-run with ``--verbose``.
+    """
+    base_msg = str(install_error)
+
+    # Walk the exception chain to find a ResolutionImpossible cause
+    cause = getattr(install_error, "__cause__", None)
+    resolution_impossible = None
+    while cause is not None:
+        # Import lazily to avoid circular imports at module level
+        try:
+            from pipenv.patched.pip._vendor.resolvelib import ResolutionImpossible
+
+            if isinstance(cause, ResolutionImpossible):
+                resolution_impossible = cause
+                break
+        except ImportError:
+            break
+        cause = getattr(cause, "__cause__", None)
+
+    if resolution_impossible is None or not getattr(
+        resolution_impossible, "causes", None
+    ):
+        return base_msg
+
+    lines = [base_msg, "\nThe conflict is caused by:"]
+    for req_info in resolution_impossible.causes:
+        requirement = getattr(req_info, "requirement", None)
+        parent = getattr(req_info, "parent", None)
+        if requirement is None:
+            continue
+        req_str = (
+            requirement.format_for_error()
+            if hasattr(requirement, "format_for_error")
+            else str(requirement)
+        )
+        if parent is not None:
+            parent_name = getattr(parent, "name", str(parent))
+            parent_version = getattr(parent, "version", "")
+            prefix = f"    {parent_name} {parent_version} depends on "
+        else:
+            prefix = "    The user requested "
+        lines.append(prefix + req_str)
+
+    return "\n".join(lines)
+
+
 class Resolver:
     def __init__(
         self,
@@ -472,7 +525,7 @@ class Resolver:
             try:
                 results = resolver.resolve(self.constraints, check_supported_wheels=False)
             except InstallationError as e:
-                raise ResolutionFailure(message=e)
+                raise ResolutionFailure(message=_format_resolution_error(e)) from e
             else:
                 self.results = set(results.all_requirements)
                 self.resolved_tree.update(self.results)
@@ -877,6 +930,12 @@ def resolve(cmd, st, project):
         st.console.print(environments.PIPENV_SPINNER_FAIL_TEXT.format("Locking Failed!"))
         if not is_verbose:
             err.print(errors)
+            if errors and "ResolutionImpossible" in errors:
+                err.print(
+                    "[cyan]Hint:[/cyan] Re-run with [yellow]--verbose[/yellow] "
+                    "to see the full dependency resolution output and identify "
+                    "which packages are in conflict."
+                )
         raise ResolutionFailure("Failed to lock Pipfile.lock!")
     if is_verbose:
         err.print(out.strip())


### PR DESCRIPTION
Fixes #5823

## Problem

When dependency resolution fails, users see which packages could not be installed but not **why** — i.e. which sub-dependency requirement caused the conflict. The detailed breakdown (`The conflict is caused by: ...`) was only logged at pip's `INFO` level, so it was silently suppressed unless `--verbose` was explicitly passed.

## Changes

### `pipenv/patched/pip/_internal/resolution/resolvelib/factory.py`
- Elevate the `"The conflict is caused by:"` log message from `logger.info` → `logger.critical` so it always appears in stderr output, regardless of verbosity level. This fixes the **subprocess resolver path** (the default) where pipenv cannot intercept the Python exception object directly.

### `pipenv/utils/resolver.py`
- Add `_format_resolution_error()` helper that walks the `InstallationError.__cause__` chain to find a `ResolutionImpossible` instance and formats each conflicting requirement (parent package + required specifier) into a human-readable block.
- `Resolver.resolve()` now passes the `InstallationError` through this helper before wrapping it in `ResolutionFailure`, so the **parent-process resolver path** (`PIPENV_RESOLVER_PARENT_PYTHON=1`) also surfaces full conflict details.

### `pipenv/exceptions.py`
- Add a `--verbose` hint to `ResolutionFailure`'s user-facing extra message so users are always nudged toward the flag that reveals the full resolution log.

## Before / After

**Before:**
```
✘ Locking Failed!
CRITICAL: Cannot install pyspark==3.3.2 because these package versions have conflicting dependencies.
Warning: Your dependencies could not be resolved.
```

**After:**
```
✘ Locking Failed!
CRITICAL: Cannot install pyspark==3.3.2 because these package versions have conflicting dependencies.
CRITICAL:
The conflict is caused by:
    py4j 0.10.9.7 depends on py4j<0.11,>=0.10.9.7
    The user requested py4j==0.10.9.5
Warning: Your dependencies could not be resolved.
Hint: try $ pipenv lock --verbose to see the full dependency resolution output.
```

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author