### PR TITLE
Add --exclude-index flag to requirements command and fix --where exit code

### DIFF
--- a/news/4085.bugfix.rst
+++ b/news/4085.bugfix.rst
@@ -1,0 +1,2 @@
+``pipenv --where`` now exits with a non-zero exit code (1) when no Pipfile is
+found, making it suitable for use in scripts and CI pipelines.

--- a/news/4398.feature.rst
+++ b/news/4398.feature.rst
@@ -1,0 +1,3 @@
+Add ``--exclude-index`` flag to ``pipenv requirements`` command to allow users
+to exclude index URLs (``-i`` and ``--extra-index-url``) from the generated output.
+This is useful when the index is configured separately in the target environment.

--- a/pipenv/cli/command.py
+++ b/pipenv/cli/command.py
@@ -1059,6 +1059,12 @@ def verify(state):
 @option("--hash", is_flag=True, default=False, help="Add package hashes.")
 @option("--exclude-markers", is_flag=True, default=False, help="Exclude markers.")
 @option(
+    "--exclude-index",
+    is_flag=True,
+    default=False,
+    help="Exclude index URLs from the output.",
+)
+@option(
     "--categories",
     is_flag=False,
     default="",
@@ -1084,6 +1090,7 @@ def requirements(
     dev_only=False,
     hash=False,
     exclude_markers=False,
+    exclude_index=False,
     categories="",
     from_pipfile=False,
     no_lock=False,
@@ -1103,6 +1110,7 @@ def requirements(
         categories=categories,
         from_pipfile=from_pipfile,
         no_lock=no_lock,
+        include_index=not exclude_index,
     )
 
 

--- a/pipenv/routines/requirements.py
+++ b/pipenv/routines/requirements.py
@@ -17,6 +17,7 @@ def generate_requirements(
     categories="",
     from_pipfile=False,
     no_lock=False,
+    include_index=True,
 ):
     # If --no-lock, generate from Pipfile directly without using lockfile versions
     if no_lock:
@@ -26,18 +27,20 @@ def generate_requirements(
             dev_only=dev_only,
             include_markers=include_markers,
             categories=categories,
+            include_index=include_index,
         )
         return
 
     lockfile = project.load_lockfile(expand_env_vars=False)
     pipfile_package_names = project.pipfile_package_names
 
-    # Print index URLs first
-    for i, package_index in enumerate(lockfile["_meta"]["sources"]):
-        prefix = "-i" if i == 0 else "--extra-index-url"
-        print(
-            " ".join([prefix, package_index["url"]])
-        )  # Use print instead of console.print
+    # Print index URLs first (unless excluded)
+    if include_index:
+        for i, package_index in enumerate(lockfile["_meta"]["sources"]):
+            prefix = "-i" if i == 0 else "--extra-index-url"
+            print(
+                " ".join([prefix, package_index["url"]])
+            )  # Use print instead of console.print
 
     deps = {}
     categories_list = re.split(r", *| ", categories) if categories else []
@@ -92,6 +95,7 @@ def _generate_requirements_from_pipfile(
     dev_only=False,
     include_markers=True,
     categories="",
+    include_index=True,
 ):
     """Generate requirements directly from Pipfile using flexible version specifiers.
 
@@ -100,13 +104,14 @@ def _generate_requirements_from_pipfile(
     """
     parsed_pipfile = project.parsed_pipfile
 
-    # Print index URLs from Pipfile sources
-    sources = parsed_pipfile.get("source", [])
-    for i, source in enumerate(sources):
-        url = source.get("url", "")
-        if url:
-            prefix = "-i" if i == 0 else "--extra-index-url"
-            print(f"{prefix} {url}")
+    # Print index URLs from Pipfile sources (unless excluded)
+    if include_index:
+        sources = parsed_pipfile.get("source", [])
+        for i, source in enumerate(sources):
+            url = source.get("url", "")
+            if url:
+                prefix = "-i" if i == 0 else "--extra-index-url"
+                print(f"{prefix} {url}")
 
     deps = {}
     categories_list = re.split(r", *| ", categories) if categories else []

--- a/pipenv/utils/virtualenv.py
+++ b/pipenv/utils/virtualenv.py
@@ -563,7 +563,7 @@ def do_where(project, virtualenv=False, bare=True):
                 "No Pipfile present at project home. Consider running "
                 "[green]`pipenv install`[/green] first to automatically generate a Pipfile for you."
             )
-            return
+            sys.exit(1)
         location = project.pipfile_location
         # Shorten the virtual display of the path to the virtualenv.
         if not bare:


### PR DESCRIPTION
## Summary

This PR addresses two long-standing open issues from the 2019-2020 triage batch:

### Fixes #4398 — Add `--exclude-index` flag to `pipenv requirements`

Adds an `--exclude-index` flag that excludes index URLs (`-i` and `--extra-index-url`) from the generated requirements output. This is useful for environments where the index is configured separately (e.g., pip config, environment variables, or CI systems).

```bash
# Before (always includes index URLs):
$ pipenv requirements
-i https://pypi.org/simple
requests==2.31.0

# Now:
$ pipenv requirements --exclude-index
requests==2.31.0
```

Works with both lockfile-based and `--no-lock` (Pipfile-based) requirements generation.

### Fixes #4085 — `pipenv --where` non-zero exit when no Pipfile found

`pipenv --where` now exits with code 1 (instead of 0) when no Pipfile is found, making it suitable for scripting and CI pipelines.

## Related Issue Triage

As part of this effort, the following old issues were also triaged and closed:
- #4453 — Already fixed (PIP_IGNORE_INSTALLED passthrough)
- #4101 — Fixed by resolver rewrite
- #3693 — Fixed by resolver rewrite (better conflict messages)
- #4240 — Closed as TOML design limitation
- #4133 — Closed as stale (Windows shell escaping, 2018 era)
- #4036 — Closed as stale (blank env var edge case, 2018 era)
- #4025 — Closed as not planned (PEP 508 spec limitation)
- #3505 — Closed as completed (PowerShell prompt now works)

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author