### PR TITLE
fix: restore --pre flag and allow_prereleases behavior with pip 26+ (#6563)

### DIFF
--- a/pipenv/utils/resolver.py
+++ b/pipenv/utils/resolver.py
@@ -14,6 +14,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 from pipenv import environments, resolver
 from pipenv.exceptions import ResolutionFailure
 from pipenv.patched.pip._internal.cache import WheelCache
+from pipenv.patched.pip._internal.cli.cmdoptions import check_release_control_exclusive
 from pipenv.patched.pip._internal.commands.install import InstallCommand
 from pipenv.patched.pip._internal.exceptions import InstallationError
 from pipenv.patched.pip._internal.models.target_python import TargetPython
@@ -429,6 +430,14 @@ class Resolver:
         pip_options.pre = self.pre or self.project.settings.get(
             "allow_prereleases", False
         )
+        # In pip 26+, setting options.pre=True is no longer sufficient to
+        # enable pre-release resolution. pip's PackageFinder uses
+        # release_control.all_releases to determine whether pre-releases are
+        # allowed, and check_release_control_exclusive() is what transforms
+        # options.pre=True into release_control.all_releases={":all:"}.
+        # pip's own commands (install, download, lock) call this in run(),
+        # but pipenv bypasses those entry points, so we must call it here.
+        check_release_control_exclusive(pip_options)
         return pip_options
 
     @property  # Remove cached_property to prevent stale sessions and authentication issues


### PR DESCRIPTION
## Summary

Fixes #6563 — `--pre` flag ignored since v2026.1.0.

## Root Cause

In **pip 26.0.1** (vendored in v2026.1.0), the `--pre` flag's internal mechanism changed. `PackageFinder` no longer reads `options.pre` directly to decide whether to include pre-releases. Instead it reads `release_control.all_releases`, which is only populated when `check_release_control_exclusive()` is called.

Pip's own commands (`install`, `download`, `lock`, etc.) call this function at the start of their `run()` methods. However, pipenv's `Resolver` bypasses those entry points and constructs pip options directly via `Resolver.pip_options`. As a result, `release_control.all_releases` was never populated — pre-releases were silently excluded even when `--pre` was passed or `allow_prereleases = true` was set in the Pipfile.

## Fix

Import and call `check_release_control_exclusive(pip_options)` at the end of `Resolver.pip_options`. This transforms `options.pre = True` into `release_control.all_releases = {":all:"}`, which `PackageFinder` correctly reads to enable pre-release resolution.

This fixes both:
- `pipenv lock --pre` (CLI flag)
- `allow_prereleases = true` in the `[pipenv]` Pipfile section

## Testing

All 41 unit tests in `tests/unit/test_dependencies.py` (which cover `CandidateEvaluator` with `ReleaseControl`) pass.

The existing integration test `test_lock_with_prereleases` (which uses `allow_prereleases = true`) continues to pass.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author