### PR TITLE
Fix --dry-run help text for update command

### DIFF
--- a/pipenv/cli/command.py
+++ b/pipenv/cli/command.py
@@ -819,7 +819,12 @@ def audit(
 @cli.command(short_help="Runs lock, then sync.", context_settings=CONTEXT_SETTINGS)
 @option("--bare", is_flag=True, default=False, help="Minimal output.")
 @option("--outdated", is_flag=True, default=False, help="List out-of-date dependencies.")
-@option("--dry-run", is_flag=True, default=None, help="List out-of-date dependencies.")
+@option(
+    "--dry-run",
+    is_flag=True,
+    default=None,
+    help="List packages that would be updated without actually updating.",
+)
 @install_options
 @upgrade_options
 @pass_state


### PR DESCRIPTION
Fixes #5725

The `--dry-run` and `--outdated` options on the `update` command had identical help text: *"List out-of-date dependencies."*

Updated `--dry-run` to: *"List packages that would be updated without actually updating."*

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author