### PR TITLE
Add patch files for pip customizations applied during vendoring

### DIFF
--- a/tasks/vendoring/patches/patched/_post-pip_distutils_fallback.patch
+++ b/tasks/vendoring/patches/patched/_post-pip_distutils_fallback.patch
@@ -1,0 +1,62 @@
+diff --git b/pipenv/patched/pip/_internal/locations/__init__.py a/pipenv/patched/pip/_internal/locations/__init__.py
+index 6e5d6045..95184b8a 100644
+--- b/pipenv/patched/pip/_internal/locations/__init__.py
++++ a/pipenv/patched/pip/_internal/locations/__init__.py
+@@ -64,7 +64,22 @@ if not _USE_SYSCONFIG:
+     # Import distutils lazily to avoid deprecation warnings,
+     # but import it soon enough that it is in memory and available during
+     # a pip reinstall.
+-    from . import _distutils
++    try:
++        from . import _distutils
++    except ImportError:
++        # distutils is not available on this interpreter – it was removed in
++        # Python 3.12 and is absent on some Linux distributions (e.g. Debian /
++        # Ubuntu without the python3-distutils package).  This can also occur in
++        # a mixed-version scenario where pipenv is installed under Python 3.12+
++        # but a subprocess runs under Python < 3.10, causing _USE_SYSCONFIG to
++        # evaluate to False while distutils is still missing.
++        # Fall back to sysconfig so that install-scheme resolution continues to
++        # work.  See https://github.com/pypa/pipenv/issues/5674.
++        logger.debug(
++            "distutils is not available; falling back to sysconfig for "
++            "install-scheme resolution."
++        )
++        _USE_SYSCONFIG = True
+ 
+ # Be noisy about incompatibilities if this platforms "should" be using
+ # sysconfig, but is explicitly opting out and using distutils instead.
+diff --git b/pipenv/patched/pip/_internal/locations/_distutils.py a/pipenv/patched/pip/_internal/locations/_distutils.py
+index 9e9ee5f1..c9044585 100644
+--- b/pipenv/patched/pip/_internal/locations/_distutils.py
++++ a/pipenv/patched/pip/_internal/locations/_distutils.py
+@@ -19,10 +19,25 @@ except (ImportError, AttributeError):
+ import logging
+ import os
+ import sys
+-from distutils.cmd import Command as DistutilsCommand
+-from distutils.command.install import SCHEME_KEYS
+-from distutils.command.install import install as distutils_install_command
+-from distutils.sysconfig import get_python_lib
++
++try:
++    from distutils.cmd import Command as DistutilsCommand
++    from distutils.command.install import SCHEME_KEYS
++    from distutils.command.install import install as distutils_install_command
++    from distutils.sysconfig import get_python_lib
++except ModuleNotFoundError as _distutils_missing_exc:
++    # distutils was removed in Python 3.12 and is absent on some Linux
++    # distributions without the python3-distutils package.  Raise a clear
++    # ImportError so that the caller (locations/__init__.py) can detect the
++    # situation and fall back to sysconfig instead.
++    # See https://github.com/pypa/pipenv/issues/5674.
++    raise ImportError(
++        "distutils is not available on this interpreter. "
++        "On Python 3.12+ distutils was removed from the standard library. "
++        "Install setuptools to provide a distutils shim, or ensure your "
++        "Python installation includes the distutils package "
++        "(e.g. 'python3-distutils' on Debian/Ubuntu)."
++    ) from _distutils_missing_exc
+ 
+ from pipenv.patched.pip._internal.models.scheme import Scheme
+ from pipenv.patched.pip._internal.utils.compat import WINDOWS

--- a/tasks/vendoring/patches/patched/_post-pip_editable_extras.patch
+++ b/tasks/vendoring/patches/patched/_post-pip_editable_extras.patch
@@ -1,0 +1,22 @@
+diff --git b/pipenv/patched/pip/_internal/req/constructors.py a/pipenv/patched/pip/_internal/req/constructors.py
+index b28e004d..ecf02126 100644
+--- b/pipenv/patched/pip/_internal/req/constructors.py
++++ a/pipenv/patched/pip/_internal/req/constructors.py
+@@ -128,9 +128,16 @@ def _parse_pip_syntax_editable(editable_req: str) -> tuple[str | None, str, set[
+     for version_control in vcs:
+         if url.lower().startswith(f"{version_control}:"):
+             url = f"{version_control}+{url}"
++            url_no_extras = f"{version_control}+{url_no_extras}"
+             break
+ 
+-    return Link(url).egg_fragment, url, set()
++    if extras:
++        return (
++            Link(url_no_extras).egg_fragment,
++            url_no_extras,
++            get_requirement("placeholder" + extras.lower()).extras,
++        )
++    return Link(url_no_extras).egg_fragment, url_no_extras, set()
+ 
+ 
+ def parse_editable(editable_req: str) -> tuple[str | None, str, set[str]]:

--- a/tasks/vendoring/patches/patched/_post-pip_resolution_log_level.patch
+++ b/tasks/vendoring/patches/patched/_post-pip_resolution_log_level.patch
@@ -1,0 +1,13 @@
+diff --git b/pipenv/patched/pip/_internal/resolution/resolvelib/factory.py a/pipenv/patched/pip/_internal/resolution/resolvelib/factory.py
+index a551b020..03ee8262 100644
+--- b/pipenv/patched/pip/_internal/resolution/resolvelib/factory.py
++++ a/pipenv/patched/pip/_internal/resolution/resolvelib/factory.py
+@@ -847,7 +847,7 @@ class Factory:
+             + "the dependency conflict\n"
+         )
+ 
+-        logger.info(msg)
++        logger.critical(msg)
+ 
+         return DistributionNotFound(
+             "ResolutionImpossible: for help visit "

--- a/tasks/vendoring/patches/patched/_post-pip_wheel_name_casing.patch
+++ b/tasks/vendoring/patches/patched/_post-pip_wheel_name_casing.patch
@@ -1,0 +1,43 @@
+diff --git b/pipenv/patched/pip/_internal/req/req_install.py a/pipenv/patched/pip/_internal/req/req_install.py
+index b52ce441..9465e32c 100644
+--- b/pipenv/patched/pip/_internal/req/req_install.py
++++ a/pipenv/patched/pip/_internal/req/req_install.py
+@@ -766,8 +766,28 @@ class InstallRequirement:
+         pycompile: bool = True,
+     ) -> None:
+         assert self.req is not None
++
++        # Prefer the distribution name recorded in the wheel's own METADATA
++        # over self.req.name, which may be the canonicalised (lowercased) form
++        # produced by pipenv's lockfile normalisation.  Using the original
++        # author-chosen casing ensures the headers install directory
++        # (scheme.headers = …/include/site/pythonX.Y/<dist_name>/) matches
++        # what downstream packages expect when they search for C/C++ headers.
++        #
++        # Example: CPyCppyy ships headers under include/.../CPyCppyy/ but the
++        # lockfile key is 'cpycppyy', so without this fix the directory ends
++        # up as 'cpycppyy/' and cppyy cannot find the headers.
++        #
++        # See: https://github.com/pypa/pipenv/issues/5717
++        dist_name = self.req.name
++        if self.local_file_path and self.is_wheel:
++            try:
++                dist_name = self.metadata["Name"]
++            except Exception:
++                pass  # fall back to the requirement name
++
+         scheme = get_scheme(
+-            self.req.name,
++            dist_name,
+             user=use_user_site,
+             home=home,
+             root=root,
+@@ -779,7 +799,7 @@ class InstallRequirement:
+         assert self.local_file_path
+ 
+         install_wheel(
+-            self.req.name,
++            dist_name,
+             self.local_file_path,
+             scheme=scheme,
+             req_description=str(self.req),


### PR DESCRIPTION
Capture direct pip modifications as proper `_post` patch files so they survive re-vendoring. These patches are applied after import rewriting.

## Patches added

- **`_post-pip_distutils_fallback.patch`**: Handle missing distutils on Python 3.12+ by falling back to sysconfig (fixes #5674)
- **`_post-pip_editable_extras.patch`**: Fix extras handling in editable VCS requirements
- **`_post-pip_wheel_name_casing.patch`**: Preserve wheel dist name casing for headers install directory (fixes #5717)
- **`_post-pip_resolution_log_level.patch`**: Use `logger.critical` for dependency resolution conflict messages

## Why

These changes were previously applied directly to the vendored pip source files, which meant they got blown away every time vendoring was re-run. By capturing them as patch files in `tasks/vendoring/patches/patched/`, they are automatically re-applied during the vendoring process.

The `_post-` prefix ensures they are applied after import rewriting (since their context lines reference the rewritten `pipenv.patched.pip` import paths).

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author