### PR TITLE
Fix pipenv shell not suspending properly with Ctrl+Z

### DIFF
--- a/pipenv/shells.py
+++ b/pipenv/shells.py
@@ -268,6 +268,33 @@ class Shell:
 
         signal.signal(signal.SIGWINCH, sigwinch_passthrough)
 
+        # Handle job-control signals (Ctrl+Z / suspend) so that the pipenv
+        # process properly suspends itself when the child shell is stopped,
+        # and resumes the child when pipenv is continued.
+        # Without this, pexpect's interact() loop keeps the pipenv process
+        # in the foreground and the parent shell never regains control.
+        # See: https://github.com/pypa/pipenv/issues/5359
+        if os.name != "nt" and hasattr(signal, "SIGTSTP"):
+
+            def sigtstp_handler(sig, frame):
+                # Stop the child shell process group
+                if c.isalive():
+                    os.kill(c.pid, signal.SIGSTOP)
+                # Restore default SIGTSTP handling and re-raise so the
+                # OS stops the pipenv process itself.
+                signal.signal(signal.SIGTSTP, signal.SIG_DFL)
+                os.kill(os.getpid(), signal.SIGTSTP)
+
+            def sigcont_handler(sig, frame):
+                # Re-install our custom SIGTSTP handler after being resumed
+                signal.signal(signal.SIGTSTP, sigtstp_handler)
+                # Resume the child shell process
+                if c.isalive():
+                    os.kill(c.pid, signal.SIGCONT)
+
+            signal.signal(signal.SIGTSTP, sigtstp_handler)
+            signal.signal(signal.SIGCONT, sigcont_handler)
+
         # Interact with the new shell.
         c.interact(escape_character=None)
         c.close()


### PR DESCRIPTION
## Summary

Fixes job control (Ctrl+Z / suspend) not working in `pipenv shell`.

## Problem

When running `pipenv shell` and attempting to suspend the shell with Ctrl+Z (or the `suspend` builtin), the pipenv process stays in the foreground and the parent shell never regains control. This is because `pexpect`'s `interact()` loop doesn't propagate SIGTSTP - it keeps reading from the PTY while the child is stopped.

## Solution

Install `SIGTSTP` and `SIGCONT` signal handlers around pexpect's `interact()` call in `fork_compat`:

- **SIGTSTP handler**: Stops the child shell process, restores default SIGTSTP handling, and re-raises the signal so the OS stops the pipenv process itself
- **SIGCONT handler**: Re-installs the custom SIGTSTP handler and resumes the child shell process

This allows the full suspend/resume cycle to work correctly:
1. User presses Ctrl+Z
2. Child shell is stopped
3. Pipenv process is stopped
4. Parent shell regains control
5. User runs `fg`
6. Pipenv resumes, child shell resumes

Only applies to POSIX systems (guarded by `os.name != 'nt'` and `hasattr(signal, 'SIGTSTP')`).

Closes #5359

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author