### PR TITLE
Fix: Clean up orphaned virtualenvs after integration tests

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -213,6 +213,21 @@ class _PipenvInstance:
         return self
 
     def __exit__(self, *args):
+        # Clean up the virtualenv before removing the project directory,
+        # otherwise orphaned virtualenvs accumulate in WORKON_HOME.
+        if self.path:
+            try:
+                c = self.run_command("pipenv --rm")
+                if c.returncode != 0:
+                    # If pipenv --rm fails, try to find and remove the venv directly
+                    c = self.run_command("pipenv --venv")
+                    if c.returncode == 0:
+                        venv_loc = c.stdout.strip()
+                        if venv_loc and os.path.isdir(venv_loc):
+                            shutil.rmtree(venv_loc, ignore_errors=True)
+            except Exception:
+                pass
+
         if self.pipfile_path:
             with contextlib.suppress(OSError):
                 os.remove(self.pipfile_path)


### PR DESCRIPTION
## Problem

The `_PipenvInstance.__exit__` method in `tests/integration/conftest.py` cleans up the temporary project directory but **never removes the virtualenv** created in `WORKON_HOME`. This causes orphaned virtualenvs to accumulate over repeated test runs, bloating:
- `~/.local/share/virtualenvs/` on Linux
- `%USERPROFILE%/.virtualenvs` on Windows

This was reported as an issue — on Windows especially, the `.virtualenvs` directory becomes heavily bloated since temp dirs aren't cleaned on reboot like `/tmp` on Linux.

## Fix

The `__exit__` method now runs `pipenv --rm` before tearing down the project directory. If that fails (e.g., no virtualenv was created for that test), it falls back to locating the venv via `pipenv --venv` and removing it directly. All cleanup errors are silently ignored so test teardown remains robust.

## Testing

This change is backward-compatible — tests that set `PIPENV_VENV_IN_PROJECT` (like `test_dot_venv.py`) will have their in-project `.venv` cleaned up by the existing `TemporaryDirectory` teardown, and `pipenv --rm` handles the rest gracefully.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author