### PR TITLE
Fix: store --no-binary in Pipfile and re-apply on install (#5362)

### DIFF
--- a/pipenv/project.py
+++ b/pipenv/project.py
@@ -1257,7 +1257,7 @@ class Project:
         self.write_toml(parsed)
 
     def generate_package_pipfile_entry(
-        self, package, pip_line, category=None, index_name=None
+        self, package, pip_line, category=None, index_name=None, no_binary=False
     ):
         """Generate a package entry from pip install line
         given the installreq package and the pip line that generated it.
@@ -1343,16 +1343,22 @@ class Project:
         if package.markers:
             entry["markers"] = str(package.markers)
 
+        # Store no_binary flag so pipenv re-applies --no-binary on future installs
+        if no_binary:
+            entry["no_binary"] = True
+
         if len(entry) == 1 and "version" in entry:
             return name, normalized_name, specifier
         else:
             return name, normalized_name, entry
 
-    def add_package_to_pipfile(self, package, pip_line, dev=False, category=None):
+    def add_package_to_pipfile(
+        self, package, pip_line, dev=False, category=None, no_binary=False
+    ):
         category = category if category else "dev-packages" if dev else "packages"
 
         name, normalized_name, entry = self.generate_package_pipfile_entry(
-            package, pip_line, category=category
+            package, pip_line, category=category, no_binary=no_binary
         )
 
         return self.add_pipfile_entry_to_pipfile(

--- a/pipenv/routines/install.py
+++ b/pipenv/routines/install.py
@@ -27,6 +27,57 @@ from pipenv.utils.requirements import add_index_to_pipfile, import_requirements
 from pipenv.utils.shell import temp_environ
 
 
+def _should_use_no_binary(pkg_name, extra_pip_args):
+    """Return True if --no-binary should be recorded in the Pipfile for pkg_name.
+
+    Checks both ``extra_pip_args`` (e.g. ``["--no-binary", "cartopy"]``) and the
+    ``PIP_NO_BINARY`` environment variable (e.g. ``PIP_NO_BINARY=cartopy``).
+    """
+    if not pkg_name:
+        return False
+
+    # Normalise the name the same way pip does internally so that
+    # "Cartopy", "cartopy", and "cartopy" all match.
+    def _normalise(name):
+        return name.lower().replace("-", "_").replace(".", "_")
+
+    pkg_norm = _normalise(pkg_name)
+
+    def _name_matches(value):
+        """Return True if value is ':all:' or contains pkg_name."""
+        if value.strip() == ":all:":
+            return True
+        return any(
+            _normalise(part.strip()) == pkg_norm
+            for part in value.split(",")
+            if part.strip()
+        )
+
+    # Check extra_pip_args
+    if extra_pip_args:
+        i = 0
+        while i < len(extra_pip_args):
+            arg = extra_pip_args[i]
+            if arg == "--no-binary" and i + 1 < len(extra_pip_args):
+                if _name_matches(extra_pip_args[i + 1]):
+                    return True
+                i += 2
+            elif arg.startswith("--no-binary="):
+                val = arg.split("=", 1)[1]
+                if _name_matches(val):
+                    return True
+                i += 1
+            else:
+                i += 1
+
+    # Check PIP_NO_BINARY environment variable
+    pip_no_binary = os.environ.get("PIP_NO_BINARY", "")
+    if pip_no_binary and _name_matches(pip_no_binary):
+        return True
+
+    return False
+
+
 def handle_new_packages(
     project,
     packages,
@@ -80,16 +131,24 @@ def handle_new_packages(
                     sys.exit(1)
 
                 try:
+                    no_binary = _should_use_no_binary(
+                        pkg_requirement.name if pkg_requirement else None,
+                        extra_pip_args,
+                    )
                     if pipfile_categories:
                         for category in pipfile_categories:
                             added, cat, normalized_name = project.add_package_to_pipfile(
-                                pkg_requirement, pkg_line, dev, category
+                                pkg_requirement,
+                                pkg_line,
+                                dev,
+                                category,
+                                no_binary=no_binary,
                             )
                             if added:
                                 new_packages.append((normalized_name, cat))
                     else:
                         added, cat, normalized_name = project.add_package_to_pipfile(
-                            pkg_requirement, pkg_line, dev
+                            pkg_requirement, pkg_line, dev, no_binary=no_binary
                         )
                         if added:
                             new_packages.append((normalized_name, cat))
@@ -602,6 +661,19 @@ def batch_install(
 ):
     if sequential_deps is None:
         sequential_deps = []
+
+    # Collect packages that require --no-binary from the lockfile / pipfile section.
+    # This ensures that packages installed via "pipenv install" from an existing
+    # Pipfile/lockfile honour the no_binary flag that was recorded at install time.
+    no_binary_packages = [
+        pkg_name
+        for pkg_name, entry in lockfile_section.items()
+        if isinstance(entry, dict) and entry.get("no_binary")
+    ]
+    if no_binary_packages:
+        extra_pip_args = list(extra_pip_args or [])
+        extra_pip_args += ["--no-binary", ",".join(no_binary_packages)]
+
     deps_to_install = deps_list[:]
     deps_to_install.extend(sequential_deps)
     filtered_deps = []

--- a/pipenv/utils/dependencies.py
+++ b/pipenv/utils/dependencies.py
@@ -262,7 +262,9 @@ def _file_url_to_relative_path(file_url, base_dir):
         return file_url
 
 
-def clean_resolved_dep(project, dep, is_top_level=False, current_entry=None):
+def clean_resolved_dep(  # noqa: PLR0912
+    project, dep, is_top_level=False, current_entry=None
+):
     from pipenv.patched.pip._vendor.packaging.requirements import (
         Requirement as PipRequirement,
     )
@@ -353,6 +355,10 @@ def clean_resolved_dep(project, dep, is_top_level=False, current_entry=None):
 
     if dep.get("extras"):
         lockfile["extras"] = sorted(dep["extras"])
+
+    # Preserve the no_binary flag so pipenv can re-apply --no-binary on future installs
+    if dep.get("no_binary"):
+        lockfile["no_binary"] = True
 
     # In case we lock a uri or a file when the user supplied a path
     # remove the uri or file keys from the entry and keep the path

--- a/pipenv/utils/locking.py
+++ b/pipenv/utils/locking.py
@@ -133,6 +133,9 @@ def format_requirement_for_lockfile(
                 entry["editable"] = pipfile_entry["editable"]
             entry.pop("version", None)
             entry.pop("index", None)
+        # Propagate no_binary so batch_install can re-apply --no-binary on sync/install
+        if pipfile_entry.get("no_binary"):
+            entry["no_binary"] = True
 
     entry = translate_markers(entry)
     return name, entry

--- a/tests/unit/test_dependencies.py
+++ b/tests/unit/test_dependencies.py
@@ -456,3 +456,108 @@ class TestCandidateEvaluatorPrereleases:
         assert "0.20b0" not in versions
         assert "0.50b0" in versions
         assert "0.60b0" in versions
+
+
+
+# ---------------------------------------------------------------------------
+# Tests for no_binary handling (GitHub issue #5362)
+# ---------------------------------------------------------------------------
+
+class TestNoBinaryCleanResolvedDep:
+    """Ensure clean_resolved_dep preserves the no_binary flag."""
+
+    def test_no_binary_true_is_preserved(self):
+        """no_binary = True must survive clean_resolved_dep so the lockfile
+        records it and batch_install can re-apply --no-binary."""
+        project = MagicMock()
+        project.project_directory = None
+
+        dep = {
+            "name": "cartopy",
+            "version": "==0.21.0",
+            "no_binary": True,
+        }
+        result = clean_resolved_dep(project, dep)
+
+        assert "cartopy" in result
+        assert result["cartopy"].get("no_binary") is True
+
+    def test_no_binary_false_is_not_written(self):
+        """When no_binary is falsy it should not appear in the lockfile entry."""
+        project = MagicMock()
+        project.project_directory = None
+
+        dep = {
+            "name": "requests",
+            "version": "==2.28.0",
+            "no_binary": False,
+        }
+        result = clean_resolved_dep(project, dep)
+
+        assert "no_binary" not in result.get("requests", {})
+
+    def test_no_binary_absent_is_not_written(self):
+        """When no_binary is absent it should not appear in the lockfile entry."""
+        project = MagicMock()
+        project.project_directory = None
+
+        dep = {
+            "name": "requests",
+            "version": "==2.28.0",
+        }
+        result = clean_resolved_dep(project, dep)
+
+        assert "no_binary" not in result.get("requests", {})
+
+
+class TestShouldUseNoBinary:
+    """Tests for the _should_use_no_binary helper in routines/install.py."""
+
+    def _call(self, pkg_name, extra_pip_args=None, env=None):
+        import os
+        from unittest.mock import patch
+        from pipenv.routines.install import _should_use_no_binary
+
+        env = env or {}
+        with patch.dict(os.environ, env, clear=False):
+            return _should_use_no_binary(pkg_name, extra_pip_args)
+
+    def test_extra_pip_args_space_separated(self):
+        assert self._call("cartopy", ["--no-binary", "cartopy"]) is True
+
+    def test_extra_pip_args_equals_form(self):
+        assert self._call("cartopy", ["--no-binary=cartopy"]) is True
+
+    def test_extra_pip_args_all(self):
+        assert self._call("cartopy", ["--no-binary", ":all:"]) is True
+
+    def test_extra_pip_args_comma_list_matches(self):
+        assert self._call("cartopy", ["--no-binary", "numpy,cartopy,scipy"]) is True
+
+    def test_extra_pip_args_comma_list_no_match(self):
+        assert self._call("cartopy", ["--no-binary", "numpy,scipy"]) is False
+
+    def test_extra_pip_args_different_package(self):
+        assert self._call("cartopy", ["--no-binary", "numpy"]) is False
+
+    def test_pip_no_binary_env_var_matches(self):
+        assert self._call("cartopy", env={"PIP_NO_BINARY": "cartopy"}) is True
+
+    def test_pip_no_binary_env_var_all(self):
+        assert self._call("cartopy", env={"PIP_NO_BINARY": ":all:"}) is True
+
+    def test_pip_no_binary_env_var_no_match(self):
+        assert self._call("cartopy", env={"PIP_NO_BINARY": "numpy"}) is False
+
+    def test_case_insensitive_match(self):
+        assert self._call("Cartopy", ["--no-binary", "cartopy"]) is True
+
+    def test_normalised_name_match(self):
+        # pip normalises dashes/underscores, ensure we do too
+        assert self._call("some-package", ["--no-binary", "some_package"]) is True
+
+    def test_empty_extra_pip_args(self):
+        assert self._call("cartopy", []) is False
+
+    def test_none_pkg_name(self):
+        assert self._call(None, ["--no-binary", "cartopy"]) is False


### PR DESCRIPTION
## Summary

Fixes #5362.

When a package is installed with `--no-binary` (via `--extra-pip-args` or the `PIP_NO_BINARY` environment variable), pipenv now **records `no_binary = true` in the Pipfile** entry for that package and **propagates it to `Pipfile.lock`**. Subsequent `pipenv install` / `pipenv sync` runs re-apply `--no-binary <pkg>` automatically.

### Before

```bash
PIP_NO_BINARY=cartopy pipenv install cartopy
```

`Pipfile` got:
```toml
[packages]
cartopy = "*"
```

On a clean `pipenv install` from this Pipfile, cartopy was installed from a wheel — ignoring the user's intent.

### After

```toml
[packages]
cartopy = {version = "*", no_binary = true}
```

and `Pipfile.lock`:
```json
"cartopy": {"version": "==0.21.0", "no_binary": true, ...}
```

Every `pipenv install` / `pipenv sync` will pass `--no-binary cartopy` to pip.

## Changes

| File | Change |
|---|---|
| `pipenv/project.py` | `generate_package_pipfile_entry` + `add_package_to_pipfile` accept `no_binary=` kwarg and write `no_binary = true` to the Pipfile entry |
| `pipenv/routines/install.py` | New `_should_use_no_binary()` helper inspects `extra_pip_args` and `PIP_NO_BINARY`; `handle_new_packages` uses it; `batch_install` reads `no_binary` from the lockfile section and extends `extra_pip_args` |
| `pipenv/utils/dependencies.py` | `clean_resolved_dep` preserves the `no_binary` key through the resolver |
| `pipenv/utils/locking.py` | `format_requirement_for_lockfile` propagates `no_binary` from the Pipfile entry to the lockfile entry |
| `tests/unit/test_dependencies.py` | 16 new unit tests (3 for `clean_resolved_dep`, 13 for `_should_use_no_binary`) |

## Supported invocation styles

| Style | Detected? |
|---|---|
| `pipenv install pkg --extra-pip-args="--no-binary pkg"` | ✅ |
| `pipenv install pkg --extra-pip-args="--no-binary=pkg"` | ✅ |
| `pipenv install pkg --extra-pip-args="--no-binary :all:"` | ✅ |
| `pipenv install pkg --extra-pip-args="--no-binary pkg1,pkg2"` | ✅ |
| `PIP_NO_BINARY=pkg pipenv install pkg` | ✅ |
| `PIP_NO_BINARY=:all: pipenv install pkg` | ✅ |

Name matching is case-insensitive and normalises dashes/underscores/dots (mirrors pip's own normalisation).

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author