### PR TITLE
Fix cross-category resolution producing conflicting version pins

### DIFF
--- a/pipenv/resolver.py
+++ b/pipenv/resolver.py
@@ -85,6 +85,12 @@ def get_parser():
         action="store",
         default=None,
     )
+    parser.add_argument(
+        "--resolved-default-deps-file",
+        metavar="resolved_default_deps_file",
+        action="store",
+        default=None,
+    )
     parser.add_argument("packages", nargs="*")
     return parser
 
@@ -110,6 +116,17 @@ def handle_parsed_args(parsed):
         # Convert list of package specs from command line to dict format
         # Expected format: each item is either "name" or "name==version" etc.
         parsed.packages = _parse_package_list(parsed.packages)
+    # Read resolved default deps (pinned versions from already-resolved default
+    # category, including transitive deps) to use as constraints for non-default
+    # categories.  See gh-4665 / gh-4473.
+    parsed.resolved_default_deps = None
+    if parsed.resolved_default_deps_file:
+        try:
+            with open(parsed.resolved_default_deps_file) as f:
+                parsed.resolved_default_deps = json.load(f)
+            os.unlink(parsed.resolved_default_deps_file)
+        except (json.JSONDecodeError, OSError):
+            parsed.resolved_default_deps = None
     return parsed
 
 
@@ -395,6 +412,7 @@ def resolve_packages(
     packages: Dict[str, Any],
     pipfile_category: Optional[str],
     constraints: Optional[Dict[str, Any]] = None,
+    resolved_default_deps: Optional[Dict[str, Any]] = None,
 ) -> List[Dict[str, Any]]:
     """
     Resolve package dependencies and return processed results.
@@ -409,6 +427,8 @@ def resolve_packages(
         packages: Package specifications to resolve
         pipfile_category: Category of dependencies being processed
         constraints: Additional constraints to apply
+        resolved_default_deps: Resolved lockfile entries from the default category,
+            used as constraints for non-default categories (gh-4665).
 
     Returns:
         List of processed package entries
@@ -447,6 +467,7 @@ def resolve_packages(
         clear=clear,
         allow_global=system,
         req_dir=requirements_dir,
+        resolved_default_deps=resolved_default_deps,
     )
 
     # Process results
@@ -472,9 +493,18 @@ def _main(
     packages,
     parse_only=False,
     category=None,
+    resolved_default_deps=None,
 ):
     resolve_packages(
-        pre, clear, verbose, system, write, requirements_dir, packages, category
+        pre,
+        clear,
+        verbose,
+        system,
+        write,
+        requirements_dir,
+        packages,
+        category,
+        resolved_default_deps=resolved_default_deps,
     )
 
 
@@ -538,6 +568,7 @@ def main(argv=None):
         parsed.packages,
         parse_only=parsed.parse_only,
         category=parsed.category,
+        resolved_default_deps=parsed.resolved_default_deps,
     )
 
 

--- a/pipenv/routines/lock.py
+++ b/pipenv/routines/lock.py
@@ -51,6 +51,18 @@ def do_lock(
             if not hasattr(v, "keys"):
                 del lockfile[category][k]
 
+    # Determine whether to enforce default constraints on non-default categories.
+    # When enabled (the default), resolved pins from the default category
+    # (including transitive deps) are passed as constraints when resolving
+    # non-default categories.  This prevents conflicting version pins across
+    # categories (gh-4665, gh-4473).
+    # Users can opt out via [pipenv] use_default_constraints = false in Pipfile.
+    use_default_constraints = project.settings.get("use_default_constraints", True)
+
+    # After resolving "default", we collect the resolved pins (including
+    # transitive deps) to pass as constraints to subsequent categories.
+    resolved_default_deps = None
+
     # Resolve package to generate constraints before resolving other categories
     for category in lockfile_categories:
         pipfile_category = get_pipfile_category_using_lockfile_section(category)
@@ -71,6 +83,12 @@ def do_lock(
 
         from pipenv.utils.resolver import venv_resolve_deps
 
+        # For non-default categories, pass resolved default deps as constraints
+        # so the resolver produces compatible version pins.
+        category_default_deps = None
+        if category != "default" and use_default_constraints:
+            category_default_deps = resolved_default_deps
+
         try:
             # Mutates the lockfile
             venv_resolve_deps(
@@ -86,6 +104,7 @@ def do_lock(
                 lockfile=lockfile,
                 old_lock_data=old_lock_data,
                 extra_pip_args=extra_pip_args,
+                resolved_default_deps=category_default_deps,
             )
         except RuntimeError:
             sys.exit(1)
@@ -93,14 +112,23 @@ def do_lock(
             err.print(traceback.format_exc())
             sys.exit(1)
 
-    # Overwrite any category packages with default packages.
-    for category in lockfile_categories:
+        # After resolving default, capture the resolved pins for constraining
+        # subsequent categories.
         if category == "default":
-            pass
-        if lockfile.get(category):
-            lockfile[category].update(
-                overwrite_with_default(lockfile.get("default", {}), lockfile[category])
-            )
+            resolved_default_deps = lockfile.get("default", {})
+
+    # Overwrite any non-default category packages with default packages,
+    # but only when use_default_constraints is enabled.
+    if use_default_constraints:
+        for category in lockfile_categories:
+            if category == "default":
+                continue
+            if lockfile.get(category):
+                lockfile[category].update(
+                    overwrite_with_default(
+                        lockfile.get("default", {}), lockfile[category]
+                    )
+                )
     if write:
         lockfile.update({"_meta": project.get_lockfile_meta()})
         project.write_lockfile(lockfile)

--- a/pipenv/routines/update.py
+++ b/pipenv/routines/update.py
@@ -474,6 +474,7 @@ def _resolve_and_update_lockfile(
     system,
     pypi_mirror,
     lockfile,
+    resolved_default_deps=None,
 ):
     """Resolve dependencies and update lockfile."""
     if not requested_packages[pipfile_category]:
@@ -500,6 +501,7 @@ def _resolve_and_update_lockfile(
         allow_global=system,
         pypi_mirror=pypi_mirror,
         pipfile=requested_packages[pipfile_category],
+        resolved_default_deps=resolved_default_deps,
     )
 
     if not upgrade_lock_data:
@@ -519,6 +521,7 @@ def _resolve_and_update_lockfile(
         allow_global=system,
         pypi_mirror=pypi_mirror,
         pipfile=complete_packages,
+        resolved_default_deps=resolved_default_deps,
     )
 
     # Update lockfile with verified resolution data
@@ -677,9 +680,13 @@ def upgrade(
     # Flag for tracking if we have package arguments
     has_package_args = bool(package_args)
 
+    # Determine whether to enforce default constraints on non-default categories.
+    use_default_constraints = project.settings.get("use_default_constraints", True)
+
     # Process each category
     requested_packages = defaultdict(dict)
     category_resolutions = {}
+    resolved_default_deps = None
 
     for category in categories:
         pipfile_category = get_pipfile_category_using_lockfile_section(category)
@@ -705,6 +712,11 @@ def upgrade(
                 lock_only=lock_only,
             )
 
+        # For non-default categories, pass resolved default deps as constraints
+        category_default_deps = None
+        if category != "default" and use_default_constraints:
+            category_default_deps = resolved_default_deps
+
         # Resolve dependencies and update lockfile
         upgrade_lock_data = _resolve_and_update_lockfile(
             project,
@@ -716,6 +728,7 @@ def upgrade(
             system,
             pypi_mirror,
             lockfile,
+            resolved_default_deps=category_default_deps,
         )
 
         # Store the full resolution for this category
@@ -731,6 +744,7 @@ def upgrade(
                 allow_global=system,
                 pypi_mirror=pypi_mirror,
                 pipfile=complete_packages,
+                resolved_default_deps=category_default_deps,
             )
             category_resolutions[category] = full_lock_resolution
 
@@ -745,19 +759,27 @@ def upgrade(
                 reverse_deps,
             )
 
+        # After resolving default, capture resolved pins for constraining
+        # subsequent categories.
+        if category == "default":
+            resolved_default_deps = lockfile.get("default", {})
+
         # Reset package args for next category if needed
         if not has_package_args:
             package_args = []
 
-    # Overwrite any non-default category packages with default packages (if present)
-    # This ensures transitive dependencies in develop match the versions from default
-    for category in categories:
-        if category == "default":
-            continue
-        if lockfile.get(category):
-            lockfile[category].update(
-                overwrite_with_default(lockfile.get("default", {}), lockfile[category])
-            )
+    # Overwrite any non-default category packages with default packages,
+    # but only when use_default_constraints is enabled.
+    if use_default_constraints:
+        for category in categories:
+            if category == "default":
+                continue
+            if lockfile.get(category):
+                lockfile[category].update(
+                    overwrite_with_default(
+                        lockfile.get("default", {}), lockfile[category]
+                    )
+                )
 
     # Update and write lockfile
     lockfile.update({"_meta": project.get_lockfile_meta()})

--- a/pipenv/utils/dependencies.py
+++ b/pipenv/utils/dependencies.py
@@ -1428,6 +1428,31 @@ def get_constraints_from_deps(deps):
     return constraints
 
 
+def get_constraints_from_resolved_deps(resolved_deps):
+    """Get pinned constraints from resolved lockfile data (including transitive deps).
+
+    Unlike get_constraints_from_deps which uses Pipfile specs (only direct deps),
+    this extracts exact version pins from already-resolved lockfile entries,
+    which includes transitive dependencies.
+
+    :param dict resolved_deps: A lockfile section dict, e.g. lockfile["default"]
+    :return: A set of constraint strings like {"sqlalchemy==1.4.5", "greenlet==1.0.0"}
+    :rtype: set
+    """
+    constraints = set()
+    for dep_name, dep_info in resolved_deps.items():
+        if not isinstance(dep_info, dict):
+            continue
+        # Skip path/file/VCS deps - they can't be expressed as simple constraints
+        if any(k in dep_info for k in ("path", "file", "git", "hg", "svn", "bzr")):
+            continue
+        version = dep_info.get("version")
+        if version:
+            canonical = canonicalize_name(dep_name)
+            constraints.add(f"{canonical}{version}")
+    return constraints
+
+
 def prepare_constraint_file(
     constraints,
     directory=None,

--- a/pipenv/utils/resolver.py
+++ b/pipenv/utils/resolver.py
@@ -281,6 +281,7 @@ class Resolver:
         original_deps=None,
         install_reqs=None,
         pipfile_entries=None,
+        resolved_default_deps=None,
     ):
         self.initial_constraints = constraints
         self.req_dir = req_dir
@@ -297,6 +298,10 @@ class Resolver:
         self.skipped = skipped if skipped is not None else {}
         self.markers = {}
         self.requires_python_markers = {}
+        # Resolved lockfile entries from the default category (including transitive
+        # deps).  When set, these are used as constraints for non-default categories
+        # instead of the raw Pipfile [packages] specs.  See gh-4665.
+        self.resolved_default_deps = resolved_default_deps
         self.original_deps = original_deps if original_deps is not None else {}
         self.install_reqs = install_reqs if install_reqs is not None else {}
         self.pipfile_entries = pipfile_entries
@@ -343,6 +348,7 @@ class Resolver:
         clear: bool = False,
         pre: bool = False,
         pipfile_category: str = None,
+        resolved_default_deps: Dict[str, Any] = None,
     ) -> "Resolver":
         if not req_dir:
             req_dir = create_tracked_tempdir(suffix="-requirements", prefix="pipenv-")
@@ -430,6 +436,7 @@ class Resolver:
             original_deps=original_deps,
             install_reqs=install_reqs,
             pipfile_entries=pipfile_entries,
+            resolved_default_deps=resolved_default_deps,
         )
         for package_name, dep in original_deps.items():
             install_req = install_reqs[package_name]
@@ -480,7 +487,18 @@ class Resolver:
 
     @property
     def default_constraint_file(self):
-        default_constraints = get_constraints_from_deps(self.project.packages)
+        # When resolved default deps are available (passed from do_lock after
+        # resolving the default category), use them.  They include transitive
+        # dependencies and exact version pins, which is critical for ensuring
+        # non-default categories resolve compatible versions.  See gh-4665.
+        if self.resolved_default_deps:
+            from .dependencies import get_constraints_from_resolved_deps
+
+            default_constraints = get_constraints_from_resolved_deps(
+                self.resolved_default_deps
+            )
+        else:
+            default_constraints = get_constraints_from_deps(self.project.packages)
         default_constraint_filename = prepare_constraint_file(
             default_constraints,
             directory=self.req_dir,
@@ -1025,6 +1043,7 @@ def actually_resolve_deps(
     pre,
     pipfile_category,
     req_dir,
+    resolved_default_deps=None,
 ):
     with warnings.catch_warnings(record=True) as warning_list:
         resolver = Resolver.create(
@@ -1037,6 +1056,7 @@ def actually_resolve_deps(
             clear,
             pre,
             pipfile_category,
+            resolved_default_deps=resolved_default_deps,
         )
         resolver.resolve()
         hashes = resolver.resolve_hashes
@@ -1142,6 +1162,21 @@ def resolve(cmd, st, project):
     return subprocess.CompletedProcess(c.args, returncode, out, errors)
 
 
+def _append_resolved_default_deps_args(cmd, resolved_default_deps):
+    """Write resolved default deps to a temp JSON file and append CLI args."""
+    if not resolved_default_deps:
+        return
+    with tempfile.NamedTemporaryFile(
+        mode="w",
+        prefix="pipenv-default-deps-",
+        suffix=".json",
+        delete=False,
+    ) as default_deps_file:
+        json.dump(resolved_default_deps, default_deps_file)
+    cmd.append("--resolved-default-deps-file")
+    cmd.append(default_deps_file.name)
+
+
 def venv_resolve_deps(
     deps,
     which,
@@ -1155,6 +1190,7 @@ def venv_resolve_deps(
     lockfile=None,
     old_lock_data=None,
     extra_pip_args=None,
+    resolved_default_deps=None,
 ):
     """
     Resolve dependencies for a pipenv project, acts as a portal to the target environment.
@@ -1273,6 +1309,7 @@ def venv_resolve_deps(
                             packages=deps,
                             pipfile_category=pipfile_category,
                             constraints=deps,
+                            resolved_default_deps=resolved_default_deps,
                         )
                     if results:
                         st.console.print(
@@ -1314,6 +1351,10 @@ def venv_resolve_deps(
 
                 cmd.append("--constraints-file")
                 cmd.append(constraints_file.name)
+
+                # Pass resolved default deps to subprocess so it can constrain
+                # non-default categories with transitive dep pins.  gh-4665
+                _append_resolved_default_deps_args(cmd, resolved_default_deps)
                 st.console.print("Resolving dependencies...")
                 c = resolve(cmd, st, project=project)
                 if c.returncode == 0:
@@ -1385,6 +1426,7 @@ def resolve_deps(
     pipfile_category=None,
     allow_global=False,
     req_dir=None,
+    resolved_default_deps=None,
 ):
     """Given a list of dependencies, return a resolved list of dependencies,
     and their hashes, using the warehouse API / pip.
@@ -1414,6 +1456,7 @@ def resolve_deps(
                     pre,
                     pipfile_category,
                     req_dir=req_dir,
+                    resolved_default_deps=resolved_default_deps,
                 )
             except RuntimeError:
                 # Don't exit here, like usual.
@@ -1442,6 +1485,7 @@ def resolve_deps(
                         pre,
                         pipfile_category,
                         req_dir=req_dir,
+                        resolved_default_deps=resolved_default_deps,
                     )
                 except RuntimeError:
                     sys.exit(1)

--- a/tests/unit/test_dependencies.py
+++ b/tests/unit/test_dependencies.py
@@ -705,3 +705,65 @@ class TestDependencyAsPipInstallLineEditable:
         dep = {"file": "https://example.com/pkg-1.0-py3-none-any.whl"}
         result = self._call("pkg", dep)
         assert result == "pkg @ https://example.com/pkg-1.0-py3-none-any.whl"
+
+
+
+class TestGetConstraintsFromResolvedDeps:
+    """Tests for get_constraints_from_resolved_deps (gh-4665, gh-4473)."""
+
+    def test_extracts_version_pins(self):
+        from pipenv.utils.dependencies import get_constraints_from_resolved_deps
+
+        resolved = {
+            "sqlalchemy": {"version": "==1.4.5", "hashes": ["sha256:abc"]},
+            "greenlet": {"version": "==1.0.0"},
+        }
+        constraints = get_constraints_from_resolved_deps(resolved)
+        assert "sqlalchemy==1.4.5" in constraints
+        assert "greenlet==1.0.0" in constraints
+
+    def test_skips_vcs_deps(self):
+        from pipenv.utils.dependencies import get_constraints_from_resolved_deps
+
+        resolved = {
+            "mylib": {"git": "https://github.com/foo/bar.git", "ref": "main"},
+            "normal": {"version": "==1.0"},
+        }
+        constraints = get_constraints_from_resolved_deps(resolved)
+        assert len(constraints) == 1
+        assert "normal==1.0" in constraints
+
+    def test_skips_path_deps(self):
+        from pipenv.utils.dependencies import get_constraints_from_resolved_deps
+
+        resolved = {
+            "local": {"path": "../mylib", "editable": True},
+            "normal": {"version": "==2.0"},
+        }
+        constraints = get_constraints_from_resolved_deps(resolved)
+        assert len(constraints) == 1
+        assert "normal==2.0" in constraints
+
+    def test_skips_non_dict_entries(self):
+        from pipenv.utils.dependencies import get_constraints_from_resolved_deps
+
+        resolved = {
+            "normal": {"version": "==1.0"},
+            "bogus": "not-a-dict",
+        }
+        constraints = get_constraints_from_resolved_deps(resolved)
+        assert constraints == {"normal==1.0"}
+
+    def test_empty_deps(self):
+        from pipenv.utils.dependencies import get_constraints_from_resolved_deps
+
+        assert get_constraints_from_resolved_deps({}) == set()
+
+    def test_canonicalizes_names(self):
+        from pipenv.utils.dependencies import get_constraints_from_resolved_deps
+
+        resolved = {
+            "My-Package": {"version": "==1.0"},
+        }
+        constraints = get_constraints_from_resolved_deps(resolved)
+        assert "my-package==1.0" in constraints


### PR DESCRIPTION
## Summary

Fixes #4665 and #4473 by passing resolved default category pins (including transitive deps) as constraints when resolving non-default categories.

## Problem

Two compounding bugs in `do_lock()` caused conflicting version pins across categories:

1. **Categories resolved in isolation** — `venv_resolve_deps` was called per-category with no cross-category constraint passing, so default and dev could resolve the same transitive dependency to different versions.
2. **`overwrite_with_default` unconditionally stomped dev pins** — after resolution, any package appearing in both default and develop had its develop entry silently replaced with the default entry. There was also a `pass` where `continue` was needed.

### Example (from #4665)
```toml
[packages]
marshmallow-sqlalchemy = "==0.24.2"  # depends on sqlalchemy>=1.2.0

[dev-packages]
sqlalchemy = "==1.3.*"
```
- default resolves `sqlalchemy>=1.2.0` → picks **1.4.5** (latest)
- develop resolves `sqlalchemy==1.3.*` → picks **1.3.24**
- `overwrite_with_default` then stomps develop's `1.3.24` with default's `1.4.5`

## Solution

After resolving the "default" category, capture its resolved pins and pass them as constraints to subsequent categories via the existing `default_constraint_file` mechanism in the `Resolver` class. This ensures non-default categories resolve versions compatible with default's transitive deps.

### Changes

- **`pipenv/utils/dependencies.py`**: New `get_constraints_from_resolved_deps()` helper that extracts pinned constraints from resolved lockfile data (includes transitive deps). Skips VCS/path/file deps.
- **`pipenv/routines/lock.py`**: After resolving "default", captures resolved pins and passes them to subsequent categories. `overwrite_with_default` is now conditional on `use_default_constraints` setting and the `pass`→`continue` bug is fixed.
- **`pipenv/routines/update.py`**: Same fix applied to `upgrade()` and `_resolve_and_update_lockfile()`.
- **`pipenv/utils/resolver.py`**: Threaded `resolved_default_deps` through `venv_resolve_deps` → `resolve_deps` → `actually_resolve_deps` → `Resolver.create`. Updated `default_constraint_file` property to use resolved pins when available. Extracted `_append_resolved_default_deps_args()` helper for the subprocess path.
- **`pipenv/resolver.py`**: Added `--resolved-default-deps-file` CLI argument for the subprocess resolver.
- **`tests/unit/test_dependencies.py`**: Added `TestGetConstraintsFromResolvedDeps` with 6 tests.

### Configuration

Users can opt out via the `[pipenv]` section in Pipfile:
```toml
[pipenv]
use_default_constraints = false
```
This defaults to `true`, matching the existing behavior where default pins take precedence. When disabled, categories resolve fully independently (the pre-existing behavior, minus `overwrite_with_default`).

## Testing

- All 381 unit tests pass
- All pre-commit checks pass (ruff, black, etc.)
- The existing integration test `test_default_lock_overwrite_dev_lock` validates the expected behavior (default's `click==6.7` is correctly propagated to develop when flask depends on click)

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author