### PR TITLE
fix: preserve transitive deps of pinned packages during partial updates (closes #6575)

### DIFF
--- a/pipenv/routines/update.py
+++ b/pipenv/routines/update.py
@@ -500,7 +500,12 @@ def _resolve_and_update_lockfile(
 
 
 def _clean_unused_dependencies(
-    project, lockfile, category, full_lock_resolution, original_lockfile
+    project,
+    lockfile,
+    category,
+    full_lock_resolution,
+    original_lockfile,
+    reverse_deps=None,
 ):
     """
     Remove dependencies that are no longer needed after an upgrade.
@@ -511,6 +516,10 @@ def _clean_unused_dependencies(
         category: The category to clean (e.g., 'default', 'develop')
         full_lock_resolution: The complete resolution of dependencies
         original_lockfile: The original lockfile before the upgrade
+        reverse_deps: Optional mapping of package -> set of (requiring_package, version_constraint)
+            built from the installed environment.  When provided it is used to
+            detect transitive dependencies that are still required by packages
+            whose pinned version was NOT changed by this upgrade.
     """
     if category not in lockfile or category not in original_lockfile:
         return
@@ -533,6 +542,37 @@ def _clean_unused_dependencies(
     # Remove unused packages from the lockfile
     for package_name in unused_packages:
         if package_name in lockfile[category]:
+            # Before removing, check whether this package is still needed as a
+            # transitive dependency of a package whose version was NOT changed by
+            # this upgrade.  full_lock_resolution resolves every Pipfile entry to
+            # its *latest* available version, so its transitive closure only
+            # reflects the latest versions – not the versions currently pinned in
+            # the lockfile.  If a requiring package stayed at its original pinned
+            # version its own dependencies have not changed, so we must keep P.
+            if reverse_deps is not None:
+                still_needed = False
+                for requiring_pkg, _ in reverse_deps.get(package_name, set()):
+                    if requiring_pkg not in lockfile[category]:
+                        continue
+                    current_version = lockfile[category][requiring_pkg].get("version")
+                    original_version = (
+                        original_lockfile[category].get(requiring_pkg, {}).get("version")
+                    )
+                    # If the requiring package's version is unchanged, its
+                    # transitive dependencies haven't changed either – keep P.
+                    if (
+                        current_version is not None
+                        and current_version == original_version
+                    ):
+                        still_needed = True
+                        break
+                if still_needed:
+                    if project.s.is_verbose():
+                        err.print(
+                            f"Keeping {package_name} (still needed by a package at its pinned version)"
+                        )
+                    continue
+
             if project.s.is_verbose():
                 err.print(f"Removing unused dependency: {package_name}")
             del lockfile[category][package_name]
@@ -661,9 +701,15 @@ def upgrade(
             )
             category_resolutions[category] = full_lock_resolution
 
-            # Clean up unused dependencies
+            # Clean up unused dependencies, passing the reverse-dependency map so
+            # that transitive deps of un-upgraded (pinned) packages are preserved.
             _clean_unused_dependencies(
-                project, lockfile, category, full_lock_resolution, original_lockfile
+                project,
+                lockfile,
+                category,
+                full_lock_resolution,
+                original_lockfile,
+                reverse_deps,
             )
 
         # Reset package args for next category if needed

--- a/tests/unit/test_update.py
+++ b/tests/unit/test_update.py
@@ -136,6 +136,151 @@ def test_clean_unused_deps_noop_when_full_resolution_is_empty():
     assert "sqlparse" in lockfile["default"]
 
 
+
+# ---------------------------------------------------------------------------
+# _clean_unused_dependencies – reverse_deps integration (issue #6575)
+# ---------------------------------------------------------------------------
+
+
+def test_clean_unused_deps_preserves_dep_of_pinned_package():
+    """Regression test for #6575.
+
+    When a requiring package (e.g. google-auth) was NOT upgraded its version
+    in the lockfile is identical to the original.  full_lock_resolution was
+    computed against the *latest* versions so it may resolve google-auth to a
+    newer release that no longer needs cachetools/rsa.  Those transitive deps
+    must be kept because the lockfile still pins the old google-auth that
+    needs them.
+    """
+    project = _make_project()
+    # google-auth stays at 2.43.0 – it was not part of this upgrade
+    lockfile = {
+        "default": {
+            "google-auth": {"version": "==2.43.0"},
+            "cachetools": {"version": "==6.2.2"},
+            "rsa": {"version": "==4.9.1"},
+            # requests was the target of the upgrade and is already updated
+            "requests": {"version": "==2.31.0"},
+        }
+    }
+    original_lockfile = {
+        "default": {
+            "google-auth": {"version": "==2.43.0"},
+            "cachetools": {"version": "==6.2.2"},
+            "rsa": {"version": "==4.9.1"},
+            "requests": {"version": "==2.28.0"},
+        }
+    }
+    # full_lock_resolution resolved google-auth to 2.49.1 which no longer
+    # needs cachetools or rsa – so they are absent from this dict.
+    full_lock_resolution = {
+        "google-auth": {"version": "==2.49.1"},
+        "requests": {"version": "==2.31.0"},
+    }
+    # pipdeptree reverse map: cachetools and rsa are required by google-auth
+    reverse_deps = {
+        "cachetools": {("google-auth", ">=2.0.0,<3.0.0")},
+        "rsa": {("google-auth", ">=4.0.0")},
+    }
+
+    _clean_unused_dependencies(
+        project,
+        lockfile,
+        "default",
+        full_lock_resolution,
+        original_lockfile,
+        reverse_deps,
+    )
+
+    # google-auth is still at 2.43.0 in the lockfile (unchanged), so its
+    # transitive deps must be preserved.
+    assert "cachetools" in lockfile["default"], "cachetools should not be removed"
+    assert "rsa" in lockfile["default"], "rsa should not be removed"
+    assert "requests" in lockfile["default"]
+    assert "google-auth" in lockfile["default"]
+
+
+def test_clean_unused_deps_removes_dep_when_requiring_package_was_upgraded():
+    """Transitive dep IS removable once its requiring package was upgraded.
+
+    When google-auth is updated from 2.43.0 → 2.49.1 (version changed in the
+    lockfile), the old transitive deps cachetools/rsa are genuinely unused and
+    should be cleaned up.
+    """
+    project = _make_project()
+    # google-auth was upgraded to 2.49.1 in this upgrade cycle
+    lockfile = {
+        "default": {
+            "google-auth": {"version": "==2.49.1"},
+            "cachetools": {"version": "==6.2.2"},
+            "rsa": {"version": "==4.9.1"},
+        }
+    }
+    original_lockfile = {
+        "default": {
+            "google-auth": {"version": "==2.43.0"},
+            "cachetools": {"version": "==6.2.2"},
+            "rsa": {"version": "==4.9.1"},
+        }
+    }
+    # latest resolution also has google-auth 2.49.1 without cachetools/rsa
+    full_lock_resolution = {
+        "google-auth": {"version": "==2.49.1"},
+    }
+    reverse_deps = {
+        "cachetools": {("google-auth", ">=2.0.0,<3.0.0")},
+        "rsa": {("google-auth", ">=4.0.0")},
+    }
+
+    _clean_unused_dependencies(
+        project,
+        lockfile,
+        "default",
+        full_lock_resolution,
+        original_lockfile,
+        reverse_deps,
+    )
+
+    # google-auth version changed → its old deps should be removed
+    assert "cachetools" not in lockfile["default"], "cachetools should be removed"
+    assert "rsa" not in lockfile["default"], "rsa should be removed"
+    assert "google-auth" in lockfile["default"]
+
+
+def test_clean_unused_deps_without_reverse_deps_behaves_as_before():
+    """Omitting reverse_deps (None) falls back to the original behaviour."""
+    project = _make_project()
+    lockfile = {
+        "default": {
+            "google-auth": {"version": "==2.43.0"},
+            "cachetools": {"version": "==6.2.2"},
+        }
+    }
+    original_lockfile = {
+        "default": {
+            "google-auth": {"version": "==2.43.0"},
+            "cachetools": {"version": "==6.2.2"},
+        }
+    }
+    full_lock_resolution = {
+        "google-auth": {"version": "==2.49.1"},
+        # cachetools absent → was removed in latest resolution
+    }
+
+    # No reverse_deps → original logic, cachetools gets removed
+    _clean_unused_dependencies(
+        project,
+        lockfile,
+        "default",
+        full_lock_resolution,
+        original_lockfile,
+        # reverse_deps omitted (defaults to None)
+    )
+
+    assert "cachetools" not in lockfile["default"]
+    assert "google-auth" in lockfile["default"]
+
+
 def test_clean_unused_deps_verbose_prints_removed_package(capsys):
     """In verbose mode a message is printed for each removed package."""
     project = _make_project(verbose=True)


### PR DESCRIPTION
## Summary

Fixes #6575.

`_clean_unused_dependencies()` computes the set of "needed" packages from `full_lock_resolution`, which resolves every Pipfile entry to its **latest** available version — not the versions actually pinned in the lockfile.  During a partial update (e.g. `pipenv update requests`) a package such as `google-auth` may stay at its current pinned version (`2.43.0`) in the lockfile, yet `full_lock_resolution` resolves it to `2.49.1` — which no longer requires `cachetools` or `rsa`.  The cleanup removes them, causing a `ModuleNotFoundError` at runtime because the lockfile still pins `google-auth==2.43.0`.

## Root Cause

```
Version in lockfile  : google-auth==2.43.0  →  needs cachetools, rsa
Version in full_lock_resolution: google-auth==2.49.1  →  doesn't need them

_clean_unused_dependencies sees cachetools/rsa absent from full_lock_resolution
→ removes them from the lockfile  ✗
```

## Fix

The `reverse_deps` map (already built in `upgrade()` from the installed environment via `pipdeptree`) is now passed to `_clean_unused_dependencies()`.  Before removing a candidate package `P`, the function checks:

> Does any package that currently **requires** `P` (per `reverse_deps`) still appear in the lockfile at its **original, un-upgraded version**?

- **Yes** → `P` is still a live transitive dependency; skip removal.
- **No** (the requiring package was upgraded to a new version) → `full_lock_resolution` already models its new dependencies correctly; allow removal.

The `reverse_deps` parameter defaults to `None`, so existing callers and the current test suite are unaffected.

## Changes

| File | Change |
|---|---|
| `pipenv/routines/update.py` | `_clean_unused_dependencies`: add optional `reverse_deps` parameter with version-pinning guard; update call in `upgrade()` to pass `reverse_deps` |
| `tests/unit/test_update.py` | Three new regression tests: preserved dep of un-upgraded package, removed dep of upgraded package, fallback when `reverse_deps` is `None` |

## Tests

```
collected 9 items
tests/unit/test_update.py::test_clean_unused_deps_removes_unused_package PASSED
tests/unit/test_update.py::test_clean_unused_deps_keeps_packages_still_needed PASSED
tests/unit/test_update.py::test_clean_unused_deps_noop_when_category_missing_from_lockfile PASSED
tests/unit/test_update.py::test_clean_unused_deps_noop_when_category_missing_from_original PASSED
tests/unit/test_update.py::test_clean_unused_deps_noop_when_full_resolution_is_empty PASSED
tests/unit/test_update.py::test_clean_unused_deps_preserves_dep_of_pinned_package PASSED
tests/unit/test_update.py::test_clean_unused_deps_removes_dep_when_requiring_package_was_upgraded PASSED
tests/unit/test_update.py::test_clean_unused_deps_without_reverse_deps_behaves_as_before PASSED
tests/unit/test_update.py::test_clean_unused_deps_verbose_prints_removed_package PASSED
9 passed
```

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author