### PR TITLE
fix: enable fish shell file path completion for `pipenv run` args

### DIFF
--- a/pipenv/cli/command.py
+++ b/pipenv/cli/command.py
@@ -528,6 +528,13 @@ def activate(state):
     print(activate_cmd.strip())
 
 
+def _complete_run_args(ctx, param, incomplete):
+    """Provide file path completion for extra args passed to `pipenv run`."""
+    from pipenv.vendor.click.shell_completion import CompletionItem
+
+    return [CompletionItem(incomplete, type="file")]
+
+
 @cli.command(
     short_help="Spawns a command installed into the virtualenv.",
     context_settings=subcommand_context_no_interspersion,
@@ -535,7 +542,7 @@ def activate(state):
 @system_option
 @common_options
 @argument("command")
-@argument("args", nargs=-1)
+@argument("args", nargs=-1, shell_complete=_complete_run_args)
 @pass_state
 def run(state, command, args):
     """Spawns a command installed into the virtualenv."""


### PR DESCRIPTION
## Summary

Fixes #3478 — Fish shell tab completion does not work for file paths after `pipenv run <command>`.

## Root Cause

When using fish shell, the generated completion script registers pipenv with `--no-files`, which prevents Fish from falling back to filename completion when no custom completions are returned.

The `args` argument (`nargs=-1`) of the `run` command uses click's `STRING` type, whose `shell_complete` method returns `[]` (no completions). So when a user types:

```
pipenv run nvim ./<tab>
```

Fish gets an empty completion list and — because of `--no-files` — shows nothing instead of file paths.

## Fix

Added a `_complete_run_args` shell completion callback to the `args` argument of the `run` command that returns a `CompletionItem` with `type="file"`:

```python
def _complete_run_args(ctx, param, incomplete):
    """Provide file path completion for extra args passed to `pipenv run`."""
    from pipenv.vendor.click.shell_completion import CompletionItem

    return [CompletionItem(incomplete, type="file")]
```

The fish completion script already handles `file`-type items via `__fish_complete_path`, so this triggers proper file path completion in fish. This also benefits zsh and bash, which similarly handle `file` type completion items.

## Testing

Verified end-to-end by simulating a fish completion request:

```python
# COMP_WORDS='pipenv run nvim ./', COMP_CWORD='./'
# → resolves to run command's `args` Argument
# → returns CompletionItem(value='./', type='file')
# → fish calls __fish_complete_path ./ ✓
```

All 368 existing unit tests pass.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author