### PR TITLE
docs: address 8 open documentation issues

### DIFF
--- a/docs/dev/contributing.md
+++ b/docs/dev/contributing.md
@@ -107,6 +107,66 @@ easiest to use either the `.tar.gz` or universal wheels (ex: `py2.py3-none`). If
 a `.tar.gz` or universal wheel is not available, add wheels for all available
 architectures and platforms.
 
+## News Fragments (Changelog Entries)
+
+Pipenv uses [towncrier](https://towncrier.readthedocs.io/) to manage its changelog.
+Every pull request that changes user-visible behaviour should include a **news fragment**
+so the change is captured in the next release's `CHANGELOG.md`.
+
+### Creating a News Fragment
+
+News fragments live in the `news/` directory. Create a file named:
+
+```
+news/<issue-number>.<type>.rst
+```
+
+Where `<type>` is one of:
+
+| Type | Description | Appears in CHANGELOG? |
+|------|-------------|----------------------|
+| `feature` | New feature or improvement | Yes |
+| `behavior` | Change to existing behavior | Yes |
+| `bugfix` | Bug fix | Yes |
+| `vendor` | Update to a vendored library | Yes |
+| `doc` | Documentation-only improvement | Yes |
+| `removal` | Deprecation or removal | Yes |
+| `process` | Change to dev/CI process | Yes |
+| `trivial` | Typo fix, refactor, or other minor change | **No** (not shown in CHANGELOG) |
+
+For example, to document a bug fix for issue #1234:
+
+```bash
+$ echo "Fixed the frobnication logic when the widget is None." > news/1234.bugfix.rst
+```
+
+### Trivial Fragments
+
+Use the `trivial` type for changes that do **not** warrant a user-facing changelog entry
+(e.g. internal refactors, test-only changes, typo fixes in comments):
+
+```bash
+$ echo "." > news/1234.trivial.rst
+```
+
+```{note}
+Trivial fragments **are** required by CI to confirm you have considered whether a
+changelog entry is needed — but they are intentionally excluded from the generated
+`CHANGELOG.md`. This is expected: `towncrier` collects them, deletes the files, and
+silently omits them from the output. You do not need to add anything to the trivial
+fragment's content; a single `.` is conventional.
+```
+
+### Generating the Changelog Locally
+
+To preview what the next changelog section will look like:
+
+```bash
+$ towncrier build --draft --version 9999.0.0
+```
+
+This prints the draft changelog to stdout without modifying any files.
+
 ## Documentation Contributions
 
 Documentation improvements are always welcome! The documentation files live in

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -28,6 +28,56 @@ pip 22.1.2
 
 If pip is not installed, you can install it following the [pip installation guide](https://pip.pypa.io/en/stable/installation/).
 
+## Installing on Windows
+
+Windows is a first-class platform for Pipenv. The recommended installation method on
+Windows is **pipx**, which installs Pipenv in an isolated environment and makes the
+`pipenv` command available system-wide.
+
+### Recommended: pipx (Windows)
+
+1. **Install pipx** (requires Python 3.7+):
+   ```powershell
+   > python -m pip install --user pipx
+   > python -m pipx ensurepath
+   ```
+   Close and reopen your terminal so the updated `PATH` takes effect.
+
+2. **Install Pipenv via pipx:**
+   ```powershell
+   > pipx install pipenv
+   ```
+
+3. **Verify the installation:**
+   ```powershell
+   > pipenv --version
+   ```
+
+### Alternative: pip install (Windows)
+
+If you prefer not to use pipx, you can install Pipenv with pip:
+
+```powershell
+> pip install pipenv
+```
+
+If the `pipenv` command is not found afterwards, add the Python Scripts directory to
+your `PATH`:
+
+1. Find the Scripts directory:
+   ```powershell
+   > python -m site --user-site
+   C:\Users\Username\AppData\Roaming\Python\Python311\site-packages
+   ```
+2. Replace `site-packages` with `Scripts` in that path.
+3. Add it to your `PATH` via **System → Advanced system settings → Environment Variables**.
+
+```{note}
+Unlike Linux and macOS, `pip install --user` on Windows places the `pipenv` executable
+under `%APPDATA%\Python\PythonXY\Scripts\`. Make sure this directory is on your `PATH`
+or use pipx to avoid this manual step entirely.
+```
+
 ## Installation Methods
 
 ### Recommended: Isolated Virtual Environment Installation

--- a/docs/locking.md
+++ b/docs/locking.md
@@ -231,6 +231,59 @@ Key sections:
 - `develop`: Development dependencies
 - Custom categories: Any additional package categories you've defined
 
+## Multi-Platform Considerations
+
+### Platform-Specific Lock Files
+
+`Pipfile.lock` is generated based on the **current platform** where `pipenv lock` is run.
+This means:
+
+- Package hashes included in the lock file are only those for wheels/sdists compatible
+  with the platform and Python version used during locking.
+- If your team develops on macOS but deploys to Linux, the lock file generated on macOS
+  may include different hashes than one generated on Linux (especially for packages with
+  platform-specific binary wheels).
+
+This is expected behavior, but it is important to be aware of when working across multiple
+platforms or operating systems.
+
+### Working Across Multiple Platforms
+
+If your project runs on multiple platforms (e.g., developers on Windows/macOS and
+production on Linux), consider these strategies:
+
+**Option 1: Lock on the target platform**
+
+Generate the `Pipfile.lock` on the same platform (or a Docker container matching it) as
+your production environment:
+
+```bash
+# Lock inside a Linux container
+$ docker run --rm -v $(pwd):/app -w /app python:3.11-slim \
+    sh -c "pip install pipenv && pipenv lock"
+```
+
+**Option 2: Use `PIPENV_VENV_IN_PROJECT` with CI/CD**
+
+Generate the lock file in CI on your target platform and commit it to version control,
+ensuring all developers install with `pipenv sync` instead of re-locking locally.
+
+**Option 3: Use `--extra-pip-args` for cross-platform wheels**
+
+For packages that need specific platform wheels, you can use pip's `--platform` flag
+during installation (but not during locking):
+
+```bash
+$ pipenv install --extra-pip-args="--platform=manylinux2014_x86_64 --only-binary=:all:"
+```
+
+```{note}
+Native cross-platform lock file generation (a single `Pipfile.lock` with hashes for
+all target platforms) is not currently supported by Pipenv. This is a known limitation.
+If this is a hard requirement, consider generating separate lock files per platform in
+CI and selecting the appropriate one at deploy time.
+```
+
 ## Best Practices
 
 ### Version Control

--- a/docs/pipfile.md
+++ b/docs/pipfile.md
@@ -147,6 +147,36 @@ mypy = "*"
 sphinx = {version = ">=4.0.0", extras = ["docs"]}
 ```
 
+#### Pinning a Package in `dev-packages` That Is Also a Production Dependency
+
+If a package is required by a production dependency (listed under `[packages]`) *and*
+you also pin it explicitly in `[dev-packages]`, the resolver treats both sections as
+part of a single unified dependency graph. The production dependency's constraints
+take precedence when they conflict.
+
+For example:
+
+```toml
+[packages]
+apispec = "*"       # apispec depends on `packaging` (any version)
+
+[dev-packages]
+packaging = "==21.3"  # Pinned to an older version
+```
+
+Here, `packaging` will be resolved to whatever version satisfies `apispec`'s
+requirement (e.g. `==22.0`), **not** necessarily `==21.3`. No resolution error
+is raised because `apispec = "*"` allows any version of `packaging`.
+
+```{note}
+This is intentional behaviour: Pipenv uses a single resolver for all categories and
+there is only one installed version of each package per environment. To enforce a
+specific version, add the pin to `[packages]` as well, or tighten the constraint on
+the package that requires it (e.g. `apispec = {version = "*", dependencies = {packaging = "==21.3"}}`
+is not valid Pipfile syntax; instead use `pipenv install "packaging==21.3"` so the
+pin appears in `[packages]`).
+```
+
 ### Python Version Requirements
 
 The `[requires]` section specifies Python version constraints:

--- a/docs/specifiers.md
+++ b/docs/specifiers.md
@@ -112,6 +112,21 @@ Or for more specific control:
 python_full_version = "3.10.4"  # Exactly Python 3.10.4
 ```
 
+```{warning}
+**`python_version` only accepts an exact version string**, such as `"3.10"` or `"3"`.
+It does **not** accept version range specifiers like `">= 3.6"` or `"~= 3.9"`.
+
+If you write `python_version = ">= 3.6"`, Pipenv will warn that the required Python
+version was not found and may behave unexpectedly:
+
+    Warning: Python >= 3.6 was not found on your system...
+    Warning: Your Pipfile requires python_version >= 3.6, but you are using 3.9.2 (...)
+
+To express a minimum Python requirement, simply set the lowest version you support
+as the exact `python_version` (e.g. `python_version = "3.9"`). If you need
+a fully exact pin, use `python_full_version` instead (e.g. `python_full_version = "3.9.7"`).
+```
+
 ### Python Version Selection Logic
 
 When you run `pipenv install` without specifying a Python version:
@@ -235,6 +250,25 @@ pyobjc = {version = "*", sys_platform = "== 'darwin'"}
 ```
 
 Any key from the [PEP 508 environment markers](https://peps.python.org/pep-0508/#environment-markers) can be used as a shorthand.
+
+#### Platform Markers and Locking
+
+```{important}
+When `pipenv lock` runs, pip resolves **all** packages in your `Pipfile`, regardless of
+platform markers. If a package with a `sys_platform == 'win32'` marker is listed and
+pip cannot find a matching distribution for it on your current platform (e.g. Linux),
+you may see an error like:
+
+    ERROR: No matching distribution found for pywin32
+
+This happens because pip's resolver attempts to download metadata for all listed packages
+and some Windows-only packages do not publish distributions for Linux/macOS.
+
+**Workaround:** Ensure the package supports all platforms at the *metadata* level, or
+split Windows-specific packages into a separate Pipfile or category. For packages that
+truly have no Linux/macOS releases at all, consider managing them outside of Pipenv for
+the non-Windows environments.
+```
 
 #### Architecture-Specific Dependencies
 

--- a/docs/virtualenv.md
+++ b/docs/virtualenv.md
@@ -146,11 +146,16 @@ Dangerous characters (i.e., ``$!*@"``, as well as space, line feed, carriage ret
 
 ## Moving or Renaming Projects
 
-When you move or rename a project directory, Pipenv can no longer find the associated virtual environment because the path hash changes.
+When you move or rename a project directory, Pipenv can no longer find the associated
+virtual environment because the virtual environment name includes a hash of the full
+project path. After a move or rename, `pipenv --venv` will report an error and
+`pipenv shell` / `pipenv run` will fail.
 
 ### Recommended Workflow for Moving/Renaming
 
-1. Remove the virtual environment before moving or renaming:
+Follow these steps **before** moving or renaming your project directory:
+
+1. Remove the virtual environment:
    ```bash
    $ pipenv --rm
    ```
@@ -164,6 +169,40 @@ When you move or rename a project directory, Pipenv can no longer find the assoc
    ```
 
 This ensures that Pipenv creates a new virtual environment with the correct path hash.
+
+### Recovery: Already Moved Without `pipenv --rm`
+
+If you have already moved or renamed your project directory without first removing the
+virtual environment, the old virtualenv is now orphaned. Follow these steps to recover:
+
+1. **Navigate to the new project location:**
+   ```bash
+   $ cd /path/to/new/location
+   ```
+
+2. **Recreate the virtual environment** (Pipenv will create a fresh one for the new path):
+   ```bash
+   $ pipenv install
+   ```
+   This reads your existing `Pipfile` (and `Pipfile.lock` if present) and creates a
+   correctly named virtual environment for the new path.
+
+3. **Clean up the orphaned virtual environment** (optional, to reclaim disk space):
+   ```bash
+   # List all virtualenvs to find the orphaned one
+   $ ls ~/.local/share/virtualenvs/   # Linux/macOS
+   $ ls %USERPROFILE%\.virtualenvs\   # Windows
+
+   # Remove it (replace <old-venv-name> with the orphaned environment's name)
+   $ rm -rf ~/.local/share/virtualenvs/<old-venv-name>
+   ```
+
+```{tip}
+To avoid this issue entirely, set `PIPENV_VENV_IN_PROJECT=1` in your shell
+configuration. This places the virtual environment in a `.venv` directory **inside**
+your project, so it always moves with the project directory and the path hash
+problem does not arise.
+```
 
 ## Using Different Python Versions
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -283,6 +283,65 @@ $ git commit -m "Update dependencies"
 $ pipenv install
 ```
 
+## Upgrading the Python Version
+
+When you want to move a project from one Python version to another (e.g., from 3.9 to
+3.11), follow these steps to ensure a clean upgrade.
+
+### Step-by-Step Python Version Upgrade
+
+1. **Install the new Python version** on your system (via pyenv, asdf, your OS package
+   manager, or python.org):
+   ```bash
+   # Using pyenv
+   $ pyenv install 3.11
+   ```
+
+2. **Remove the current virtual environment** so Pipenv can create a fresh one:
+   ```bash
+   $ pipenv --rm
+   ```
+
+3. **Update the `[requires]` section** in your `Pipfile` to the new version:
+   ```toml
+   [requires]
+   python_version = "3.11"
+   ```
+
+4. **Recreate the virtual environment** with the new Python version:
+   ```bash
+   $ pipenv --python 3.11
+   ```
+
+5. **Re-lock and install all dependencies** to regenerate `Pipfile.lock` for the new
+   Python version:
+   ```bash
+   $ pipenv lock
+   $ pipenv sync --dev
+   ```
+
+6. **Verify the upgrade:**
+   ```bash
+   $ pipenv run python --version
+   Python 3.11.x
+   ```
+
+### Quick Reference
+
+```bash
+$ pipenv --rm
+# Edit Pipfile: python_version = "3.11"
+$ pipenv --python 3.11
+$ pipenv lock
+$ pipenv sync --dev
+```
+
+```{note}
+Do **not** edit `Pipfile.lock` by hand to change the Python version. Always re-run
+`pipenv lock` after updating `[requires]` so that the lock file is regenerated with
+the correct platform markers and package versions for the new interpreter.
+```
+
 ## Troubleshooting Workflows
 
 ### Resolving Dependency Conflicts

--- a/news/4053.doc.rst
+++ b/news/4053.doc.rst
@@ -1,0 +1,1 @@
+Added a dedicated "Installing on Windows" section to the installation docs with the recommended pipx method and PATH setup guidance.

--- a/news/4577.doc.rst
+++ b/news/4577.doc.rst
@@ -1,0 +1,1 @@
+Added a "Upgrading the Python Version" workflow section to docs/workflows.md with step-by-step instructions for moving a project to a new Python interpreter.

--- a/news/4636.doc.rst
+++ b/news/4636.doc.rst
@@ -1,0 +1,1 @@
+Documented that ``python_version`` in the ``[requires]`` section only accepts an exact version string and not range specifiers such as ``>= 3.6``.

--- a/news/5129.doc.rst
+++ b/news/5129.doc.rst
@@ -1,0 +1,1 @@
+Enhanced the "Moving or Renaming Projects" section in docs/virtualenv.md with a recovery workflow for users who already moved their project without running ``pipenv --rm`` first, and added a tip about ``PIPENV_VENV_IN_PROJECT``.

--- a/news/5130.doc.rst
+++ b/news/5130.doc.rst
@@ -1,0 +1,1 @@
+Added a "Multi-Platform Considerations" section to docs/locking.md explaining that ``Pipfile.lock`` is platform-specific and documenting workarounds for cross-platform teams.

--- a/news/5324.doc.rst
+++ b/news/5324.doc.rst
@@ -1,0 +1,1 @@
+Added a "News Fragments" section to docs/dev/contributing.md explaining towncrier fragment types, including why ``trivial`` fragments are intentionally omitted from the generated CHANGELOG.

--- a/news/5528.doc.rst
+++ b/news/5528.doc.rst
@@ -1,0 +1,1 @@
+Documented the behavior when a package pinned in ``[dev-packages]`` conflicts with the version resolved via ``[packages]`` dependencies, and clarified how to enforce a specific version in that scenario.

--- a/news/6028.doc.rst
+++ b/news/6028.doc.rst
@@ -1,0 +1,1 @@
+Added a "Platform Markers and Locking" note to docs/specifiers.md explaining why packages with ``sys_platform`` markers may still cause resolution failures on non-matching platforms and documenting workarounds.


### PR DESCRIPTION
This PR closes 8 long-standing open documentation issues in a single pass.

## Changes

### `docs/installation.md` — Closes #4053
Added a dedicated **"Installing on Windows"** section at the top of the installation guide. Documents the recommended `pipx` method and the alternative `pip install` approach, including how to add the Scripts directory to `PATH`.

### `docs/workflows.md` — Closes #4577
Added an **"Upgrading the Python Version"** workflow section with a step-by-step guide covering `pipenv --rm`, updating `[requires]`, `pipenv --python X.Y`, `pipenv lock`, and `pipenv sync --dev`.

### `docs/specifiers.md` — Closes #4636
Added a `{warning}` block under **"Python Version vs. Full Version"** clearly stating that `python_version` in `[requires]` only accepts an exact version string, not a range specifier like `>= 3.6`.

### `docs/virtualenv.md` — Closes #5129
Enhanced the **"Moving or Renaming Projects"** section with a recovery workflow for users who already moved their project without running `pipenv --rm`, plus a tip about `PIPENV_VENV_IN_PROJECT=1`.

### `docs/locking.md` — Closes #5130
Added a **"Multi-Platform Considerations"** section explaining that `Pipfile.lock` is platform-specific and documenting three practical workarounds for cross-platform teams.

### `docs/dev/contributing.md` — Closes #5324
Added a **"News Fragments"** section explaining all towncrier types with a reference table, and specifically why `trivial` fragments are intentionally omitted from the CHANGELOG.

### `docs/pipfile.md` — Closes #5528
Documented the behavior when a package is pinned in `[dev-packages]` but also pulled in via `[packages]` dependencies — the resolver uses a unified graph so the production constraint wins.

### `docs/specifiers.md` — Closes #6028
Added a **"Platform Markers and Locking"** note explaining that `pipenv lock` resolves all packages regardless of `sys_platform` markers, with the root cause and workarounds.

## News Fragments

One `news/<issue>.doc.rst` fragment added per closed issue.


---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author