### PR TITLE
Run virtualenv from a empty directory to prevent current directory from polluting PYTHONPATH

### DIFF
--- a/news/6569.bugfix.rst
+++ b/news/6569.bugfix.rst
@@ -1,0 +1,1 @@
+Run python -m virtualenv from empty directory to prevent PYTHONPATH pollution. Fixes #6568.

--- a/pipenv/utils/virtualenv.py
+++ b/pipenv/utils/virtualenv.py
@@ -10,6 +10,7 @@ from pipenv import environments, exceptions
 from pipenv.utils import Confirm, console, err
 from pipenv.utils.dependencies import python_version
 from pipenv.utils.environment import ensure_environment
+from pipenv.utils.fileutils import create_tracked_tempdir
 from pipenv.utils.processes import subprocess_run
 from pipenv.utils.shell import find_python, shorten_path
 
@@ -77,7 +78,13 @@ def do_create_virtualenv(project, python=None, site_packages=None, pypi_mirror=N
         "Creating virtual environment...", spinner=project.s.PIPENV_SPINNER
     ):
         cmd = _create_virtualenv_cmd(project, python, site_packages=site_packages)
-        c = subprocess_run(cmd, env=pip_config)
+
+        # Issue: https://github.com/pypa/pipenv/issues/6568
+        # Run virtualenv from an empty temporary directory to prevent PYTHONPATH pollution.
+        # Once we drop support for python3.10 we can add a -P to the `python -m virtualenv` call to avoid this workaround
+        temp_dir = create_tracked_tempdir()
+        c = subprocess_run(cmd, env=pip_config, cwd=temp_dir)
+
         err.print(f"[cyan]{c.stdout}[/cyan]")
         if c.returncode != 0:
             error = (


### PR DESCRIPTION
### The issue

What is the thing you want to fix? Is it associated with an issue on GitHub? Please mention it.

Issue: https://github.com/pypa/pipenv/issues/6568

TLDR: If a user has a file in the current directory that shadows a module used by virtualenv it will make the virtualenv creation fail

### The fix

How does this pull request fix your problem? Did you consider any alternatives? Why is this the *best* solution, in your opinion?

When calling a module with 'python -m <module>' python's default behavior is to prepend the current directory to the PYTHONPATH which if there is a file with the same name as library/module use by the module we are trying to invoke, it will cause an error. To avoid this issue python has a `-P` flag that prevent this behavior.

```
-P     : don't prepend a potentially unsafe path to sys.path; also PYTHONSAFEPATH
```


 Example of the solution working
```bash
[flavio@Mac ~]
$ mkdir -p /tmp/foo

[flavio@Mac ~]
$ cd /tmp/foo

[flavio@Mac /tmp/foo]
$ echo 'import requests' > secrets.py

[flavio@Mac /tmp/foo]
$ pipenv install certifi
Creating a virtualenv for this project
Pipfile: /private/tmp/foo/Pipfile
Using /Users/flavio/Applications/brew/bin/python33.14.2 to create virtualenv...
⠦ Creating virtual environment...created virtual environment CPython3.14.2.final.0-64-arm64 in 488ms
  creator CPython3Posix(dest=/Users/flavio/.virtualenvs/foo-mzLZXOua, clear=False, no_vcs_ignore=False,
global=False)
  seeder FromAppData(download=False, pip=bundle, via=copy,
app_data_dir=/Users/flavio/Library/Caches/virtualenv)
    added seed packages: pip==26.0.1
  activators
BashActivator,CShellActivator,FishActivator,NushellActivator,PowerShellActivator,PythonActivator

✔ Successfully created virtual environment!
Virtualenv location: /Users/flavio/.virtualenvs/foo-mzLZXOua
Creating a Pipfile for this project...
Pipfile.lock not found, creating...
Locking  dependencies...
Locking  dependencies...
Updated Pipfile.lock (be43225d7d56471fd9b60269c82252cc19448eb3578abebecdcd914e2213171e)!
To activate this project's virtualenv, run pipenv shell.
Alternatively, run a command inside the virtualenv with pipenv run.
Installing certifi...
✔ Installation Succeeded
To activate this project's virtualenv, run pipenv shell.
Alternatively, run a command inside the virtualenv with pipenv run.
Installing dependencies from Pipfile.lock (13171e)...
All dependencies are now up-to-date!
Upgrading certifi in  dependencies.
Building requirements...
Resolving dependencies...
✔ Success!
To activate this project's virtualenv, run pipenv shell.
Alternatively, run a command inside the virtualenv with pipenv run.
Installing dependencies from Pipfile.lock (c5a106)...
All dependencies are now up-to-date!
Installing dependencies from Pipfile.lock (c5a106)...
```


### The checklist

* [x] Associated issue
* [x] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.

