### PR TITLE
feat(#5195): support PEP 440 version specifiers in Pipfile python_version

### DIFF
--- a/pipenv/utils/project.py
+++ b/pipenv/utils/project.py
@@ -9,6 +9,7 @@ from pipenv.utils.dependencies import python_version
 from pipenv.utils.pipfile import ensure_pipfile
 from pipenv.utils.shell import shorten_path
 from pipenv.utils.virtualenv import ensure_virtualenv, find_a_system_python
+from pipenv.vendor.packaging.specifiers import InvalidSpecifier, SpecifierSet
 
 if TYPE_CHECKING:
     STRING_TYPE = str
@@ -23,26 +24,27 @@ def _python_version_matches_required(actual_ver_str, required_ver_str):
     """Return True if *actual_ver_str* satisfies *required_ver_str*.
 
     ``required_ver_str`` comes from the Pipfile ``[requires]`` section and may
-    be either a ``python_version`` (``"X.Y"``, major.minor only) or a
-    ``python_full_version`` (``"X.Y.Z"``).
+    be either:
+
+    * A PEP 440 version specifier string like ``">=3.8"`` or ``">=3.9,<4"``
+      (the ``python_version`` field contains an operator).
+    * A plain ``"X.Y"`` (major.minor) or ``"X.Y.Z"`` (full version) string.
 
     ``actual_ver_str`` is the full version string reported by the Python
-    interpreter (e.g. ``"3.13.11"``).
-
-    A simple substring/``in`` check is **wrong** here: ``"3.11" in "3.13.11"``
-    is ``True`` because ``"3.11"`` happens to appear as a substring of
-    ``"3.13.11"``, causing an incompatible Python version to be silently
-    accepted.  See https://github.com/pypa/pipenv/issues/6514.
-
-    Instead, this function:
-    * When *required_ver_str* has fewer than three dot-separated components
-      (i.e. only ``major.minor``), compares just the ``major`` and ``minor``
-      fields of both parsed versions.
-    * When *required_ver_str* has three or more components (``major.minor.patch``),
-      requires an exact match of the parsed versions.
+    interpreter (e.g. ``"3.13.1"``).
     """
     if not actual_ver_str or not required_ver_str:
         return False
+
+    # If the required string contains a PEP 440 operator, treat it as a
+    # SpecifierSet (e.g. ">=3.8", ">=3.9,<4").
+    if any(op in required_ver_str for op in (">=", "<=", "!=", "~=", ">", "<")):
+        try:
+            spec = SpecifierSet(required_ver_str)
+            return actual_ver_str in spec
+        except InvalidSpecifier:
+            pass
+
     try:
         actual = parse_version(actual_ver_str)
         required = parse_version(required_ver_str)

--- a/pipenv/utils/virtualenv.py
+++ b/pipenv/utils/virtualenv.py
@@ -308,11 +308,21 @@ def ensure_python(project, python=None):
         if python:
             range_pattern = r"^[<>]=?|!="
             if re.search(range_pattern, python):
-                err.print(
-                    f"[bold red]Error[/bold red]: Python version range specifier '[cyan]{python}[/cyan]' is not supported. "
-                    "[yellow]Please use an absolute version number or specify the path to the Python executable on Pipfile.[/yellow]"
+                # PEP 440 specifier like ">=3.8" — find the best installed match.
+                path_to_python = _find_python_for_specifier(
+                    python, pyenv_only=project.s.PIPENV_PYENV_ONLY
                 )
-                sys.exit(1)
+                if path_to_python:
+                    err.print(
+                        f"Found Python satisfying [cyan]{python}[/cyan]: [green]{path_to_python}[/green]"
+                    )
+                    return path_to_python
+                else:
+                    err.print(
+                        f"[bold red]Error[/bold red]: No installed Python satisfies [cyan]{python}[/cyan]. "
+                        "[yellow]Install a compatible Python via pyenv or asdf first.[/yellow]"
+                    )
+                    sys.exit(1)
 
     if not python:
         python = project.s.PIPENV_DEFAULT_PYTHON_VERSION
@@ -450,6 +460,45 @@ def ensure_python(project, python=None):
                 )
                 sys.exit(1)
     return path_to_python
+
+
+def _find_python_for_specifier(specifier_str, pyenv_only=False):
+    """Return the path to the highest installed Python satisfying *specifier_str*.
+
+    *specifier_str* is a PEP 440 version-specifier string such as ``">=3.8"``
+    or ``">=3.9,<4"``.  Returns ``None`` when no installed Python satisfies the
+    constraint.
+    """
+    from pipenv.vendor.packaging.specifiers import InvalidSpecifier, SpecifierSet
+    from pipenv.vendor.pythonfinder import Finder
+
+    try:
+        spec = SpecifierSet(specifier_str)
+    except InvalidSpecifier:
+        return None
+
+    finder = Finder(system=True, global_search=True, pyenv_only=pyenv_only)
+    all_versions = finder.find_all_python_versions()
+
+    candidates = []
+    for python_info in all_versions:
+        ver_str = python_info.version_str
+        if ver_str:
+            try:
+                if ver_str in spec:
+                    candidates.append(python_info)
+            except Exception:
+                pass
+
+    if not candidates:
+        return None
+
+    # find_all_python_versions already sorts descending; pick first.
+    best = sorted(candidates, key=lambda x: x.version_sort, reverse=True)[0]
+    path = (
+        best.path if best.path else (Path(best.executable) if best.executable else None)
+    )
+    return str(path) if path else None
 
 
 def find_python_from_py_launcher(version):


### PR DESCRIPTION
## Summary

Fixes #5195 — allows users to specify a minimum (or ranged) Python version in their `Pipfile` using PEP 440 specifier syntax:

```toml
[requires]
python_version = ">=3.8"
```

Instead of erroring with `"Python version range specifier is not supported"`, pipenv now finds the highest installed Python satisfying the constraint.

## Changes

### `pipenv/utils/virtualenv.py`
- Added `_find_python_for_specifier(specifier_str, pyenv_only=False)` — uses `packaging.specifiers.SpecifierSet` to filter all available system Pythons and returns the path to the best matching one.
- Modified `ensure_python()`: when the Pipfile `python_version` contains a PEP 440 operator (`>=`, `<=`, `!=`, `~=`, `>`, `<`), call the new helper instead of `sys.exit(1)`.

### `pipenv/utils/project.py`
- Updated `_python_version_matches_required()` to handle specifier-style `required_ver_str`. When the required string contains an operator, a `SpecifierSet` is used to check compatibility, so the "wrong Python version" warning works correctly with `>=3.8` style constraints.

## Behaviour

| Pipfile `python_version` | Before | After |
|---|---|---|  
| `"3.9"` | Works | Works (unchanged) |
| `">=3.8"` | `Error: range specifier not supported` → exit 1 | Finds highest installed Python ≥ 3.8 |
| `">=3.9,<4"` | Error → exit 1 | Finds highest installed Python in range |
| No match found | Error → exit 1 | Clear error: `No installed Python satisfies >=3.8` |

## Related Triage

Also posted triage/closing comments on several issues in the same groups that are either out-of-scope, already fixed, or upstream issues:
- #4942 — fixed by pythonfinder rewrite
- #5377 — upstream `hacking` package issue (legacy `setup.py egg_info`)
- #5637 — WSL + wsl-vpnkit interaction, not a pipenv bug
- #5511 — multiple virtualenvs per project: architectural change, out of scope
- #5463 — answered: use `--python` flag or `tox`/`nox` for multi-version testing
- #4934, #4611 — `pipenv remove` covers the active project; orphan GC is out of scope

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author