### PR TITLE
fix: preserve wheel metadata name casing for headers install path (#5717)

### DIFF
--- a/pipenv/patched/pip/_internal/req/req_install.py
+++ b/pipenv/patched/pip/_internal/req/req_install.py
@@ -766,8 +766,28 @@ class InstallRequirement:
         pycompile: bool = True,
     ) -> None:
         assert self.req is not None
+
+        # Prefer the distribution name recorded in the wheel's own METADATA
+        # over self.req.name, which may be the canonicalised (lowercased) form
+        # produced by pipenv's lockfile normalisation.  Using the original
+        # author-chosen casing ensures the headers install directory
+        # (scheme.headers = …/include/site/pythonX.Y/<dist_name>/) matches
+        # what downstream packages expect when they search for C/C++ headers.
+        #
+        # Example: CPyCppyy ships headers under include/.../CPyCppyy/ but the
+        # lockfile key is 'cpycppyy', so without this fix the directory ends
+        # up as 'cpycppyy/' and cppyy cannot find the headers.
+        #
+        # See: https://github.com/pypa/pipenv/issues/5717
+        dist_name = self.req.name
+        if self.local_file_path and self.is_wheel:
+            try:
+                dist_name = self.metadata["Name"]
+            except Exception:
+                pass  # fall back to the requirement name
+
         scheme = get_scheme(
-            self.req.name,
+            dist_name,
             user=use_user_site,
             home=home,
             root=root,
@@ -779,7 +799,7 @@ class InstallRequirement:
         assert self.local_file_path
 
         install_wheel(
-            self.req.name,
+            dist_name,
             self.local_file_path,
             scheme=scheme,
             req_description=str(self.req),

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -1,6 +1,6 @@
 import os
 from tempfile import TemporaryDirectory
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
 
@@ -512,6 +512,70 @@ def test_fork_compat_sentinel_restores_echo():
     )
     assert sentinel_expect_idx < setecho_true_idx, (
         "Sentinel expect must complete before setecho(True) to avoid the race condition"
+    )
+
+
+@pytest.mark.core
+def test_install_uses_metadata_name_for_headers():
+    """Regression test for GH-5717: headers directory must use the wheel's
+    own metadata name (original casing) rather than the canonicalised/
+    lowercased requirement name that comes from the lockfile.
+
+    Example: CPyCppyy is stored as 'cpycppyy' in the lockfile (due to
+    normalize_name() in format_requirement_for_lockfile), so self.req.name
+    is 'cpycppyy'.  But the wheel's METADATA has 'Name: CPyCppyy'.
+    The headers must land in …/include/site/pythonX.Y/CPyCppyy/ not
+    …/cpycppyy/ so that downstream consumers (cppyy) can find them.
+
+    The fix reads self.metadata["Name"] from the wheel and passes that as
+    dist_name to get_scheme() and install_wheel(), overriding the lowercase
+    req.name.
+    """
+    from pipenv.patched.pip._internal.req.req_install import InstallRequirement
+
+    captured = {}
+
+    def fake_get_scheme(dist_name, **kwargs):
+        captured["dist_name"] = dist_name
+        return MagicMock()
+
+    def fake_install_wheel(name, *args, **kwargs):
+        captured["install_name"] = name
+
+    mock_req = MagicMock()
+    mock_req.name = "cpycppyy"  # lowercase — as stored in the lockfile
+
+    ireq = InstallRequirement.__new__(InstallRequirement)
+    ireq.req = mock_req
+    ireq.isolated = False
+    ireq.local_file_path = "/fake/CPyCppyy-1.12.13-cp312-cp312-linux_x86_64.whl"
+    ireq.install_succeeded = None
+    ireq.user_supplied = True
+
+    # is_wheel, is_direct, and metadata are all read-only properties on
+    # InstallRequirement, so they must be patched at the class level.
+    # metadata returns a dict-like object mimicking the wheel's METADATA file.
+    metadata_mock = {"Name": "CPyCppyy"}
+    with patch.object(
+        InstallRequirement, "is_wheel", new_callable=PropertyMock, return_value=True
+    ), patch.object(
+        InstallRequirement, "is_direct", new_callable=PropertyMock, return_value=False
+    ), patch.object(
+        InstallRequirement, "metadata", new_callable=PropertyMock, return_value=metadata_mock
+    ), patch(
+        "pipenv.patched.pip._internal.req.req_install.get_scheme",
+        side_effect=fake_get_scheme,
+    ), patch(
+        "pipenv.patched.pip._internal.req.req_install.install_wheel",
+        side_effect=fake_install_wheel,
+    ):
+        ireq.install()
+
+    assert captured["dist_name"] == "CPyCppyy", (
+        f"get_scheme should receive 'CPyCppyy' (from wheel metadata) not {captured['dist_name']!r}"
+    )
+    assert captured["install_name"] == "CPyCppyy", (
+        f"install_wheel should receive 'CPyCppyy' (from wheel metadata) not {captured['install_name']!r}"
     )
 
 


### PR DESCRIPTION
## Summary

Fixes #5717 — `pipenv install cppyy` creates `include/…/cpycppyy/` (lowercase) instead of `include/…/CPyCppyy/` (original case), causing `cppyy` to fail at runtime because it cannot find `CPyCppyy/API.h`.

## Root Cause

**Three-step bug chain:**

### Step 1 — Lockfile normalises the name to lowercase
`format_requirement_for_lockfile()` in `locking.py` calls:
```python
name = normalize_name(req.name)  # 'CPyCppyy' → 'cpycppyy'
```
The lockfile is written with the key `cpycppyy`.

### Step 2 — Install reads the lowercase key as the package name
When `pipenv sync` / `pipenv install` runs, `requirement_from_lockfile("cpycppyy", …)` produces the pip line:
```
cpycppyy==1.12.13 --hash=sha256:…
```
Pip parses this and `InstallRequirement.req.name` becomes `"cpycppyy"`.

### Step 3 — `get_scheme` uses the (lowercase) req name for the headers path
```python
# req_install.py — before this fix
scheme = get_scheme(self.req.name, …)
# → scheme.headers = …/include/site/python3.x/cpycppyy/
```
The `CPyCppyy` wheel's headers land in `cpycppyy/` instead of `CPyCppyy/`. Downstream code (cppyy) searches for `CPyCppyy/API.h` and fails.

## Fix

In `InstallRequirement.install()`, before computing the scheme, read the distribution name directly from the **wheel's own METADATA**:

```python
dist_name = self.req.name
if self.local_file_path and self.is_wheel:
    try:
        dist_name = self.metadata["Name"]   # 'CPyCppyy' from the wheel
    except Exception:
        pass  # fall back to req.name

scheme = get_scheme(dist_name, …)
install_wheel(dist_name, …)
```

`self.metadata` is backed by `get_dist()` → `get_wheel_distribution(FilesystemWheel(self.local_file_path), …)`, which reads the wheel's METADATA file. The METADATA `Name:` field contains the author-specified casing (`CPyCppyy`), so the headers directory is created with the correct case.

The fallback to `self.req.name` ensures backward-compatible behaviour for any edge case where metadata is unavailable.

## Test

Added `test_install_uses_metadata_name_for_headers` in `tests/unit/test_core.py`:
- Creates an `InstallRequirement` with `req.name = "cpycppyy"` (as it would appear from the lockfile)
- Patches `metadata["Name"]` to return `"CPyCppyy"` (as it would appear in the wheel's METADATA)
- Patches `is_wheel` and `is_direct` (read-only properties) via `PropertyMock`
- Asserts that both `get_scheme` and `install_wheel` receive `"CPyCppyy"`, not `"cpycppyy"`

## Checklist
- [x] Root cause identified across the full lockfile → install pipeline
- [x] Minimal targeted fix in pip internals only (no lockfile format change)
- [x] Graceful fallback: if `self.metadata["Name"]` raises for any reason, `self.req.name` is used (existing behaviour)
- [x] Unit test added and passing
- [x] All 24 unit tests pass
- [x] ruff clean

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author