### PR TITLE
Allow pipenv sync and install --ignore-pipfile to work without a Pipfile

### DIFF
--- a/pipenv/routines/install.py
+++ b/pipenv/routines/install.py
@@ -347,6 +347,7 @@ def do_install(
         pypi_mirror=pypi_mirror,
         site_packages=site_packages,
         pipfile_categories=pipfile_categories,
+        lockfile_only=ignore_pipfile,
     )
 
     do_install_validations(
@@ -853,7 +854,7 @@ def do_init(
     """Initialize the project, ensuring that the Pipfile and Pipfile.lock are in place.
     Returns True if packages were updated + installed.
     """
-    if not deploy:
+    if not deploy and not ignore_pipfile:
         ensure_pipfile(project, system=system)
 
     handle_lockfile(

--- a/pipenv/routines/sync.py
+++ b/pipenv/routines/sync.py
@@ -24,6 +24,7 @@ def do_sync(
         raise exceptions.LockfileNotFound("Pipfile.lock")
 
     # Ensure that virtualenv is available if not system.
+    # sync only needs the lockfile, so skip Pipfile creation.
     ensure_project(
         project,
         python=python,
@@ -33,6 +34,7 @@ def do_sync(
         pypi_mirror=pypi_mirror,
         clear=clear,
         site_packages=site_packages,
+        lockfile_only=True,
     )
 
     # Install everything.

--- a/pipenv/utils/project.py
+++ b/pipenv/utils/project.py
@@ -71,6 +71,7 @@ def ensure_project(
     pypi_mirror=None,
     clear=False,
     pipfile_categories=None,
+    lockfile_only=False,
 ):
     """Ensures both Pipfile and virtualenv exist for the project."""
 
@@ -173,14 +174,16 @@ def ensure_project(
             else:
                 raise exceptions.DeployException
 
-    # Ensure the Pipfile exists.
-    ensure_pipfile(
-        project,
-        validate=validate,
-        skip_requirements=skip_requirements,
-        system=system,
-        pipfile_categories=pipfile_categories,
-    )
+    # Ensure the Pipfile exists (skip when installing from lockfile only,
+    # e.g. ``pipenv sync`` — we don't need or want to create a blank Pipfile).
+    if not lockfile_only:
+        ensure_pipfile(
+            project,
+            validate=validate,
+            skip_requirements=skip_requirements,
+            system=system,
+            pipfile_categories=pipfile_categories,
+        )
     os.environ["PIP_PYTHON_PATH"] = project.python(system=system)
 
 


### PR DESCRIPTION
## Summary

Fixes #4958

Previously, `pipenv sync` and `pipenv install --ignore-pipfile` would create a blank Pipfile when one didn't exist, even though they only need the lockfile. This was confusing in deployment scenarios where only `Pipfile.lock` is shipped.

## Changes

- **`pipenv/utils/project.py`**: Add `lockfile_only` parameter to `ensure_project()` that skips `ensure_pipfile()` when `True`
- **`pipenv/routines/sync.py`**: Pass `lockfile_only=True` since sync only reads from the lockfile
- **`pipenv/routines/install.py`**: Pass `lockfile_only=ignore_pipfile` from `do_install()` so `--ignore-pipfile` skips Pipfile creation; skip `ensure_pipfile()` in `do_init()` when `ignore_pipfile=True`

## Before

```bash
# Directory with only Pipfile.lock
$ ls
Pipfile.lock
$ pipenv sync
# Creates blank Pipfile, installs packages
$ ls
Pipfile  Pipfile.lock  .venv/
```

## After

```bash
# Directory with only Pipfile.lock
$ ls
Pipfile.lock
$ pipenv sync
# Installs packages, no blank Pipfile created
$ ls
Pipfile.lock  .venv/
```

Normal `pipenv install` (without `--ignore-pipfile`) still creates a Pipfile as before.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author