### PR TITLE
Add retry logic for transient resolution failures

### DIFF
--- a/pipenv/utils/resolver.py
+++ b/pipenv/utils/resolver.py
@@ -974,12 +974,27 @@ def _is_download_status_line(line: str) -> bool:
     return False
 
 
-def resolve(cmd, st, project):
+def _is_transient_resolution_failure(errors: str) -> bool:
+    """Return True if the resolution failure looks transient and worth retrying.
+
+    Genuine dependency conflicts (ResolutionImpossible) will not benefit from
+    a retry, but network timeouts, HTTP errors, and other transient issues may
+    resolve on a subsequent attempt.  When the error output does not contain a
+    known non-retryable marker we assume the failure *is* transient (e.g. the
+    resolver subprocess crashed or was killed without producing a clear error).
+    """
+    non_retryable_markers = [
+        "ResolutionImpossible",
+    ]
+    return not any(marker in errors for marker in non_retryable_markers)
+
+
+def _run_resolve_subprocess(cmd, st, is_verbose):
+    """Run the resolver subprocess once and return a CompletedProcess."""
     import threading
 
     # cmd is a pre-tokenized list (not a TOML sequence); pass it directly.
     c = subprocess_run([str(x) for x in cmd], block=False, env=os.environ.copy())
-    is_verbose = project.s.is_verbose()
 
     # Use threading to read from both stdout and stderr concurrently.
     # This prevents deadlocks when the subprocess writes a lot of data to stdout,
@@ -1024,20 +1039,44 @@ def resolve(cmd, st, project):
     out = "".join(stdout_chunks)
     errors = "".join(stderr_lines)
 
-    if returncode != 0:
+    return subprocess.CompletedProcess(c.args, returncode, out, errors)
+
+
+def resolve(cmd, st, project):
+    max_retries = project.s.PIPENV_MAX_RETRIES
+    is_verbose = project.s.is_verbose()
+
+    for attempt in range(1 + max_retries):
+        c = _run_resolve_subprocess(cmd, st, is_verbose)
+
+        if c.returncode == 0:
+            if is_verbose:
+                err.print(c.stdout.strip())
+            return c
+
+        # Resolution failed — decide whether to retry
+        if attempt < max_retries and _is_transient_resolution_failure(c.stderr):
+            delay = 2 ** (attempt + 1)  # 2s, 4s, 8s, ...
+            err.print(
+                f"[yellow]Locking failed (attempt {attempt + 1}/{1 + max_retries}), "
+                f"retrying in {delay}s...[/yellow]"
+            )
+            if is_verbose and c.stderr:
+                err.print(c.stderr)
+            time.sleep(delay)
+            continue
+
+        # Final failure — no more retries
         st.console.print(environments.PIPENV_SPINNER_FAIL_TEXT.format("Locking Failed!"))
         if not is_verbose:
-            err.print(errors)
-            if errors and "ResolutionImpossible" in errors:
+            err.print(c.stderr)
+            if c.stderr and "ResolutionImpossible" in c.stderr:
                 err.print(
                     "[cyan]Hint:[/cyan] Re-run with [yellow]--verbose[/yellow] "
                     "to see the full dependency resolution output and identify "
                     "which packages are in conflict."
                 )
         raise ResolutionFailure("Failed to lock Pipfile.lock!")
-    if is_verbose:
-        err.print(out.strip())
-    return subprocess.CompletedProcess(c.args, returncode, out, errors)
 
 
 def venv_resolve_deps(

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1353,3 +1353,41 @@ class TestIsDownloadStatusLine:
         assert _is_download_status_line(line) is False
 
 
+class TestIsTransientResolutionFailure:
+    """Tests for _is_transient_resolution_failure.
+
+    The function decides whether a failed resolution subprocess should be
+    retried.  Genuine dependency conflicts (ResolutionImpossible) should
+    NOT be retried, while network errors and other transient failures should.
+    """
+
+    @pytest.mark.utils
+    @pytest.mark.parametrize(
+        "errors",
+        [
+            "ConnectionError: connection refused",
+            "ReadTimeoutError: timed out",
+            "SSLError: certificate verify failed",
+            "pip._vendor.urllib3.exceptions.NewConnectionError",
+            "requests.exceptions.ConnectionError",
+            "",  # empty stderr — resolver crashed without output
+            "Some unknown error occurred",
+        ],
+    )
+    def test_transient_failures_are_retryable(self, errors):
+        from pipenv.utils.resolver import _is_transient_resolution_failure
+
+        assert _is_transient_resolution_failure(errors) is True
+
+    @pytest.mark.utils
+    @pytest.mark.parametrize(
+        "errors",
+        [
+            "ResolutionImpossible: cannot resolve foo>=2.0 and bar<1.0",
+            "ERROR: ResolutionImpossible\nsome extra context",
+        ],
+    )
+    def test_resolution_impossible_is_not_retryable(self, errors):
+        from pipenv.utils.resolver import _is_transient_resolution_failure
+
+        assert _is_transient_resolution_failure(errors) is False


### PR DESCRIPTION
## Summary

The `resolve()` function now retries the resolver subprocess on transient failures, using the existing `PIPENV_MAX_RETRIES` setting (defaults to 1 in CI, 0 otherwise).

## Problem

CI benchmark runs (and user `pipenv lock` / `pipenv install` commands) intermittently fail with "Locking Failed!" due to transient network issues — connection resets, timeouts, HTTP 503s, etc. — when resolving large dependency sets against PyPI. These failures are not genuine dependency conflicts, just bad luck with network conditions.

## Solution

- **`_is_transient_resolution_failure()`** — determines whether a failure is worth retrying. `ResolutionImpossible` (genuine dependency conflict) is never retried. Everything else is assumed transient.
- **`_run_resolve_subprocess()`** — extracted from `resolve()` to run the resolver subprocess once and return a `CompletedProcess`. This also fixes ruff B023 warnings by keeping closures out of the retry loop.
- **`resolve()`** — now loops up to `1 + PIPENV_MAX_RETRIES` times with exponential backoff (2s, 4s, 8s…) on transient failures.

## Behavior

| Environment | `PIPENV_MAX_RETRIES` default | Total attempts |
|---|---|---|
| CI (`CI=1`) | 1 | 2 |
| Local | 0 | 1 (no change) |
| Custom | user-set value | 1 + value |

Users can override with `PIPENV_MAX_RETRIES=N` for more retries if needed.

## Tests

Added `TestIsTransientResolutionFailure` with 9 test cases covering:
- Network errors (ConnectionError, ReadTimeoutError, SSLError, etc.) → retryable
- Empty stderr (resolver crashed) → retryable
- Unknown errors → retryable
- `ResolutionImpossible` → NOT retryable

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author