### PR TITLE
Fix resolver to use Pipfile python version for marker evaluation

### DIFF
--- a/pipenv/resolver.py
+++ b/pipenv/resolver.py
@@ -478,6 +478,36 @@ def _main(
     )
 
 
+def _apply_python_version_override():
+    """Monkey-patch ``default_environment`` in pip's vendored packaging so that
+    marker evaluation during dependency resolution uses the Python version
+    specified in the Pipfile rather than the running interpreter's version.
+
+    The override is communicated via the ``PIPENV_RESOLVER_PYTHON_VERSION``
+    environment variable (set by the parent ``venv_resolve_deps`` call).
+    See https://github.com/pypa/pipenv/issues/5908
+    """
+    resolver_python = os.environ.get("PIPENV_RESOLVER_PYTHON_VERSION")
+    if not resolver_python:
+        return
+
+    parts = resolver_python.split(".")
+    python_version = ".".join(parts[:2])
+    python_full_version = resolver_python
+
+    import pipenv.patched.pip._vendor.packaging.markers as pip_markers
+
+    _orig = pip_markers.default_environment
+
+    def _patched():
+        env = _orig()
+        env["python_version"] = python_version
+        env["python_full_version"] = python_full_version
+        return env
+
+    pip_markers.default_environment = _patched
+
+
 def main(argv=None):
     parser = get_parser()
     parsed, remaining = parser.parse_known_args(argv)
@@ -486,6 +516,9 @@ def main(argv=None):
     os.environ["PYTHONIOENCODING"] = "utf-8"
     os.environ["PYTHONUNBUFFERED"] = "1"
     parsed = handle_parsed_args(parsed)
+
+    # Apply Python version override from Pipfile before resolving.
+    _apply_python_version_override()
 
     # Validate required arguments
     if not parsed.packages:

--- a/pipenv/utils/resolver.py
+++ b/pipenv/utils/resolver.py
@@ -52,6 +52,77 @@ else:
     import importlib.metadata as importlib_metadata
 
 
+def _get_pipfile_python_override(project):
+    """Determine python_version and python_full_version overrides from the Pipfile.
+
+    When the Pipfile specifies ``python_version = "3.11"`` (major.minor only),
+    the resolver should evaluate markers as if ``python_full_version`` were
+    ``"3.11.0"`` — the lowest patch release for that minor series.  This ensures
+    that dependencies guarded by markers like
+    ``python_full_version <= "3.11.2"`` are *included* in the lock file so that
+    the lock file is portable across all patch releases of that minor version.
+
+    Returns a dict with ``python_version`` and ``python_full_version`` keys
+    suitable for passing as an environment override, or *None* if no override
+    is needed.
+    """
+    if not project.pipfile_exists:
+        return None
+
+    requires = project.parsed_pipfile.get("requires", {})
+    python_full = requires.get("python_full_version")
+    python_ver = requires.get("python_version")
+
+    if python_full and python_full != "*":
+        # Explicit full version — use it directly.
+        parts = python_full.split(".")
+        return {
+            "python_full_version": python_full,
+            "python_version": ".".join(parts[:2]),
+        }
+
+    if python_ver and python_ver != "*":
+        # Only major.minor specified — assume .0 patch for inclusive resolution.
+        return {
+            "python_full_version": f"{python_ver}.0",
+            "python_version": python_ver,
+        }
+
+    return None
+
+
+@contextlib.contextmanager
+def _patched_marker_environment(override):
+    """Context manager that monkey-patches ``default_environment`` in pip's
+    vendored ``packaging.markers`` so that marker evaluation during dependency
+    resolution uses the Pipfile-specified Python version rather than the
+    running interpreter's version.
+
+    Only ``python_version`` and ``python_full_version`` are overridden; all
+    other environment markers (``os_name``, ``sys_platform``, etc.) remain
+    unchanged.
+    """
+    if not override:
+        yield
+        return
+
+    import pipenv.patched.pip._vendor.packaging.markers as pip_markers
+
+    _orig = pip_markers.default_environment
+
+    def _patched_default_environment():
+        env = _orig()
+        env["python_version"] = override["python_version"]
+        env["python_full_version"] = override["python_full_version"]
+        return env
+
+    pip_markers.default_environment = _patched_default_environment
+    try:
+        yield
+    finally:
+        pip_markers.default_environment = _orig
+
+
 def get_package_finder(
     install_cmd=None,
     options=None,
@@ -1033,6 +1104,14 @@ def venv_resolve_deps(
             os.environ.pop("PIPENV_SITE_DIR", None)
         if extra_pip_args:
             os.environ["PIPENV_EXTRA_PIP_ARGS"] = json.dumps(extra_pip_args)
+        # Pass the Pipfile-required Python version to the resolver subprocess
+        # so that marker evaluation uses it instead of the running interpreter's
+        # version.  See https://github.com/pypa/pipenv/issues/5908
+        python_override = _get_pipfile_python_override(project)
+        if python_override:
+            os.environ["PIPENV_RESOLVER_PYTHON_VERSION"] = python_override[
+                "python_full_version"
+            ]
         with console.status(
             f"Locking {pipfile_category}...", spinner=project.s.PIPENV_SPINNER
         ) as st:
@@ -1048,17 +1127,18 @@ def venv_resolve_deps(
             # Useful for debugging and hitting breakpoints in the resolver
             if project.s.PIPENV_RESOLVER_PARENT_PYTHON:
                 try:
-                    results = resolver.resolve_packages(
-                        pre,
-                        clear,
-                        project.s.is_verbose(),
-                        system=allow_global,
-                        write=False,
-                        requirements_dir=req_dir,
-                        packages=deps,
-                        pipfile_category=pipfile_category,
-                        constraints=deps,
-                    )
+                    with _patched_marker_environment(python_override):
+                        results = resolver.resolve_packages(
+                            pre,
+                            clear,
+                            project.s.is_verbose(),
+                            system=allow_global,
+                            write=False,
+                            requirements_dir=req_dir,
+                            packages=deps,
+                            pipfile_category=pipfile_category,
+                            constraints=deps,
+                        )
                     if results:
                         st.console.print(
                             environments.PIPENV_SPINNER_OK_TEXT.format("Success!")
@@ -1185,35 +1265,11 @@ def resolve_deps(
     # First (proper) attempt:
     if not req_dir:
         req_dir = create_tracked_tempdir(prefix="pipenv-", suffix="-requirements")
+    python_override = _get_pipfile_python_override(project)
     with HackedPythonVersion(python_path=project.python(system=allow_global)):
-        try:
-            results, hashes, internal_resolver = actually_resolve_deps(
-                deps,
-                index_lookup,
-                markers_lookup,
-                project,
-                sources,
-                clear,
-                pre,
-                pipfile_category,
-                req_dir=req_dir,
-            )
-        except RuntimeError:
-            # Don't exit here, like usual.
-            results = None
-    # Second (last-resort) attempt:
-    if results is None:
-        with HackedPythonVersion(
-            python_path=project.python(system=allow_global),
-        ):
+        with _patched_marker_environment(python_override):
             try:
-                # Attempt to resolve again, with different Python version information,
-                # particularly for particularly particular packages.
-                (
-                    results,
-                    hashes,
-                    internal_resolver,
-                ) = actually_resolve_deps(
+                results, hashes, internal_resolver = actually_resolve_deps(
                     deps,
                     index_lookup,
                     markers_lookup,
@@ -1225,7 +1281,35 @@ def resolve_deps(
                     req_dir=req_dir,
                 )
             except RuntimeError:
-                sys.exit(1)
+                # Don't exit here, like usual.
+                results = None
+    # Second (last-resort) attempt:
+    if results is None:
+        with HackedPythonVersion(
+            python_path=project.python(system=allow_global),
+        ):
+            with _patched_marker_environment(python_override):
+                try:
+                    # Attempt to resolve again, with different Python version
+                    # information, particularly for particularly particular
+                    # packages.
+                    (
+                        results,
+                        hashes,
+                        internal_resolver,
+                    ) = actually_resolve_deps(
+                        deps,
+                        index_lookup,
+                        markers_lookup,
+                        project,
+                        sources,
+                        clear,
+                        pre,
+                        pipfile_category,
+                        req_dir=req_dir,
+                    )
+                except RuntimeError:
+                    sys.exit(1)
     return results, internal_resolver
 
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1007,3 +1007,113 @@ class TestPipfileVenvInProject:
         pipfile = '[pipenv]\nvenv_in_project = true\n\n[packages]\n\n[dev-packages]\n'
         project = self._make_project_with_pipfile(tmp_path, monkeypatch, pipfile, env_var=False)
         assert project.is_venv_in_project() is False
+
+
+
+class TestPipfilePythonOverride:
+    """Tests for _get_pipfile_python_override and _patched_marker_environment.
+
+    See https://github.com/pypa/pipenv/issues/5908
+    """
+
+    def _make_project(self, monkeypatch, requires):
+        """Create a mock project with the given [requires] section."""
+        proj = mock.MagicMock()
+        proj.pipfile_exists = True
+        proj.parsed_pipfile = {"requires": requires} if requires else {}
+        return proj
+
+    @pytest.mark.utils
+    def test_override_python_version_only(self, monkeypatch):
+        """python_version = '3.11' should produce python_full_version = '3.11.0'."""
+        from pipenv.utils.resolver import _get_pipfile_python_override
+
+        proj = self._make_project(monkeypatch, {"python_version": "3.11"})
+        override = _get_pipfile_python_override(proj)
+        assert override is not None
+        assert override["python_version"] == "3.11"
+        assert override["python_full_version"] == "3.11.0"
+
+    @pytest.mark.utils
+    def test_override_python_full_version(self, monkeypatch):
+        """python_full_version = '3.11.2' should be used as-is."""
+        from pipenv.utils.resolver import _get_pipfile_python_override
+
+        proj = self._make_project(monkeypatch, {"python_full_version": "3.11.2"})
+        override = _get_pipfile_python_override(proj)
+        assert override is not None
+        assert override["python_version"] == "3.11"
+        assert override["python_full_version"] == "3.11.2"
+
+    @pytest.mark.utils
+    def test_override_wildcard_returns_none(self, monkeypatch):
+        """python_version = '*' should not produce an override."""
+        from pipenv.utils.resolver import _get_pipfile_python_override
+
+        proj = self._make_project(monkeypatch, {"python_version": "*"})
+        override = _get_pipfile_python_override(proj)
+        assert override is None
+
+    @pytest.mark.utils
+    def test_override_no_requires_returns_none(self, monkeypatch):
+        """No [requires] section should not produce an override."""
+        from pipenv.utils.resolver import _get_pipfile_python_override
+
+        proj = self._make_project(monkeypatch, None)
+        override = _get_pipfile_python_override(proj)
+        assert override is None
+
+    @pytest.mark.utils
+    def test_override_no_pipfile_returns_none(self, monkeypatch):
+        """No Pipfile should not produce an override."""
+        from pipenv.utils.resolver import _get_pipfile_python_override
+
+        proj = mock.MagicMock()
+        proj.pipfile_exists = False
+        override = _get_pipfile_python_override(proj)
+        assert override is None
+
+    @pytest.mark.utils
+    def test_patched_marker_environment_overrides_python(self):
+        """_patched_marker_environment should override python_version and
+        python_full_version in default_environment."""
+        import pipenv.patched.pip._vendor.packaging.markers as pip_markers
+        from pipenv.utils.resolver import _patched_marker_environment
+
+        override = {"python_version": "3.11", "python_full_version": "3.11.0"}
+        with _patched_marker_environment(override):
+            env = pip_markers.default_environment()
+            assert env["python_version"] == "3.11"
+            assert env["python_full_version"] == "3.11.0"
+
+        # After exit, original values should be restored.
+        env_after = pip_markers.default_environment()
+        assert env_after["python_version"] != "3.11" or sys.version_info[:2] == (3, 11)
+
+    @pytest.mark.utils
+    def test_patched_marker_environment_none_is_noop(self):
+        """_patched_marker_environment(None) should be a no-op."""
+        import pipenv.patched.pip._vendor.packaging.markers as pip_markers
+        from pipenv.utils.resolver import _patched_marker_environment
+
+        env_before = pip_markers.default_environment()
+        with _patched_marker_environment(None):
+            env_during = pip_markers.default_environment()
+        assert env_before["python_full_version"] == env_during["python_full_version"]
+
+    @pytest.mark.utils
+    def test_marker_evaluation_uses_override(self):
+        """Markers should evaluate against the overridden Python version."""
+        from pipenv.patched.pip._vendor.packaging.markers import Marker
+        from pipenv.utils.resolver import _patched_marker_environment
+
+        marker = Marker('python_full_version <= "3.11.2"')
+        override = {"python_version": "3.11", "python_full_version": "3.11.0"}
+        with _patched_marker_environment(override):
+            # 3.11.0 <= 3.11.2 → True
+            assert marker.evaluate() is True
+
+        override_high = {"python_version": "3.11", "python_full_version": "3.11.5"}
+        with _patched_marker_environment(override_high):
+            # 3.11.5 <= 3.11.2 → False
+            assert marker.evaluate() is False


### PR DESCRIPTION
Fixes #5908

## Problem

When the Pipfile specifies `python_version = "3.11"` (major.minor only), the resolver evaluates dependency markers using the running interpreter's full version (e.g. `3.11.5`). This means dependencies guarded by markers like `python_full_version <= "3.11.2"` (such as `async-timeout` required by `redis`) are excluded from the lockfile when locking with Python 3.11.3+, even though they're needed for Python 3.11.0–3.11.2.

## Solution

When the Pipfile specifies only `python_version` (e.g. `"3.11"`), the resolver now evaluates markers as if `python_full_version` were `"3.11.0"` — the lowest patch release for that minor series. This ensures all dependencies that could be needed by *any* patch release of that minor version are included in the lockfile.

### Changes

- **`pipenv/utils/resolver.py`**: Added `_get_pipfile_python_override()` to derive version overrides from the Pipfile, and `_patched_marker_environment()` context manager to monkey-patch `packaging.markers.default_environment` during resolution. Applied the override in both `venv_resolve_deps` (subprocess path) and `resolve_deps` (in-process path).
- **`pipenv/resolver.py`**: Added `_apply_python_version_override()` to read the `PIPENV_RESOLVER_PYTHON_VERSION` env var in the resolver subprocess and apply the same monkey-patch.
- **`tests/unit/test_utils.py`**: Added 8 unit tests covering the override logic, context manager behavior, and marker evaluation with overrides.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author