### PR TITLE
Fix: preserve env var references in lockfile during pipenv update

### DIFF
--- a/pipenv/routines/update.py
+++ b/pipenv/routines/update.py
@@ -466,6 +466,7 @@ def _resolve_and_update_lockfile(
         pre=pre,
         allow_global=system,
         pypi_mirror=pypi_mirror,
+        pipfile=requested_packages[pipfile_category],
     )
 
     if not upgrade_lock_data:
@@ -484,6 +485,7 @@ def _resolve_and_update_lockfile(
         pre=pre,
         allow_global=system,
         pypi_mirror=pypi_mirror,
+        pipfile=complete_packages,
     )
 
     # Update lockfile with verified resolution data
@@ -649,6 +651,7 @@ def upgrade(
                 pre=pre,
                 allow_global=system,
                 pypi_mirror=pypi_mirror,
+                pipfile=complete_packages,
             )
             category_resolutions[category] = full_lock_resolution
 


### PR DESCRIPTION
## Summary

Fixes a credential leakage bug where `pipenv update` would expand environment variable references (e.g., `${GITHUB_TOKEN}`) in VCS URLs and write the plaintext values into `Pipfile.lock`.

## Problem

When running `pipenv update --categories="prod-only"` (or similar), VCS dependencies with env var references like:

```toml
[prod-only]
example = { ref = "1.2.3", git = "https://${GITHUB_TOKEN}@github.com/test/example" }
```

would result in the **expanded** (plaintext) token being written to `Pipfile.lock`:

```json
"example": {
    "git": "git+https://ghp_redacted@github.com/test/example",
    "ref": "<SHA>"
}
```

This did **not** happen with `pipenv lock`, only with `pipenv update`.

## Root Cause

The `_resolve_and_update_lockfile()` and `upgrade()` functions in `pipenv/routines/update.py` called `venv_resolve_deps()` **without** passing the `pipfile=` parameter.

Without `pipfile=`, `venv_resolve_deps` falls back to `getattr(project, pipfile_category, {})` which returns `{}` for most categories. This empty dict is passed to `prepare_lockfile()` → `get_locked_dep()`, where the critical `dep.update(pipfile_entry)` never executes because the pipfile section is empty. As a result, the expanded VCS URL (with the actual token value from the resolver subprocess) gets written to the lockfile instead of the env var reference.

The `do_lock` path (`pipenv lock`) already correctly passes `pipfile=packages`, which is why `pipenv lock` preserves env var references but `pipenv update` did not.

## Fix

Pass `pipfile=` to all three `venv_resolve_deps()` calls in the update path, matching the behavior of `do_lock`.

Partially addresses #3751

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author