### PR TITLE
fix(#4868): URL-encode expanded credentials in Pipfile source URLs

### DIFF
--- a/pipenv/project.py
+++ b/pipenv/project.py
@@ -62,6 +62,7 @@ from pipenv.utils.pylock import PylockFile, find_pylock_file
 from pipenv.utils.project import get_default_pyproject_backend
 from pipenv.utils.requirements import normalize_name
 from pipenv.utils.shell import (
+    expand_url_credentials,
     find_requirements,
     find_windows_executable,
     get_workon_home,
@@ -1177,8 +1178,18 @@ class Project:
                 sources[0]["url"] = os.environ["PIPENV_PYPI_MIRROR"]
             return sources
         # Expand environment variables in the source URLs.
+        # For the "url" field we use expand_url_credentials() which URL-encodes
+        # the expanded credential values so that passwords with special characters
+        # (e.g. '@', ':', '%') produce a valid URL (#4868).
         sources = [
-            {k: safe_expandvars(v) if expand_vars else v for k, v in source.items()}
+            {
+                k: (
+                    (expand_url_credentials(v) if k == "url" else safe_expandvars(v))
+                    if expand_vars
+                    else v
+                )
+                for k, v in source.items()
+            }
             for source in self.parsed_pipfile["source"]
         ]
         for source in sources:
@@ -1692,9 +1703,10 @@ class Project:
 
         if expand_env_vars:
             # Expand environment variables in Pipfile.lock at runtime.
+            # Use expand_url_credentials() so that passwords with special
+            # characters are URL-encoded after expansion (#4868).
             for i, _ in enumerate(j["_meta"].get("sources", {})):
-                # Path doesn't have expandvars method, so we need to use os.path.expandvars
-                j["_meta"]["sources"][i]["url"] = os.path.expandvars(
+                j["_meta"]["sources"][i]["url"] = expand_url_credentials(
                     j["_meta"]["sources"][i]["url"]
                 )
 

--- a/pipenv/utils/shell.py
+++ b/pipenv/utils/shell.py
@@ -234,6 +234,76 @@ def safe_expandvars(value):
     return value
 
 
+def expand_url_credentials(url):
+    """Expand ``${VAR}`` tokens in a source URL, URL-encoding the expanded
+    credential values so that passwords containing special characters such as
+    ``@``, ``:``, ``%``, or ``#`` produce a valid URL (#4868).
+
+    Only the *userinfo* portion (``user:password@``) is URL-encoded after
+    expansion.  The host, scheme, path, and query are expanded with plain
+    ``os.path.expandvars()`` — no percent-encoding is applied there.
+
+    Single-quoted references (``'${VAR}'``) are also supported: the
+    surrounding quotes are stripped before expansion so that the legacy Pipfile
+    idiom for protecting special characters continues to work.
+    """
+    import re
+    from urllib.parse import quote, urlsplit, urlunsplit
+
+    if not url or ("${" not in url and "$" not in url):
+        return url
+
+    try:
+        parsed = urlsplit(url)
+    except Exception:
+        return os.path.expandvars(url)
+
+    # No auth component — fall through to plain expansion.
+    if "@" not in parsed.netloc:
+        return os.path.expandvars(url)
+
+    # Matches both '${VAR}' (single-quoted legacy) and ${VAR} / $VAR.
+    _env_var_re = re.compile(r"'?\$\{([^}]+)\}'?|\$([A-Za-z_][A-Za-z0-9_]*)")
+
+    def _expand_and_encode(s):
+        def _sub(m):
+            var_name = m.group(1) or m.group(2)
+            value = os.environ.get(var_name)
+            if value is None:
+                return m.group(0)  # var not set — leave token unchanged
+            return quote(value, safe="")  # URL-encode special chars
+
+        return _env_var_re.sub(_sub, s)
+
+    # Split on the LAST '@' so any un-encoded '@' in unexpanded tokens
+    # doesn't confuse the split.
+    userinfo, _, hostinfo = parsed.netloc.rpartition("@")
+
+    # Split userinfo on the FIRST ':' to isolate username and password.
+    if ":" in userinfo:
+        raw_user, _, raw_pass = userinfo.partition(":")
+        encoded_userinfo = (
+            f"{_expand_and_encode(raw_user)}:{_expand_and_encode(raw_pass)}"
+        )
+    else:
+        encoded_userinfo = _expand_and_encode(userinfo)
+
+    # Expand the host without encoding (it may contain ${VAR} for the
+    # registry hostname but must not be percent-encoded).
+    expanded_hostinfo = os.path.expandvars(hostinfo)
+
+    new_netloc = f"{encoded_userinfo}@{expanded_hostinfo}"
+    return urlunsplit(
+        (
+            parsed.scheme,
+            new_netloc,
+            os.path.expandvars(parsed.path),
+            os.path.expandvars(parsed.query),
+            parsed.fragment,
+        )
+    )
+
+
 def cmd_list_to_shell(args):
     """Convert a list of arguments to a quoted shell command."""
     return " ".join(shlex.quote(str(token)) for token in args)


### PR DESCRIPTION
## Summary

Fixes #4868 — passwords containing special URL characters (`@`, `:`, `%`, `#`, etc.) now work correctly when stored in environment variables referenced from a `[[source]]` URL in the Pipfile.

Also restores the legacy **single-quote idiom** (`'${VAR}'`) that was documented as best practice before v2021.11.5 and stopped working when `requirementslib` was removed.

---

## Root Cause

`pipfile_sources()` and `load_lockfile()` both called `os.path.expandvars()` on the raw source URL. This expands `${PASS}` to its literal value but does **no URL-encoding**, so a password like `foo@bar` produces:

```
https://user:foo@bar@example.com/simple   ← malformed!
```

Some URL parsers (including Python's `urlsplit`) handle the extra `@` leniently, but others (and pip's auth layer) do not. Passwords containing `:` cause even worse breakage by splitting into a wrong username/password pair.

---

## Fix

New function `expand_url_credentials(url)` in `pipenv/utils/shell.py`:

1. Parses the URL with `urlsplit`
2. Splits the netloc into `userinfo@hostinfo` on the **last** `@`
3. Splits `userinfo` into `user:password` on the **first** `:`
4. Expands `${VAR}` tokens **only in the credential fields** and percent-encodes the expanded values via `urllib.parse.quote(value, safe='')`
5. Expands the host normally (no encoding) — so `${REGISTRY_HOST}` also works
6. Strips surrounding single quotes from `'${VAR}'` before expansion, restoring the legacy idiom

---

## Behaviour

| Pipfile URL template | `PASS=foo@bar` | Before | After |
|---|---|---|---|
| `https://user:${PASS}@host/` | — | `user:foo@bar@host` (malformed) | `user:foo%40bar@host` ✅ |
| `https://user:'${PASS}'@host/` | — | `user:'foo@bar'@host` (wrong pw) | `user:foo%40bar@host` ✅ |
| `https://user:${PASS}@${HOST}/` | `HOST=priv.co` | broken | `user:foo%40bar@priv.co` ✅ |
| `https://pypi.org/simple` | — | unchanged | unchanged ✅ |

---

## Files Changed

- **`pipenv/utils/shell.py`** — adds `expand_url_credentials()`
- **`pipenv/project.py`** — imports `expand_url_credentials`; uses it in `pipfile_sources()` for the `url` field, and in `load_lockfile()` replacing the bare `os.path.expandvars()` call

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author