### PR TITLE
Show download progress during locking phase (fixes #5718)

### DIFF
--- a/pipenv/utils/resolver.py
+++ b/pipenv/utils/resolver.py
@@ -951,6 +951,29 @@ def actually_resolve_deps(
     return (results, hashes, resolver)
 
 
+def _is_download_status_line(line: str) -> bool:
+    """Return True if the pip stderr line reports a file download.
+
+    pip emits lines like::
+
+        Downloading torch-2.0.0-cp311-cp311-linux_x86_64.whl (726.8 MB)
+
+    to stderr during the resolution/hash-gathering phase.  We surface these
+    even in non-verbose mode so that users can see *why* pipenv appears to be
+    doing nothing for a long time instead of assuming it is frozen.
+    """
+    stripped = line.strip()
+    # Match "Downloading <name>.whl (X MB)" style messages.
+    if stripped.startswith("Downloading ") and (
+        " MB)" in stripped
+        or " kB)" in stripped
+        or " KB)" in stripped
+        or " GB)" in stripped
+    ):
+        return True
+    return False
+
+
 def resolve(cmd, st, project):
     import threading
 
@@ -974,12 +997,16 @@ def resolve(cmd, st, project):
             stdout_chunks.append(chunk)
 
     def read_stderr():
-        """Read stderr line by line, optionally printing in verbose mode."""
+        """Read stderr line by line, printing verbose output or download notices."""
         for line in iter(c.stderr.readline, ""):
             if line.rstrip():
                 stderr_lines.append(line)
                 if is_verbose:
                     st.console.print(line.rstrip())
+                elif _is_download_status_line(line):
+                    # Always show download progress so users know pipenv is not
+                    # frozen when pip is fetching a large package (issue #5718).
+                    err.print(f"  [dim]{line.rstrip()}[/dim]")
 
     # Start reader threads
     stdout_thread = threading.Thread(target=read_stdout, daemon=True)

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1306,3 +1306,50 @@ class TestFormatRequirementForLockfile:
         # The important thing is that the file URL IS stored.
         assert "file" in entry
 
+
+class TestIsDownloadStatusLine:
+    """Tests for _is_download_status_line (issue #5718).
+
+    pip emits download progress lines to stderr during dependency resolution.
+    These should always be shown to users so they know pipenv isn't frozen
+    while a large package is being fetched.
+    """
+
+    @pytest.mark.utils
+    @pytest.mark.parametrize(
+        "line",
+        [
+            "  Downloading torch-2.0.0-cp311-cp311-linux_x86_64.whl (726.8 MB)",
+            "Downloading torch-2.0.0-cp311-cp311-linux_x86_64.whl (726.8 MB)",
+            "  Downloading requests-2.31.0-py3-none-any.whl (62.6 kB)",
+            "  Downloading numpy-1.25.0-cp311-cp311-manylinux_2_17_x86_64.whl (17.3 MB)",
+            "  Downloading model-2.0.tar.gz (1.2 GB)",
+            "  Downloading small_pkg-0.1.0-py3-none-any.whl (512 KB)",
+        ],
+    )
+    def test_recognises_download_lines(self, line):
+        from pipenv.utils.resolver import _is_download_status_line
+
+        assert _is_download_status_line(line) is True
+
+    @pytest.mark.utils
+    @pytest.mark.parametrize(
+        "line",
+        [
+            # Resolution / collection messages – not downloads
+            "Collecting torch",
+            "  Using cached torch-2.0.0-cp311-cp311-linux_x86_64.whl (726.8 MB)",
+            "Downloading",  # bare keyword, no size
+            "Downloading torch-2.0.0.whl",  # no parenthesised size
+            "Successfully installed torch-2.0.0",
+            "Building wheels for collected packages: torch",
+            "",
+            "   ",
+        ],
+    )
+    def test_ignores_non_download_lines(self, line):
+        from pipenv.utils.resolver import _is_download_status_line
+
+        assert _is_download_status_line(line) is False
+
+


### PR DESCRIPTION
## Summary

Addresses #5718 — users installing large packages (e.g. `torch`) saw the `Locking [packages] dependencies...` / `Resolving dependencies...` messages then nothing for many minutes, with 0% CPU, and reasonably concluded that pipenv had frozen.

The root cause is that pip writes `Downloading <pkg>.whl (X MB)` to stderr during the resolution/hash-gathering phase, but those lines were only forwarded to the terminal in `--verbose` mode.

## What changed

**`pipenv/utils/resolver.py`**

- Added `_is_download_status_line(line)` — a small helper that returns `True` for lines that match pip's download-progress format (`Downloading <name> (X MB/kB/KB/GB)`).
- In the `read_stderr` inner function of `resolve()`, download-matching lines are now printed in dim style even in non-verbose mode, so users can see activity without the full firehose of `--verbose`.

Cached-wheel hits (`Using cached ...`) and collection headers (`Collecting ...`) are intentionally excluded to keep the output tidy.

**`tests/unit/test_utils.py`**

- Added `TestIsDownloadStatusLine` with 14 parametrized cases covering all supported size units and the false-positive patterns that should remain silent.

## Example output (non-verbose)

```
Locking [packages] dependencies...
Building requirements...
Resolving dependencies...
  Downloading torch-2.0.0-cp311-cp311-linux_x86_64.whl (726.8 MB)
✔ Success!
```

Users still get the full picture with `--verbose`; this change just surfaces the one line that matters most when a download is the reason for the wait.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author