### PR TITLE
Fix pipenv shell launching wrong shell on Windows (#5478)

### DIFF
--- a/pipenv/shells.py
+++ b/pipenv/shells.py
@@ -22,6 +22,13 @@ def _build_info(value):
 def detect_info(project):
     if project.s.PIPENV_SHELL_EXPLICIT:
         return _build_info(project.s.PIPENV_SHELL_EXPLICIT)
+    # On Windows, prefer $SHELL over shellingham process-tree detection.
+    # shellingham walks the process tree and can be confused by cmd.exe shims
+    # (e.g. pyenv), returning 'cmd' even when the user is in bash or powershell.
+    # $SHELL is set by POSIX-like environments (Git Bash, MSYS2, WSL) to the
+    # correct interactive shell.
+    if os.name == "nt" and project.s.PIPENV_SHELL:
+        return _build_info(project.s.PIPENV_SHELL)
     try:
         return shellingham.detect_shell()
     except (shellingham.ShellDetectionFailure, TypeError):

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -9,6 +9,7 @@ from pipenv.shells import _get_activate_script, _get_deactivate_wrapper_script
 from pipenv.utils.environment import load_dot_env
 from pipenv.utils.shell import temp_environ
 from pipenv.utils.virtualenv import warn_in_virtualenv
+from pipenv.vendor import shellingham
 
 
 @pytest.mark.core
@@ -767,3 +768,74 @@ def test_install_build_system_packages_calls_pip_install(project):
     call_kwargs = mock_pip_install.call_args
     assert call_kwargs[1]["deps"] == build_requires
     assert call_kwargs[1]["ignore_hashes"] is True
+
+
+
+# --- Tests for shell detection (GH-5478) ---
+
+
+@pytest.mark.core
+def test_detect_info_prefers_shell_env_on_windows():
+    """On Windows, detect_info should prefer $SHELL over shellingham to avoid
+    shellingham returning 'cmd' when pyenv shims are in the process tree.
+
+    See: https://github.com/pypa/pipenv/issues/5478
+    """
+    from pipenv.shells import detect_info
+
+    mock_project = MagicMock()
+    mock_project.s.PIPENV_SHELL_EXPLICIT = None
+    mock_project.s.PIPENV_SHELL = r"C:\Program Files\Git\usr\bin\bash.exe"
+
+    with patch("pipenv.shells.os.name", "nt"):
+        name, path = detect_info(mock_project)
+        assert name == "bash"
+        assert path == r"C:\Program Files\Git\usr\bin\bash.exe"
+
+
+@pytest.mark.core
+def test_detect_info_explicit_takes_priority_over_shell_env():
+    """PIPENV_SHELL_EXPLICIT should always win, even on Windows."""
+    from pipenv.shells import detect_info
+
+    mock_project = MagicMock()
+    mock_project.s.PIPENV_SHELL_EXPLICIT = r"C:\Windows\System32\cmd.exe"
+    mock_project.s.PIPENV_SHELL = r"C:\Program Files\Git\usr\bin\bash.exe"
+
+    with patch("pipenv.shells.os.name", "nt"):
+        name, path = detect_info(mock_project)
+        assert name == "cmd"
+        assert path == r"C:\Windows\System32\cmd.exe"
+
+
+@pytest.mark.core
+def test_detect_info_falls_through_to_shellingham_on_posix():
+    """On POSIX, shellingham should be used even if $SHELL is set."""
+    from pipenv.shells import detect_info
+
+    mock_project = MagicMock()
+    mock_project.s.PIPENV_SHELL_EXPLICIT = None
+    mock_project.s.PIPENV_SHELL = "/bin/bash"
+
+    with patch("pipenv.shells.os.name", "posix"), \
+         patch("pipenv.shells.shellingham.detect_shell", return_value=("zsh", "/bin/zsh")):
+        name, path = detect_info(mock_project)
+        assert name == "zsh"
+        assert path == "/bin/zsh"
+
+
+@pytest.mark.core
+def test_detect_info_falls_back_to_shell_env_when_shellingham_fails():
+    """When shellingham fails, detect_info should fall back to PIPENV_SHELL."""
+    from pipenv.shells import detect_info
+
+    mock_project = MagicMock()
+    mock_project.s.PIPENV_SHELL_EXPLICIT = None
+    mock_project.s.PIPENV_SHELL = "/bin/bash"
+
+    with patch("pipenv.shells.os.name", "posix"), \
+         patch("pipenv.shells.shellingham.detect_shell",
+               side_effect=shellingham.ShellDetectionFailure()):
+        name, path = detect_info(mock_project)
+        assert name == "bash"
+        assert path == "/bin/bash"


### PR DESCRIPTION
## Summary

Fixes `pipenv shell` launching `cmd.exe` instead of the user's actual interactive shell (bash, powershell) on Windows.

Closes #5478

## Problem

On Windows, `shellingham.detect_shell()` walks the process tree and returns the first shell it finds. When pyenv is installed, its shims use `cmd.exe`, so shellingham returns `('cmd', 'C:\\Windows\\System32\\cmd.exe')` even when the user is in Git Bash or PowerShell.

Meanwhile, `$SHELL` is correctly set by POSIX-like environments:
```python
>>> import shellingham
>>> shellingham.detect_shell()
('cmd', 'C:\\Windows\\System32\\cmd.exe')  # Wrong!
>>> import os
>>> os.getenv('SHELL')
'C:\\Program Files\\Git\\usr\\bin\\bash.exe'  # Correct!
```

## Fix

On Windows (`os.name == 'nt'`), check the `$SHELL` environment variable (available via `project.s.PIPENV_SHELL`) **before** falling back to shellingham's process tree detection.

The updated priority order for `detect_info()` is:
1. `PIPENV_SHELL` (explicit override via env var) — unchanged
2. `$SHELL` on Windows only — **NEW**
3. `shellingham.detect_shell()` — unchanged
4. `PIPENV_SHELL` fallback (when shellingham fails) — unchanged

This is safe because:
- `$SHELL` is only checked on Windows where shellingham's process tree walking is unreliable
- On POSIX systems, shellingham works correctly and remains the primary detection method
- `PIPENV_SHELL_EXPLICIT` still takes absolute priority for users who want to override everything

## Changes

- **`pipenv/shells.py`** — Added `$SHELL` check before shellingham on Windows in `detect_info()`
- **`tests/unit/test_core.py`** — 4 unit tests:
  - `test_detect_info_prefers_shell_env_on_windows` — verifies $SHELL wins over shellingham on Windows
  - `test_detect_info_explicit_takes_priority_over_shell_env` — verifies PIPENV_SHELL_EXPLICIT always wins
  - `test_detect_info_falls_through_to_shellingham_on_posix` — verifies no behavior change on POSIX
  - `test_detect_info_falls_back_to_shell_env_when_shellingham_fails` — verifies existing fallback still works

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author