### PR TITLE
Fix ResolutionTooDeepError caused by wrong python_full_version in marker evaluation

### DIFF
--- a/pipenv/utils/resolver.py
+++ b/pipenv/utils/resolver.py
@@ -89,9 +89,22 @@ def _get_pipfile_python_override(project):
             # evaluation — don't override, let the running interpreter's
             # actual version be used.
             return None
-        # Only major.minor specified — assume .0 patch for inclusive resolution.
+        # Only major.minor specified — use the running interpreter's actual
+        # patch version so that markers like ``python_full_version >= "3.11.4"``
+        # evaluate correctly.  Previously we assumed ".0" which caused
+        # ResolutionTooDeep failures by wrongly excluding packages.
+        import platform
+
+        actual_full = platform.python_version()  # e.g. "3.11.15"
+        actual_major_minor = ".".join(actual_full.split(".")[:2])
+        if actual_major_minor == python_ver:
+            # Running interpreter matches the Pipfile — use its real patch.
+            full_version = actual_full
+        else:
+            # Different minor version — fall back to .0 (best guess).
+            full_version = f"{python_ver}.0"
         return {
-            "python_full_version": f"{python_ver}.0",
+            "python_full_version": full_version,
             "python_version": python_ver,
         }
 

--- a/pipenv/utils/virtualenv.py
+++ b/pipenv/utils/virtualenv.py
@@ -60,8 +60,8 @@ def do_create_virtualenv(project, python=None, site_packages=None, pypi_mirror=N
         using_string = "Using default python from"
 
     err.print(
-        f"[bold]{using_string}[/bold] [bold][yellow]{python}[/yellow][/bold]"
-        f"[green]{python_version(python)}[green] "
+        f"[bold]{using_string}[/bold] [bold][yellow]{python}[/yellow][/bold] "
+        f"[green]{python_version(python)}[/green] "
         "[bold]to create virtualenv...[/bold]"
     )
 


### PR DESCRIPTION
## Problem

The benchmark CI is failing with `ResolutionTooDeepError` when trying to resolve Sentry's 101 requirements. The resolver hits the 200,000 round limit after ~396 seconds of backtracking.

**Root cause**: When the Pipfile specifies only `python_version = "3.11"` (without an explicit `python_full_version`), `_get_pipfile_python_override()` was hardcoding `python_full_version` to `"3.11.0"`. This caused markers like `python_full_version >= "3.11.4"` to evaluate as **False** during resolution, wrongly excluding necessary dependencies and triggering excessive backtracking.

## Fix

### 1. Use the actual interpreter's patch version (`pipenv/utils/resolver.py`)

When only `python_version` (major.minor) is specified in the Pipfile, `_get_pipfile_python_override()` now uses the running interpreter's actual `python_full_version` (e.g. `3.11.15`) instead of hardcoding `.0`. It only falls back to `.0` when the running interpreter has a different major.minor than what the Pipfile specifies.

**Before**: `python_version = "3.11"` → `python_full_version = "3.11.0"` (always)
**After**: `python_version = "3.11"` on Python 3.11.15 → `python_full_version = "3.11.15"` (actual)

### 2. Fix Rich markup bug in virtualenv creation message (`pipenv/utils/virtualenv.py`)

- Fixed unclosed `[green]` tag (was `[green]` instead of `[/green]`)
- Added missing space between the Python path and version string
- This caused the CI log to show `python3.11.15` (concatenated path+version) instead of `python3.11 3.11.15`

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author