### PR TITLE
fix: always restore PTY echo via try/finally in fork_compat

### DIFF
--- a/pipenv/shells.py
+++ b/pipenv/shells.py
@@ -205,21 +205,23 @@ class Shell:
         except Exception:
             pass  # setecho may not be supported on all platforms
 
-        c.sendline(_get_activate_script(self.cmd, venv))
-
-        # Wrap the deactivate function to also unset PIPENV_ACTIVE
-        deactivate_wrapper = _get_deactivate_wrapper_script(self.cmd)
-        if deactivate_wrapper:
-            c.sendline(deactivate_wrapper)
-
-        if args:
-            c.sendline(" ".join(args))
-
-        # Re-enable echo so the interactive session behaves normally.
         try:
-            c.setecho(True)
-        except Exception:
-            pass
+            c.sendline(_get_activate_script(self.cmd, venv))
+
+            # Wrap the deactivate function to also unset PIPENV_ACTIVE
+            deactivate_wrapper = _get_deactivate_wrapper_script(self.cmd)
+            if deactivate_wrapper:
+                c.sendline(deactivate_wrapper)
+
+            if args:
+                c.sendline(" ".join(args))
+        finally:
+            # Re-enable echo so the interactive session behaves normally,
+            # even if an exception was raised while sending setup commands.
+            try:
+                c.setecho(True)
+            except Exception:
+                pass
 
         # Handler for terminal resizing events
         # Must be defined here to have the shell process in its context, since


### PR DESCRIPTION
## Summary

Followup fix for #6531.

As noted by @smee30 in a commit comment, the fix in #6531 introduced a regression: if any `sendline()` call raised an exception after `setecho(False)`, PTY echo would remain disabled permanently, leaving the user's terminal broken (no input echoed).

## Root Cause

The `setecho(True)` restore call was placed sequentially after the `sendline` calls with no guarantee of execution on failure.

## Fix

Wrap all setup `sendline` calls in a `try/finally` block so `setecho(True)` is **always** executed regardless of exceptions.

```python
try:
    c.setecho(False)
except Exception:
    pass

try:
    c.sendline(_get_activate_script(self.cmd, venv))
    ...
finally:
    try:
        c.setecho(True)
    except Exception:
        pass
```

## References

- Fixes regression introduced in #6531
- Reported by @smee30

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author