### PR TITLE
Add `pipenv remove` command, deprecate `--rm` option

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -20,7 +20,7 @@ These options can be used with any Pipenv command:
 | `--venv` | Output virtualenv information |
 | `--py` | Output Python interpreter information |
 | `--envs` | Output environment variable options |
-| `--rm` | Remove the virtualenv |
+| `--rm` | Remove the virtualenv (deprecated: use `pipenv remove` instead) |
 | `--bare` | Minimal output |
 | `--man` | Display manpage |
 | `--support` | Output diagnostic information for GitHub issues |
@@ -545,6 +545,7 @@ Understanding how Pipenv commands relate to each other can help you use them mor
 - `upgrade`: Updates Pipfile.lock for specific packages without installing them
 - `uninstall`: Removes packages from virtualenv and Pipfile
 - `clean`: Removes packages from virtualenv that aren't in Pipfile.lock
+- `remove`: Deletes the entire virtualenv for the current project
 
 ## Best Practices
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -16,6 +16,7 @@ This document provides a comprehensive reference for all Pipenv commands, includ
 | `shell` | Spawn a shell within the virtual environment |
 | `run` | Run a command within the virtual environment |
 | `graph` | Display dependency graph information |
+| `remove` | Remove the virtualenv for the current project |
 | `clean` | Remove packages not specified in Pipfile.lock |
 | `verify` | Verify the Pipfile.lock hash is up-to-date |
 | `requirements` | Generate a requirements.txt from Pipfile.lock |
@@ -457,6 +458,29 @@ $ pipenv requirements --categories="tests,docs"
 | `--hash` | Include package hashes |
 | `--exclude-markers` | Exclude PEP 508 markers |
 | `--categories` | Include packages from specified categories |
+
+## remove
+
+The `remove` command deletes the virtualenv associated with the current project.
+
+### Basic Usage
+
+```bash
+$ pipenv remove
+```
+
+### Examples
+
+Remove the current project's virtualenv:
+
+```bash
+$ pipenv remove
+Removing virtualenv (/home/user/.local/share/virtualenvs/myproject-abc123)...
+```
+
+You can then recreate it with `pipenv install`.
+
+> **Note**: The legacy `pipenv --rm` flag performs the same action but is deprecated and will be removed in a future release. Use `pipenv remove` instead.
 
 ## clean
 

--- a/pipenv/cli/command.py
+++ b/pipenv/cli/command.py
@@ -78,7 +78,12 @@ def _apply_default_categories(ctx: Context, state) -> None:
 @option(
     "--envs", is_flag=True, default=False, help="Output Environment Variable options."
 )
-@option("--rm", is_flag=True, default=False, help="Remove the virtualenv.")
+@option(
+    "--rm",
+    is_flag=True,
+    default=False,
+    help="Remove the virtualenv. [deprecated: use `pipenv remove` instead]",
+)
 @option("--bare", is_flag=True, default=False, help="Minimal output.")
 @option("--man", is_flag=True, default=False, help="Display manpage.")
 @option(
@@ -112,7 +117,7 @@ def cli(
     from pipenv.routines.clear import do_clear
     from pipenv.utils.display import format_help
     from pipenv.utils.project import ensure_project
-    from pipenv.utils.virtualenv import cleanup_virtualenv, do_where, warn_in_virtualenv
+    from pipenv.utils.virtualenv import do_where, warn_in_virtualenv
 
     if "PIPENV_COLORBLIND" in os.environ:
         err.print(
@@ -174,32 +179,13 @@ def cli(
             else:
                 print(state.project.virtualenv_location)
                 return 0
-        # --rm was passed...
+        # --rm was passed (deprecated: use `pipenv remove` instead)...
         elif rm:
-            # Abort if --system (or running in a virtualenv).
-            if state.project.s.PIPENV_USE_SYSTEM or environments.is_in_virtualenv():
-                console.print(
-                    "You are attempting to remove a virtualenv that "
-                    "Pipenv did not create. Aborting.",
-                    style="red",
-                )
-                ctx.abort()
-            if state.project.virtualenv_exists:
-                loc = state.project.virtualenv_location
-                console.print(
-                    f"[bold]Removing virtualenv[/bold] ([green]{loc}[green])..."
-                )
-
-                with console.status("Running..."):
-                    # Remove the virtualenv.
-                    cleanup_virtualenv(state.project, bare=True)
-                return 0
-            else:
-                err.print(
-                    "No virtualenv has been created for this project yet!",
-                    style="red bold",
-                )
-                ctx.abort()
+            err.print(
+                "Warning: [yellow]--rm[/yellow] is deprecated and will be removed in a future release. "
+                "Use [green]`pipenv remove`[/green] instead.",
+            )
+            ctx.invoke(remove)
     # --python was passed...
     if (state.python) or state.site_packages:
         ensure_project(
@@ -252,6 +238,38 @@ def install(ctx, state, **kwargs):
         pipfile_categories=state.installstate.categories,
         skip_lock=state.installstate.skip_lock,
     )
+
+
+@cli.command(
+    short_help="Removes the virtualenv for the current project.",
+    context_settings=CONTEXT_SETTINGS,
+)
+@pass_state
+@pass_context
+def remove(ctx, state):
+    """Removes the virtualenv for the current project."""
+    from pipenv.utils.virtualenv import cleanup_virtualenv
+
+    # Abort if --system (or running in a virtualenv).
+    if state.project.s.PIPENV_USE_SYSTEM or environments.is_in_virtualenv():
+        console.print(
+            "You are attempting to remove a virtualenv that "
+            "Pipenv did not create. Aborting.",
+            style="red",
+        )
+        ctx.abort()
+    if state.project.virtualenv_exists:
+        loc = state.project.virtualenv_location
+        console.print(f"[bold]Removing virtualenv[/bold] ([green]{loc}[/green])...")
+        with console.status("Running..."):
+            cleanup_virtualenv(state.project, bare=True)
+        return 0
+    else:
+        err.print(
+            "No virtualenv has been created for this project yet!",
+            style="red bold",
+        )
+        ctx.abort()
 
 
 @cli.command(

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -67,7 +67,24 @@ def test_pipenv_support(pipenv_instance_pypi):
 
 
 @pytest.mark.cli
-def test_pipenv_rm(pipenv_instance_pypi):
+def test_pipenv_remove(pipenv_instance_pypi):
+    with pipenv_instance_pypi() as p:
+        c = p.pipenv("--python python")
+        assert c.returncode == 0
+        c = p.pipenv("--venv")
+        assert c.returncode == 0
+        venv_path = c.stdout.strip()
+        assert os.path.isdir(venv_path)
+
+        c = p.pipenv("remove")
+        assert c.returncode == 0
+        assert c.stdout
+        assert not os.path.isdir(venv_path)
+
+
+@pytest.mark.cli
+def test_pipenv_rm_deprecated(pipenv_instance_pypi):
+    """--rm still works but emits a deprecation warning."""
     with pipenv_instance_pypi() as p:
         c = p.pipenv("--python python")
         assert c.returncode == 0
@@ -78,7 +95,7 @@ def test_pipenv_rm(pipenv_instance_pypi):
 
         c = p.pipenv("--rm")
         assert c.returncode == 0
-        assert c.stdout
+        assert "deprecated" in c.stderr.lower()
         assert not os.path.isdir(venv_path)
 
 


### PR DESCRIPTION
Closes #2911

## Summary

This promotes the virtualenv-removal functionality from the top-level `--rm` flag to a proper `pipenv remove` subcommand, as requested in #2911.

## Changes

### `pipenv/cli/command.py`
- Added `pipenv remove` as a new subcommand that removes the virtualenv for the current project.
- `--rm` still works but now emits a deprecation warning and delegates to the new `remove` command via `ctx.invoke(remove)`.
- Updated `--rm` help text to indicate it is deprecated.

### `tests/integration/test_cli.py`
- Renamed `test_pipenv_rm` → `test_pipenv_remove` to test the new `pipenv remove` command.
- Added `test_pipenv_rm_deprecated` to verify `--rm` still works and emits a deprecation warning in stderr.

### `docs/commands.md`
- Added `remove` to the Core Commands Overview table.
- Added a full `## remove` section with usage examples and a note about the deprecated `--rm` flag.

### `docs/cli.md`
- Updated `--rm` table entry to note its deprecated status.
- Added `remove` to the command relationship overview list.

## Behaviour

```
# New command (preferred)
$ pipenv remove
Removing virtualenv (/home/user/.local/share/virtualenvs/myproject-abc123)...

# Legacy flag (still works, but warns)
$ pipenv --rm
Warning: --rm is deprecated and will be removed in a future release. Use `pipenv remove` instead.
Removing virtualenv (/home/user/.local/share/virtualenvs/myproject-abc123)...
```

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author