### PR TITLE
Fix --all flag for update and upgrade commands

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -169,6 +169,7 @@ pipenv sync [OPTIONS]
 | Option | Description |
 |--------|-------------|
 | `--dev` | Install both development and default packages |
+| `--all` | Install packages from all categories defined in the Pipfile |
 | `--categories TEXT` | Install packages from specified category groups |
 | `--python TEXT` | Specify which Python version to use |
 | `--extra-pip-args TEXT` | Pass additional arguments to pip |
@@ -183,6 +184,11 @@ $ pipenv sync
 Install development packages too:
 ```bash
 $ pipenv sync --dev
+```
+
+Install all categories (default, dev, and any custom categories):
+```bash
+$ pipenv sync --all
 ```
 
 Install specific categories:
@@ -203,6 +209,7 @@ pipenv update [OPTIONS] [PACKAGES]...
 | Option | Description |
 |--------|-------------|
 | `--dev` | Update development packages |
+| `--all` | Update packages from all categories defined in the Pipfile |
 | `--categories TEXT` | Update packages in specified categories |
 | `--outdated` | List out-of-date dependencies |
 | `--dry-run` | Show what would happen without making changes |
@@ -239,6 +246,7 @@ pipenv upgrade [OPTIONS] [PACKAGES]...
 | Option | Description |
 |--------|-------------|
 | `--dev` | Upgrade development packages |
+| `--all` | Upgrade packages from all categories defined in the Pipfile |
 | `--categories TEXT` | Upgrade packages in specified categories |
 | `--dry-run` | Show what would happen without making changes |
 | `--python TEXT` | Specify which Python version to use |

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -131,6 +131,12 @@ Install both default and development packages:
 $ pipenv sync --dev
 ```
 
+Install all categories (default, dev, and any custom categories):
+
+```bash
+$ pipenv sync --all
+```
+
 Install specific package categories:
 
 ```bash
@@ -142,6 +148,7 @@ $ pipenv sync --categories="tests,docs"
 | Option | Description |
 |--------|-------------|
 | `--dev` | Install both development and default packages |
+| `--all` | Install packages from all categories defined in the Pipfile |
 | `--categories` | Install packages from specified category groups |
 
 ## uninstall

--- a/pipenv/cli/command.py
+++ b/pipenv/cli/command.py
@@ -286,7 +286,10 @@ def upgrade(ctx, state, **kwargs):
     from pipenv.routines.update import upgrade
     from pipenv.utils.project import ensure_project
 
-    _apply_default_categories(ctx, state)
+    if state.installstate.all_categories:
+        state.installstate.categories = state.project.get_package_categories()
+    else:
+        _apply_default_categories(ctx, state)
 
     ensure_project(
         state.project,
@@ -851,7 +854,10 @@ def update(ctx, state, bare=False, dry_run=None, outdated=False, **kwargs):
     """Runs lock when no packages are specified, or upgrade, and then sync."""
     from pipenv.routines.update import do_update
 
-    _apply_default_categories(ctx, state)
+    if state.installstate.all_categories:
+        state.installstate.categories = state.project.get_package_categories()
+    else:
+        _apply_default_categories(ctx, state)
 
     do_update(
         state.project,

--- a/tests/integration/test_update.py
+++ b/tests/integration/test_update.py
@@ -38,6 +38,37 @@ def test_update_uses_default_categories_envvar(pipenv_instance_private_pypi, mon
     assert captured["categories"] == ["packages", "dev-packages"]
 
 
+@pytest.mark.update
+def test_update_all_categories_flag(pipenv_instance_private_pypi, monkeypatch):
+    captured = {}
+
+    def fake_do_update(project, **kwargs):
+        captured["categories"] = kwargs["categories"]
+
+    monkeypatch.setattr("pipenv.routines.update.do_update", fake_do_update)
+    with pipenv_instance_private_pypi() as p:
+        with open(p.pipfile_path, "w") as f:
+            contents = """
+[packages]
+six = "*"
+
+[dev-packages]
+pytest = "*"
+
+[docs]
+sphinx = "*"
+            """.strip()
+            f.write(contents)
+
+        cli_runner = CliRunner()
+        result = cli_runner.invoke(cli, ["update", "--all"])
+
+    assert result.exit_code == 0, result.output
+    assert "packages" in captured["categories"]
+    assert "dev-packages" in captured["categories"]
+    assert "docs" in captured["categories"]
+
+
 def test_get_modified_pipfile_entries_new_package(pipenv_instance_pypi):
     with pipenv_instance_pypi() as p:
         # Add package to Pipfile

--- a/tests/integration/test_upgrade.py
+++ b/tests/integration/test_upgrade.py
@@ -3,6 +3,9 @@ import os
 
 import pytest
 
+from pipenv.cli import cli
+from pipenv.vendor.click.testing import CliRunner
+
 
 @pytest.mark.upgrade
 def test_category_sorted_alphabetically_with_directive(pipenv_instance_private_pypi):
@@ -209,3 +212,38 @@ pytest = "*"
         if "requests" in updated_lock_data["develop"]:
             # If it's there, it should be updated
             assert updated_lock_data["develop"]["requests"]["version"] == f"=={target_version}"
+
+
+@pytest.mark.upgrade
+def test_upgrade_all_categories_flag(pipenv_instance_private_pypi, monkeypatch):
+    captured = {}
+
+    def fake_upgrade(project, **kwargs):
+        captured["categories"] = kwargs["categories"]
+
+    def fake_ensure_project(*args, **kwargs):
+        pass
+
+    monkeypatch.setattr("pipenv.routines.update.upgrade", fake_upgrade)
+    monkeypatch.setattr("pipenv.utils.project.ensure_project", fake_ensure_project)
+    with pipenv_instance_private_pypi() as p:
+        with open(p.pipfile_path, "w") as f:
+            contents = """
+[packages]
+six = "*"
+
+[dev-packages]
+pytest = "*"
+
+[docs]
+sphinx = "*"
+            """.strip()
+            f.write(contents)
+
+        cli_runner = CliRunner()
+        result = cli_runner.invoke(cli, ["upgrade", "--all"])
+
+    assert result.exit_code == 0, result.output
+    assert "packages" in captured["categories"]
+    assert "dev-packages" in captured["categories"]
+    assert "docs" in captured["categories"]


### PR DESCRIPTION
Fixes #5578

## Problem

The `--all` flag (which installs/updates packages from all categories defined in the Pipfile) was already implemented and working for `sync` and `install` commands, but the `update` and `upgrade` commands did not check `state.installstate.all_categories`. This meant `--all` was silently ignored on those commands.

## Changes

- **`pipenv/cli/command.py`**: Fixed `update` and `upgrade` commands to check `all_categories` before falling back to `_apply_default_categories()`, matching the pattern already used by `sync` and `install`.
- **`docs/cli.md`**: Documented the `--all` flag for `sync`, `update`, and `upgrade` commands.
- **`docs/commands.md`**: Documented the `--all` flag for the `sync` command.
- **`tests/integration/test_update.py`**: Added `test_update_all_categories_flag` test.
- **`tests/integration/test_upgrade.py`**: Added `test_upgrade_all_categories_flag` test.

## Usage

Users can now use `--all` to install/update/upgrade all categories:

```bash
pipenv sync --all       # installs all categories
pipenv update --all     # updates all categories  
pipenv upgrade --all    # upgrades all categories
pipenv install --all    # installs all categories (already worked)
```

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author