### PR TITLE
Add `--all` flag to `install` and `sync` to install all Pipfile categories

### DIFF
--- a/pipenv/cli/command.py
+++ b/pipenv/cli/command.py
@@ -229,7 +229,10 @@ def install(ctx, state, **kwargs):
     or (if no packages are given), installs all packages from Pipfile."""
     from pipenv.routines.install import do_install
 
-    _apply_default_categories(ctx, state)
+    if state.installstate.all_categories:
+        state.installstate.categories = state.project.get_package_categories()
+    else:
+        _apply_default_categories(ctx, state)
 
     do_install(
         state.project,
@@ -925,7 +928,10 @@ def sync(ctx, state, bare=False, user=False, unused=False, **kwargs):
     """Installs all packages specified in Pipfile.lock."""
     from pipenv.routines.sync import do_sync
 
-    _apply_default_categories(ctx, state)
+    if state.installstate.all_categories:
+        state.installstate.categories = state.project.get_package_categories()
+    else:
+        _apply_default_categories(ctx, state)
 
     retcode = do_sync(
         state.project,

--- a/pipenv/cli/options.py
+++ b/pipenv/cli/options.py
@@ -79,6 +79,7 @@ class InstallState:
         self.extra_pip_args = []
         self.categories = []
         self.skip_lock = False
+        self.all_categories = False
 
 
 class LockOptions:
@@ -180,6 +181,22 @@ def categories_option(f):
         callback=callback,
         expose_value=True,
         type=click_types.STRING,
+    )(f)
+
+
+def all_categories_option(f):
+    def callback(ctx, param, value):
+        state = ctx.ensure_object(State)
+        state.installstate.all_categories = value
+        return value
+
+    return option(
+        "--all",
+        is_flag=True,
+        default=False,
+        help="Install packages from all categories defined in the Pipfile.",
+        callback=callback,
+        expose_value=False,
     )(f)
 
 
@@ -615,6 +632,7 @@ def sync_options(f):
     f = install_base_options(f)
     f = install_dev_option(f)
     f = categories_option(f)
+    f = all_categories_option(f)
     return f
 
 


### PR DESCRIPTION
## Summary

Closes #6035

Users with multiple custom Pipfile categories previously had to enumerate each one explicitly:

```bash
pipenv install --categories="cat1 cat2 cat3 cat4 cat5"
```

With this change, a single flag installs (or syncs) all categories at once:

```bash
pipenv install --all
pipenv sync --all
```

## Changes

- **`pipenv/cli/options.py`**
  - Added `all_categories` field to `InstallState`
  - Added `all_categories_option()` registering `--all` as an `is_flag` option
  - Wired `all_categories_option` into `sync_options` (covers both `install` and `sync` via `install_options → sync_options`)

- **`pipenv/cli/command.py`**
  - In the `install` and `sync` handlers, when `--all` is passed, categories are resolved to `project.get_package_categories()` which returns `["packages", "dev-packages"]` plus all custom categories, automatically excluding non-package Pipfile sections (`source`, `requires`, `scripts`, `pipenv`)
  - When `--all` is not passed, existing behavior is preserved (including `_apply_default_categories` and `PIPENV_DEFAULT_CATEGORIES`)

## Example Pipfile

```toml
[packages]
requests = "*"

[dev-packages]
pytest = "*"

[docs]
sphinx = "*"

[tests]
pytest-cov = "*"
```

```bash
# Old way
pipenv install --categories="packages dev-packages docs tests"

# New way
pipenv install --all
```

## Testing

All 243 unit tests pass. Integration test coverage for the new flag can be added in `tests/integration/test_install_categories.py`.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author