### PR TITLE
Preserve symlinks when normalizing Pipfile path

### DIFF
--- a/pipenv/environments.py
+++ b/pipenv/environments.py
@@ -54,8 +54,11 @@ def normalize_pipfile_path(p):
     if p is None:
         return None
     loc = Path(p)
+    # Use os.path.abspath instead of Path.resolve() so that symlinks are
+    # preserved.  When a Pipfile is symlinked into a directory, the virtualenv
+    # should be based on the symlink's location, not the target's.  See #4471.
     try:
-        loc = loc.resolve()
+        loc = Path(os.path.abspath(loc))
     except OSError:
         loc = loc.absolute()
     # Recase the path properly on Windows. From https://stackoverflow.com/a/35229734/5043728


### PR DESCRIPTION
## Summary

Fixes #4471

When a Pipfile is a symlink (e.g., `bar/Pipfile -> ../foo/Pipfile`), pipenv was resolving the symlink to the real file location and creating the virtualenv based on the target directory (`foo`) rather than the symlink's directory (`bar`).

## Root Cause

`normalize_pipfile_path()` in `pipenv/environments.py` used `Path.resolve()`, which follows symlinks.

## Fix

Replace `Path.resolve()` with `Path(os.path.abspath())`, which normalizes the path (removes `.`, `..`, makes it absolute) **without** following symlinks.

### Before
```
cd bar
ln -s ../foo/Pipfile .
pipenv --venv
# /home/user/.virtualenvs/foo-hAsHpAtH  (wrong: based on target)
```

### After
```
cd bar
ln -s ../foo/Pipfile .
pipenv --venv
# /home/user/.virtualenvs/bar-pAtHhAsH  (correct: based on symlink location)
```

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author