### PR TITLE
Add PIPENV_KEYRING_PROVIDER for Windows Credential Manager support

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -91,11 +91,12 @@ To disable a boolean option, set it to a false value: `"0"`, `"false"`, `"no"`, 
 | `PIPENV_CLEAR` | Clear caches on run | `0` |
 | `PIPENV_SITE_PACKAGES` | Enable site-packages for virtualenv | `0` |
 
-#### Security
+#### Security and Credentials
 
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `PIPENV_PYUP_API_KEY` | PyUp.io API key for security checks | None |
+| `PIPENV_KEYRING_PROVIDER` | Keyring provider for credential lookup (`auto`, `disabled`, `import`, `subprocess`) | None (pip default: `auto`) |
 
 #### Runtime Environment Variables
 

--- a/docs/credentials.md
+++ b/docs/credentials.md
@@ -143,14 +143,27 @@ Starting with pip 23.1, you can install keyring system-wide (outside of your pro
    $ virtualenv --upgrade-embed-wheels
    ```
 
-4. **Configure pip to use the subprocess keyring provider**:
+4. **Configure the keyring provider** using one of these methods:
+
+   **Option A: Environment variable (recommended for Pipenv)**:
    ```bash
-   # Global configuration (recommended)
+   $ export PIPENV_KEYRING_PROVIDER=subprocess
+   ```
+
+   **Option B: pip configuration**:
+   ```bash
+   # Global configuration
    $ pip config set --global keyring-provider subprocess
 
    # Or user-level configuration
    $ pip config set --user keyring-provider subprocess
    ```
+
+   !!! note
+       Setting `PIPENV_KEYRING_PROVIDER` ensures that keyring credentials are used
+       during both dependency resolution and installation, even though Pipenv disables
+       interactive pip input by default. This is particularly important for credential
+       managers like Windows Credential Manager.
 
 5. **Configure your index URL with the appropriate username**:
    - For Google Artifact Registry: use `oauth2accesstoken` as username
@@ -200,6 +213,8 @@ Google Cloud Artifact Registry supports authentication via keyring:
    disable_pip_input = false
    ```
 
+   Alternatively, if your keyring provider does not require user interaction (e.g. Windows Credential Manager), you can set `PIPENV_KEYRING_PROVIDER=subprocess` instead.
+
 ### Azure Artifact Registry
 
 For Azure Artifact Registry:
@@ -210,6 +225,33 @@ For Azure Artifact Registry:
    ```
 
 2. Configure your `Pipfile` similar to the Google Cloud example above, using `VssSessionToken` as the username in your index URL.
+
+### Windows Credential Manager
+
+On Windows, pip can use credentials stored in Windows Credential Manager via the keyring library.
+To use these credentials with Pipenv:
+
+1. **Install keyring globally**:
+   ```powershell
+   > pip install --user keyring
+   ```
+
+2. **Set the keyring provider**:
+   ```powershell
+   > $env:PIPENV_KEYRING_PROVIDER="subprocess"
+   ```
+
+   Or set it permanently via system environment variables.
+
+3. **Store your credentials** in Windows Credential Manager (via Control Panel or `cmdkey`).
+
+4. **Configure your `Pipfile`** with the private index URL (with or without the username):
+   ```toml
+   [[source]]
+   url = "https://username@private-repo.example.com/simple"
+   verify_ssl = true
+   name = "private"
+   ```
 
 ### AWS CodeArtifact
 

--- a/docs/indexes.md
+++ b/docs/indexes.md
@@ -282,6 +282,7 @@ If you're having authentication problems:
 2. Ensure environment variables are properly set
 3. Verify that your credentials have access to the repository
 4. Check for special characters in your credentials that might need URL encoding
+5. If using a system credential manager (e.g. Windows Credential Manager), set `PIPENV_KEYRING_PROVIDER=subprocess` to enable keyring-based credential lookup. See [Credentials](credentials.md) for details.
 
 ### SSL Certificate Issues
 

--- a/pipenv/environment.py
+++ b/pipenv/environment.py
@@ -562,6 +562,9 @@ class Environment:
         pip_options, _ = pip_command.parser.parse_args(pip_args)
         pip_options.cache_dir = self.project.s.PIPENV_CACHE_DIR
         pip_options.pre = self.pipfile.get("pre", pre)
+        keyring_provider = self.project.s.PIPENV_KEYRING_PROVIDER
+        if keyring_provider:
+            pip_options.keyring_provider = keyring_provider
         session = pip_command._build_session(pip_options)
         finder = get_package_finder(
             install_cmd=pip_command, options=pip_options, session=session

--- a/pipenv/environments.py
+++ b/pipenv/environments.py
@@ -389,6 +389,17 @@ class Setting:
         )
         """Tells Pipenv to use the virtualenv --copies to prevent symlinks when specified as Truthy."""
 
+        self.PIPENV_KEYRING_PROVIDER = get_from_env(
+            "KEYRING_PROVIDER", check_for_negation=False
+        )
+        """If set, tells pipenv which keyring provider to use for credentials lookup.
+
+        Accepts: ``auto``, ``disabled``, ``import``, ``subprocess``.
+        When set to ``import`` or ``subprocess``, keyring credentials will be
+        used even when pip input is disabled (the default).
+        Default is unset, which lets pip use its own default (``auto``).
+        """
+
         self.PIPENV_PYUP_API_KEY = get_from_env("PYUP_API_KEY", check_for_negation=False)
 
         # Internal, support running in a different Python from sys.executable.

--- a/pipenv/utils/pip.py
+++ b/pipenv/utils/pip.py
@@ -102,6 +102,14 @@ def pip_install_deps(
             "PIP_CONFIG_FILE": os.devnull,
             "PATH": os.environ.get("PATH"),
         }
+        # Pass through keyring provider so that credential managers
+        # (e.g. Windows Credential Manager) work during install.
+        # See https://github.com/pypa/pipenv/issues/5715
+        keyring_provider = project.s.PIPENV_KEYRING_PROVIDER or os.environ.get(
+            "PIP_KEYRING_PROVIDER"
+        )
+        if keyring_provider:
+            pip_config["PIP_KEYRING_PROVIDER"] = keyring_provider
         if sources:
             pip_config["PIP_INDEX_URL"] = sources[0].get("url", "")
             if len(sources) > 1:

--- a/pipenv/utils/resolver.py
+++ b/pipenv/utils/resolver.py
@@ -454,6 +454,12 @@ class Resolver:
         pip_options.pre = self.pre or self.project.settings.get(
             "allow_prereleases", False
         )
+        # Allow the user to override the keyring provider so that credential
+        # managers (e.g. Windows Credential Manager) work even when pip input
+        # is disabled.  See https://github.com/pypa/pipenv/issues/5715
+        keyring_provider = self.project.s.PIPENV_KEYRING_PROVIDER
+        if keyring_provider:
+            pip_options.keyring_provider = keyring_provider
         # In pip 26+, setting options.pre=True is no longer sufficient to
         # enable pre-release resolution. pip's PackageFinder uses
         # release_control.all_releases to determine whether pre-releases are
@@ -1157,6 +1163,12 @@ def venv_resolve_deps(
         if pypi_mirror:
             os.environ["PIPENV_PYPI_MIRROR"] = str(pypi_mirror)
         os.environ["PIP_NO_INPUT"] = "1"
+        # Pass through keyring provider so that credential managers
+        # (e.g. Windows Credential Manager) work during resolution.
+        # See https://github.com/pypa/pipenv/issues/5715
+        keyring_provider = project.s.PIPENV_KEYRING_PROVIDER
+        if keyring_provider:
+            os.environ["PIP_KEYRING_PROVIDER"] = keyring_provider
         pipenv_site_dir = get_pipenv_sitedir()
         if pipenv_site_dir is not None:
             os.environ["PIPENV_SITE_DIR"] = pipenv_site_dir

--- a/tests/unit/test_install_error_context.py
+++ b/tests/unit/test_install_error_context.py
@@ -69,6 +69,7 @@ def test_pip_install_deps_attaches_deps_to_subprocess(monkeypatch, tmp_path):
     class _Settings:
         PIPENV_CACHE_DIR = str(tmp_path)
         PIP_EXISTS_ACTION = None
+        PIPENV_KEYRING_PROVIDER = None
 
         def is_verbose(self):
             return False
@@ -136,6 +137,7 @@ def test_pip_install_deps_suppresses_pip_conf(monkeypatch, tmp_path):
     class _Settings:
         PIPENV_CACHE_DIR = str(tmp_path)
         PIP_EXISTS_ACTION = None
+        PIPENV_KEYRING_PROVIDER = None
 
         def is_verbose(self):
             return False
@@ -206,6 +208,7 @@ def test_pip_install_deps_single_source_no_extra_index(monkeypatch, tmp_path):
     class _Settings:
         PIPENV_CACHE_DIR = str(tmp_path)
         PIP_EXISTS_ACTION = None
+        PIPENV_KEYRING_PROVIDER = None
 
         def is_verbose(self):
             return False


### PR DESCRIPTION
## Summary

Adds a new `PIPENV_KEYRING_PROVIDER` environment variable that allows users to explicitly configure the keyring provider used for credential lookup during both dependency resolution and package installation.

Fixes #5715

## Problem

By default, pipenv disables pip's interactive input (`no_input=True`). Pip's `use_keyring` property checks:

```python
@property
def use_keyring(self) -> bool:
    return self.prompting or self._keyring_provider not in ["auto", "disabled"]
```

When `no_input=True`, `prompting=False`. Combined with the default `keyring_provider="auto"`, `use_keyring` returns `False`. This means system credential managers like **Windows Credential Manager** are never consulted, even though they don't require user interaction.

## Solution

Setting `PIPENV_KEYRING_PROVIDER` to `import` or `subprocess` explicitly tells pip to use the keyring, bypassing the `use_keyring` gate. The setting is propagated through all relevant paths:

- **Resolver** (`pip_options.keyring_provider`): Used when building the pip session for dependency resolution
- **Resolver subprocess** (`PIP_KEYRING_PROVIDER` env var): Passed to the subprocess that runs the resolver
- **Install subprocess** (`PIP_KEYRING_PROVIDER` env var): Passed to the pip install subprocess (which otherwise has a sanitized environment with `PIP_CONFIG_FILE=os.devnull`)
- **Environment finder** (`pip_options.keyring_provider`): Used when looking up packages

## Usage

```bash
# Enable keyring credential lookup
export PIPENV_KEYRING_PROVIDER=subprocess
pipenv install
```

Accepted values: `auto`, `disabled`, `import`, `subprocess`

## Changes

- `pipenv/environments.py`: Add `PIPENV_KEYRING_PROVIDER` setting
- `pipenv/utils/resolver.py`: Pass keyring_provider through to pip_options and resolver subprocess env
- `pipenv/utils/pip.py`: Pass `PIP_KEYRING_PROVIDER` to pip install subprocess
- `pipenv/environment.py`: Pass keyring_provider in `get_finder` session
- `docs/configuration.md`: Add `PIPENV_KEYRING_PROVIDER` to env var reference table
- `docs/credentials.md`: Add Windows Credential Manager section, update keyring setup instructions
- `docs/indexes.md`: Mention keyring provider in authentication troubleshooting
- `tests/unit/test_install_error_context.py`: Add `PIPENV_KEYRING_PROVIDER` to mock `_Settings`

## Testing

All 360 unit tests pass. The change is backward-compatible — when `PIPENV_KEYRING_PROVIDER` is not set, behavior is identical to before.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author