### PR TITLE
fix: triage fixes for #5063 #4898 #5155

### DIFF
--- a/pipenv/utils/pip.py
+++ b/pipenv/utils/pip.py
@@ -87,6 +87,16 @@ def pip_install_deps(
         cache_dir = Path(project.s.PIPENV_CACHE_DIR)
         default_exists_action = "w"
         exists_action = project.s.PIP_EXISTS_ACTION or default_exists_action
+        # Validate PIP_EXISTS_ACTION — pip only accepts s/i/w/b/a (#5063).
+        _valid_exists_actions = {"s", "i", "w", "b", "a"}
+        if exists_action not in _valid_exists_actions:
+            err.print(
+                f"[yellow]Warning:[/yellow] PIP_EXISTS_ACTION=[cyan]{exists_action!r}[/cyan] "
+                f"is not a valid pip exists-action. "
+                f"Valid values are: {', '.join(sorted(_valid_exists_actions))}. "
+                "Falling back to [cyan]'w'[/cyan] (wipe)."
+            )
+            exists_action = default_exists_action
         # Suppress pip.conf index configuration so that only Pipfile [[source]]
         # entries are used.  This prevents pip.conf extra-index-url (e.g.
         # piwheels) from injecting indexes at install time that were not

--- a/pipenv/utils/resolver.py
+++ b/pipenv/utils/resolver.py
@@ -197,7 +197,30 @@ def _format_resolution_error(install_error):
     ``install_error.__cause__``. This helper traverses that chain and builds a
     human-readable summary of the conflicting requirements so users can diagnose
     the problem without needing to re-run with ``--verbose``.
+
+    Also handles MetadataGenerationFailed with actionable hints (#5155).
     """
+    # Detect MetadataGenerationFailed specifically and emit an actionable hint.
+    try:
+        from pipenv.patched.pip._internal.exceptions import MetadataGenerationFailed
+
+        if isinstance(install_error, MetadataGenerationFailed):
+            pkg_name = getattr(install_error, "package_name", None) or "a package"
+            return (
+                f"Metadata generation failed for {pkg_name}.\n\n"
+                "This usually means the package uses a legacy build system "
+                "(setup.py egg_info) that is incompatible with modern pip.\n\n"
+                "Possible causes and fixes:\n"
+                "  1. The package version is too old — try upgrading to a newer release.\n"
+                "  2. A file named 'util.py', 'setup.py', or similar in your project\n"
+                "     directory is shadowing a system module. Rename or move it.\n"
+                "  3. Missing build dependencies (e.g. setuptools, wheel) — run:\n"
+                "       pipenv run pip install --upgrade setuptools wheel\n"
+                "  4. Re-run with --verbose for the full pip build log."
+            )
+    except ImportError:
+        pass
+
     base_msg = str(install_error)
 
     # Walk the exception chain to find a ResolutionImpossible cause

--- a/pipenv/vendor/pythonfinder/utils/path_utils.py
+++ b/pipenv/vendor/pythonfinder/utils/path_utils.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import errno
 import os
 import re
 from pathlib import Path
@@ -230,6 +229,12 @@ def exists_and_is_accessible(path: Path) -> bool:
     """
     Check if a path exists and is accessible.
 
+    Catches all ``OSError`` subclasses (including ``PermissionError``) and
+    returns ``False`` so that network mounts, FUSE filesystems (e.g.
+    ``/keybase``), and other special paths that raise unexpected error codes
+    are silently skipped instead of propagating an unhandled exception or —
+    worse — blocking the process with a kernel-level FUSE hang (#4898).
+
     Args:
         path: The path to check.
 
@@ -238,14 +243,10 @@ def exists_and_is_accessible(path: Path) -> bool:
     """
     try:
         return path.exists()
-    except PermissionError as error:
-        if error.errno == errno.EACCES or getattr(error, "winerror", None) == 5:
-            return False
-        raise
-    except OSError as error:
-        if error.errno == errno.EACCES or getattr(error, "winerror", None) == 5:
-            return False
-        raise
+    except OSError:
+        # Covers PermissionError, EACCES, ENOTCONN, and any FUSE/network
+        # errno that would otherwise propagate or cause a hang.
+        return False
 
 
 def is_in_path(path: str | Path, parent_path: str | Path) -> bool:


### PR DESCRIPTION
## Summary

Three targeted fixes from the triage batch (Group 8–10).

---

### fix(#5063): Validate `PIP_EXISTS_ACTION` before passing to pip

Pip only accepts `s` (switch), `i` (ignore), `w` (wipe), `b` (backup), `a` (abort) for `--exists-action`. Previously, any value set in `PIP_EXISTS_ACTION` was passed through silently. Now pipenv warns and falls back to `w` when an invalid value is detected.

```
Warning: PIP_EXISTS_ACTION='xyz' is not a valid pip exists-action.
Valid values are: a, b, i, s, w. Falling back to 'w' (wipe).
```

**File:** `pipenv/utils/pip.py`

---

### fix(#4898): Broaden `OSError` handling in `exists_and_is_accessible()`

The old implementation only caught `OSError` with `errno.EACCES` (permission denied). FUSE-based filesystems like `/keybase` can raise entirely different errno codes or in the worst case block the calling process at the kernel level waiting for the FUSE daemon.

The new implementation catches **all** `OSError` subclasses and returns `False`, so any path that can't be stat'd is silently skipped. The `errno` import is also removed as it is no longer needed.

Note: kernel-level FUSE hangs (where `stat()` never returns) cannot be solved in pure Python without thread-based timeouts. However, the new pythonfinder only scans directories that are in `PATH` and known pyenv/asdf locations — it no longer walks root-level directories. So `/keybase` would only be scanned if it appears in `PATH`.

**File:** `pipenv/vendor/pythonfinder/utils/path_utils.py`

---

### fix(#5155): Actionable error message for `MetadataGenerationFailed`

`MetadataGenerationFailed` previously surfaced as the opaque pip message `"metadata generation failed"` with no guidance. `_format_resolution_error()` now detects this exception type specifically and emits a structured hint covering the four most common root causes:

1. Package version too old (legacy `setup.py egg_info`)
2. A local `util.py` / `setup.py` shadowing a system module
3. Missing `setuptools`/`wheel` build deps
4. How to get the full build log (`--verbose`)

**File:** `pipenv/utils/resolver.py`

---

## Triage comments posted

- **#5665** — already fixed in PR #6605 (resolver uses `pipfile_sources()` now)
- **#5335** — mypy enablement: long-term incremental effort, kept open as tracking issue
- **#4898** — code fix above; noted new pythonfinder no longer walks entire filesystem

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author