### PR TITLE
fix: record file:// URL for transitive PEP 508 file-scheme dependencies

### DIFF
--- a/pipenv/utils/locking.py
+++ b/pipenv/utils/locking.py
@@ -98,6 +98,14 @@ def format_requirement_for_lockfile(
                     pipfile_entry.get("file") or pipfile_entry.get("path")
                 ):
                     entry["file"] = req.link.url
+                elif req.req and req.req.url and req.req.url.startswith("file:"):
+                    # PEP 508 direct URL file:// dependency (e.g. a transitive dep
+                    # declared as ``pkg @ file:///path/to/pkg`` in upstream metadata).
+                    # req.req.url being set distinguishes this from a cached wheel
+                    # (which also resolves to a file:// link but never sets req.req.url).
+                    entry["file"] = req.link.url
+                    entry.pop("version", None)
+                    entry.pop("index", None)
             elif req.link.scheme in ("http", "https") and req.req and req.req.url:
                 # Handle direct URL dependencies (PEP 508 style: package @ https://...)
                 # Only when the requirement itself has a URL (req.req.url is set),

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1230,6 +1230,9 @@ class TestFormatRequirementForLockfile:
         req = self._make_install_req(
             "atomicwrites", link_url=cache_path, specifier="==1.4.1"
         )
+        # Index-resolved packages have no req.req.url (no PEP 508 @ URL);
+        # explicitly set to None so the PEP 508 file:// branch is not triggered.
+        req.req.url = None
 
         name, entry = format_requirement_for_lockfile(
             req=req,
@@ -1245,6 +1248,46 @@ class TestFormatRequirementForLockfile:
             "Local pip cache paths must not bleed into the lockfile"
         )
         assert entry.get("version") == "==1.4.1"
+
+    @pytest.mark.utils
+    def test_transitive_pep508_file_url_stored_in_lockfile(self):
+        """Transitive dependencies declared via PEP 508 ``pkg @ file:///...``
+        in upstream package metadata must have their ``file`` URL recorded in
+        the lockfile.
+
+        Regression test for https://github.com/pypa/pipenv/issues/6521.
+
+        When a top-level package depends on ``local-child-pkg @
+        file:///vendor/local-child-pkg``, pipenv used to write an empty entry
+        ``"local-child-pkg": {}`` because the package was not in the Pipfile
+        and the file:// path was silently dropped.  On the next ``pipenv
+        install`` pip then tried to satisfy ``local-child-pkg`` from PyPI and
+        failed with "No matching distribution found".
+        """
+        from pipenv.utils.locking import format_requirement_for_lockfile
+
+        file_url = "file:///home/user/my-project/vendor/local-child-pkg"
+        req = self._make_install_req("local-child-pkg", link_url=file_url)
+        # Simulate a PEP 508 direct URL reference: req.req.url is set to the
+        # file:// URL (as pip sets it when the requirement is ``pkg @ file://...``).
+        req.req.url = file_url
+
+        name, entry = format_requirement_for_lockfile(
+            req=req,
+            markers_lookup={},
+            index_lookup={},
+            original_deps={},
+            # Transitive dep: not in the Pipfile, so pipfile_entries is empty.
+            pipfile_entries={},
+        )
+
+        assert name == "local-child-pkg"
+        assert entry.get("file") == file_url, (
+            "PEP 508 file:// transitive deps must have their URL recorded in the lockfile"
+        )
+        # version and index should be removed (same as https:// direct URL deps)
+        assert "version" not in entry
+        assert "index" not in entry
 
     @pytest.mark.utils
     def test_regular_pypi_package_no_file_key(self):


### PR DESCRIPTION
Fixes #6521

## Problem

When a package declares a transitive dependency via PEP 508 URL syntax (e.g. `local-child-pkg @ file:///path/to/vendor/local-child-pkg` in its `install_requires`), pipenv wrote an empty entry `"local-child-pkg": {}` to `Pipfile.lock`.

On the next `pipenv install`, pip tried to satisfy `local-child-pkg` from PyPI and failed:
```
ERROR: Could not find a version that satisfies the requirement local-child-pkg (from versions: none)
ERROR: No matching distribution found for local-child-pkg
```

## Root Cause

In `format_requirement_for_lockfile` (`pipenv/utils/locking.py`), the `file` key was only written to the lock entry when the package appeared explicitly in the Pipfile (i.e. `pipfile_entry.get("file")` was truthy). Transitive dependencies are never in the Pipfile, so their `pipfile_entry` is always `{}` and the `file://` URL was silently dropped.

The tricky part: index-resolved packages whose downloaded wheel pip stores locally **also** have a `file://` link (`req.link`) — those must **not** be stored in the lockfile (that was the original bug fixed by the `pipfile_entry` guard). The two cases are distinguishable because pip sets `req.req.url` for `pkg @ file:///...` requirements and leaves it `None` for index-resolved cached wheels.

## Fix

Added an `elif` branch in `format_requirement_for_lockfile`:

```python
elif req.req and req.req.url and req.req.url.startswith("file:"):
    # PEP 508 direct URL file:// dependency (e.g. a transitive dep
    # declared as ``pkg @ file:///path/to/pkg`` in upstream metadata).
    entry["file"] = req.link.url
    entry.pop("version", None)
    entry.pop("index", None)
```

The absolute `file://` URL then flows through to `clean_resolved_dep`, which already converts it to a project-relative path via `_file_url_to_relative_path`, keeping the lockfile portable across machines.

## Tests

- Updated `test_cached_wheel_not_stored_in_lockfile` to set `req.req.url = None` (matching real pip behaviour for index packages, where MagicMock's auto-truthy default would otherwise trigger the new branch).
- Added `test_transitive_pep508_file_url_stored_in_lockfile` to assert that a transitive `file://` URL dep is correctly recorded in the lockfile.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author