### PR TITLE
Add PIPENV_PYENV_ONLY environment variable to restrict Python discovery to pyenv

### DIFF
--- a/pipenv/environments.py
+++ b/pipenv/environments.py
@@ -151,6 +151,15 @@ class Setting:
         Default is to install Python automatically via pyenv when needed, if possible.
         """
 
+        self.PIPENV_PYENV_ONLY = bool(
+            get_from_env("PYENV_ONLY", check_for_negation=False)
+        )
+        """If set, Pipenv only searches for Python interpreters installed via pyenv.
+
+        This restricts Python discovery to pyenv-managed installations only,
+        ignoring system, Homebrew, and other Python interpreters.
+        """
+
         self.PIPENV_DONT_USE_ASDF = bool(
             get_from_env("DONT_USE_ASDF", check_for_negation=False)
         )

--- a/pipenv/utils/project.py
+++ b/pipenv/utils/project.py
@@ -82,7 +82,9 @@ def ensure_project(
 
     # When --system is used with --python, validate that the Python can be found
     if system and python:
-        path_to_python = find_a_system_python(python)
+        path_to_python = find_a_system_python(
+            python, pyenv_only=project.s.PIPENV_PYENV_ONLY
+        )
         if not path_to_python:
             raise exceptions.PipenvUsageError(
                 message=f"Python version '{python}' was not found on your system. "
@@ -132,7 +134,11 @@ def ensure_project(
     if warn and project.required_python_version:
         if system or project.s.PIPENV_USE_SYSTEM:
             # For --system, check the system Python
-            path_to_python = find_a_system_python(python) if python else None
+            path_to_python = (
+                find_a_system_python(python, pyenv_only=project.s.PIPENV_PYENV_ONLY)
+                if python
+                else None
+            )
             if not path_to_python:
                 from pipenv.utils.shell import system_which
 

--- a/pipenv/utils/virtualenv.py
+++ b/pipenv/utils/virtualenv.py
@@ -322,7 +322,7 @@ def ensure_python(project, python=None):
     if not python:
         python = project.s.PIPENV_DEFAULT_PYTHON_VERSION
     # Try to find Python using system registry and default paths first
-    path_to_python = find_a_system_python(python)
+    path_to_python = find_a_system_python(python, pyenv_only=project.s.PIPENV_PYENV_ONLY)
 
     if project.s.is_verbose():
         err.print(f"Using python: {python}")
@@ -442,7 +442,9 @@ def ensure_python(project, python=None):
                     err.print(f"[cyan]{c.stdout}[/cyan]")
             # Find the newly installed Python, hopefully.
             version = str(version)
-            path_to_python = find_a_system_python(version)
+            path_to_python = find_a_system_python(
+                version, pyenv_only=project.s.PIPENV_PYENV_ONLY
+            )
             try:
                 assert python_version(path_to_python) == version
             except AssertionError:
@@ -517,7 +519,7 @@ def find_python_from_py_launcher(version):
     return None
 
 
-def find_a_system_python(line):
+def find_a_system_python(line, pyenv_only=False):
     """Find a Python installation from a given line.
 
     This tries to parse the line in various of ways:
@@ -530,6 +532,10 @@ def find_a_system_python(line):
     * Nothing fits, return None.
 
     Note: The Windows py launcher is handled separately in ensure_python.
+
+    Args:
+        line: The python version or path string to search for.
+        pyenv_only: If True, only search for pyenv-managed Python installations.
     """
 
     from pipenv.vendor.pythonfinder import Finder
@@ -542,7 +548,7 @@ def find_a_system_python(line):
         if path_obj.is_file() and os.access(str(path_obj), os.X_OK):
             return str(path_obj)
 
-    finder = Finder(system=True, global_search=True)
+    finder = Finder(system=True, global_search=True, pyenv_only=pyenv_only)
     if not line:
         return next(iter(finder.find_all_python_versions()), None)
     # Use the windows finder executable

--- a/pipenv/vendor/pythonfinder/pythonfinder.py
+++ b/pipenv/vendor/pythonfinder/pythonfinder.py
@@ -32,6 +32,7 @@ class Finder:
         global_search: bool = True,
         ignore_unsupported: bool = True,
         sort_by_path: bool = False,
+        pyenv_only: bool = False,
     ):
         """
         Initialize a new Finder.
@@ -47,48 +48,57 @@ class Finder:
         self.global_search = global_search
         self.ignore_unsupported = ignore_unsupported
         self.sort_by_path = sort_by_path
+        self.pyenv_only = pyenv_only
 
         # Initialize finders
-        self.system_finder = SystemFinder(
-            paths=[path] if path else None,
-            global_search=global_search,
-            system=system,
-            ignore_unsupported=ignore_unsupported,
-        )
-
         self.pyenv_finder = PyenvFinder(
             ignore_unsupported=ignore_unsupported,
         )
 
-        self.asdf_finder = AsdfFinder(
-            ignore_unsupported=ignore_unsupported,
-        )
-
-        # Initialize Windows-specific finders if on Windows
-        self.py_launcher_finder = None
-        self.windows_finder = None
-        if os.name == "nt":
-            self.py_launcher_finder = PyLauncherFinder(
+        if pyenv_only:
+            # Only use pyenv finder when PIPENV_PYENV_ONLY is set
+            self.system_finder = None
+            self.asdf_finder = None
+            self.py_launcher_finder = None
+            self.windows_finder = None
+            self.finders: list[BaseFinder] = [self.pyenv_finder]
+        else:
+            self.system_finder = SystemFinder(
+                paths=[path] if path else None,
+                global_search=global_search,
+                system=system,
                 ignore_unsupported=ignore_unsupported,
             )
-            self.windows_finder = WindowsRegistryFinder(
+
+            self.asdf_finder = AsdfFinder(
                 ignore_unsupported=ignore_unsupported,
             )
 
-        # List of all finders
-        self.finders: list[BaseFinder] = [
-            self.pyenv_finder,
-            self.asdf_finder,
-        ]
+            # Initialize Windows-specific finders if on Windows
+            self.py_launcher_finder = None
+            self.windows_finder = None
+            if os.name == "nt":
+                self.py_launcher_finder = PyLauncherFinder(
+                    ignore_unsupported=ignore_unsupported,
+                )
+                self.windows_finder = WindowsRegistryFinder(
+                    ignore_unsupported=ignore_unsupported,
+                )
 
-        # Add Windows-specific finders if on Windows
-        if self.py_launcher_finder:
-            self.finders.append(self.py_launcher_finder)
-        if self.windows_finder:
-            self.finders.append(self.windows_finder)
-            
-        # Add system finder last
-        self.finders.append(self.system_finder)
+            # List of all finders
+            self.finders: list[BaseFinder] = [
+                self.pyenv_finder,
+                self.asdf_finder,
+            ]
+
+            # Add Windows-specific finders if on Windows
+            if self.py_launcher_finder:
+                self.finders.append(self.py_launcher_finder)
+            if self.windows_finder:
+                self.finders.append(self.windows_finder)
+
+            # Add system finder last
+            self.finders.append(self.system_finder)
 
     def which(self, executable: str) -> Path | None:
         """

--- a/tests/integration/test_python_version_mismatch.py
+++ b/tests/integration/test_python_version_mismatch.py
@@ -22,7 +22,7 @@ def test_ensure_python_non_interactive_no_yes(monkeypatch, project):
     monkeypatch.setattr("pipenv.installers.Pyenv", MockInstaller)
 
     # Mock find_a_system_python to return None (Python not found)
-    monkeypatch.setattr("pipenv.utils.virtualenv.find_a_system_python", lambda x: None)
+    monkeypatch.setattr("pipenv.utils.virtualenv.find_a_system_python", lambda x, pyenv_only=False: None)
 
     # Mock os.name to not be 'nt' to skip Windows-specific code
     monkeypatch.setattr("os.name", "posix")
@@ -66,7 +66,7 @@ def test_ensure_python_non_interactive_with_yes(monkeypatch, project):
     # and then return a path after "installation"
     find_python_calls = [None]
 
-    def mock_find_python(version):
+    def mock_find_python(version, pyenv_only=False):
         if len(find_python_calls) == 1:
             find_python_calls.append("/mock/path/to/python")
             return find_python_calls[-1]

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -868,7 +868,7 @@ class TestEnsureProjectPythonVersionMismatch:
         )
         monkeypatch.setattr(
             "pipenv.utils.project.find_a_system_python",
-            lambda x: None,
+            lambda x, pyenv_only=False: None,
         )
         ensure_virtualenv_calls = []
         monkeypatch.setattr(
@@ -901,7 +901,7 @@ class TestEnsureProjectPythonVersionMismatch:
         )
         monkeypatch.setattr(
             "pipenv.utils.project.find_a_system_python",
-            lambda x: None,
+            lambda x, pyenv_only=False: None,
         )
         ensure_virtualenv_calls = []
         monkeypatch.setattr(


### PR DESCRIPTION
## Summary

Adds a new `PIPENV_PYENV_ONLY` environment variable that, when set, restricts Python interpreter discovery to only pyenv-managed installations.

## Motivation

Users who manage their Python installations exclusively through pyenv often encounter issues where pipenv picks up system or Homebrew Python interpreters instead. This leads to unexpected behavior, especially when multiple Python versions are installed through different mechanisms.

Closes #3855

## Changes

- **`pipenv/environments.py`** — Added `PIPENV_PYENV_ONLY` setting
- **`pipenv/vendor/pythonfinder/pythonfinder.py`** — Added `pyenv_only` parameter to `Finder`. When `True`, only the `PyenvFinder` is used, skipping system, asdf, and Windows finders
- **`pipenv/utils/virtualenv.py`** — Threaded `pyenv_only` through `find_a_system_python()` and its call sites in `ensure_python()`
- **`pipenv/utils/project.py`** — Threaded `pyenv_only` through `find_a_system_python()` call sites in `ensure_project()`
- **Tests** — Updated mock signatures to match the new parameter

## Usage

```bash
export PIPENV_PYENV_ONLY=1
pipenv install --python 3.11  # Will only find pyenv-installed 3.11
```

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author