### PR TITLE
Fix CLI regressions from argparse migration, env var expansion, shell history, and docs

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -208,12 +208,6 @@ $ sudo apt update
 $ sudo apt install pipenv
 ```
 
-#### Fedora
-
-```bash
-$ sudo dnf install pipenv
-```
-
 #### FreeBSD
 
 ```bash

--- a/pipenv/cli/command.py
+++ b/pipenv/cli/command.py
@@ -644,6 +644,14 @@ def cli():
     # Use parse_known_args so that extra args for 'run'/'shell' pass through.
     args, remaining = parser.parse_known_args(argv)
 
+    # Shared options use argparse.SUPPRESS as their default so that subparser
+    # defaults never overwrite values already parsed by the root parser
+    # (e.g. ``pipenv --python 3.11 sync``).  Ensure the attributes exist
+    # before env-var overlay and state building.
+    for _attr in ("python", "pypi_mirror", "verbose", "quiet", "clear", "system"):
+        if not hasattr(args, _attr):
+            setattr(args, _attr, None)
+
     # Overlay PIPENV_* env vars for any attribute still at its sentinel (None).
     apply_env_vars(args)
 

--- a/pipenv/cli/options.py
+++ b/pipenv/cli/options.py
@@ -616,13 +616,19 @@ def build_parser():
     p = subs.add_parser(
         "run", add_help=False, help="Spawn a command installed into the virtualenv."
     )
-    p.add_argument("-h", "--help", dest="help", action="store_true", default=False)
-    _add_system_option(p)
-    # NOTE: Do NOT add _add_common_options here.  The run subparser must not
+    # Only -h/--help and --system are intentionally kept on the run subparser:
+    #   -h/--help — needed so ``pipenv run --help`` shows run-specific help.
+    #     Note: ``pipenv run cmd -h`` will also be consumed by argparse; users
+    #     can use ``pipenv run cmd -- -h`` to pass -h through to the command.
+    #   --system  — pipenv-specific flag used by do_run() to skip venv creation.
+    #
+    # Do NOT add _add_common_options here.  The run subparser must not
     # recognise flags like --verbose / -v / --quiet / --python because they
     # would be consumed by argparse instead of being passed through to the
     # user's command.  Use ``pipenv --verbose run …`` for pipenv verbosity.
     # See: https://github.com/pypa/pipenv/issues/6626
+    p.add_argument("-h", "--help", dest="help", action="store_true", default=False)
+    _add_system_option(p)
     #
     # Use dest="run_command" to avoid overwriting the subparser dest ("command").
     # Do NOT add an "args" positional — everything after run_command is captured

--- a/pipenv/cli/options.py
+++ b/pipenv/cli/options.py
@@ -6,6 +6,11 @@ from pathlib import Path
 from pipenv.project import Project
 from pipenv.utils.internet import is_valid_url
 
+# Use SUPPRESS as default for options shared between the root parser and
+# subparsers.  This prevents subparser defaults from overwriting values
+# already parsed by the root parser (e.g. ``pipenv --python 3.11 sync``).
+_SHARED_DEFAULT = argparse.SUPPRESS
+
 
 class State:
     def __init__(self):
@@ -177,14 +182,14 @@ def _add_python_option(p):
     p.add_argument(
         "--python",
         dest="python",
-        default=None,
+        default=_SHARED_DEFAULT,
         help="Specify which version of Python virtualenv should use.",
     )
 
 
 def _add_pypi_mirror_option(p):
     p.add_argument(
-        "--pypi-mirror", dest="pypi_mirror", default=None, help="Specify a PyPI mirror."
+        "--pypi-mirror", dest="pypi_mirror", default=_SHARED_DEFAULT, help="Specify a PyPI mirror."
     )
 
 
@@ -194,7 +199,7 @@ def _add_verbose_option(p):
         "-v",
         dest="verbose",
         action="store_true",
-        default=None,
+        default=_SHARED_DEFAULT,
         help="Verbose mode.",
     )
 
@@ -205,7 +210,7 @@ def _add_quiet_option(p):
         "-q",
         dest="quiet",
         action="store_true",
-        default=None,
+        default=_SHARED_DEFAULT,
         help="Quiet mode.",
     )
 
@@ -232,7 +237,7 @@ def _add_clear_option(p):
         "--clear",
         dest="clear",
         action="store_true",
-        default=None,
+        default=_SHARED_DEFAULT,
         help="Clears caches (pipenv, pip).",
     )
 
@@ -242,7 +247,7 @@ def _add_system_option(p):
         "--system",
         dest="system",
         action="store_true",
-        default=None,
+        default=_SHARED_DEFAULT,
         help="System pip management.",
     )
 
@@ -613,7 +618,12 @@ def build_parser():
     )
     p.add_argument("-h", "--help", dest="help", action="store_true", default=False)
     _add_system_option(p)
-    _add_common_options(p)
+    # NOTE: Do NOT add _add_common_options here.  The run subparser must not
+    # recognise flags like --verbose / -v / --quiet / --python because they
+    # would be consumed by argparse instead of being passed through to the
+    # user's command.  Use ``pipenv --verbose run …`` for pipenv verbosity.
+    # See: https://github.com/pypa/pipenv/issues/6626
+    #
     # Use dest="run_command" to avoid overwriting the subparser dest ("command").
     # Do NOT add an "args" positional — everything after run_command is captured
     # in parse_known_args()'s remaining list so flags like -c/-v/-x are not split

--- a/pipenv/shells.py
+++ b/pipenv/shells.py
@@ -219,8 +219,12 @@ class Shell:
             # activate command is consumed by whatever prompt appears
             # first, and the virtualenv never gets activated.
             # See: https://github.com/pypa/pipenv/issues/3615
+            # Prefix every internal command with a space so that shells
+            # configured with HISTCONTROL=ignorespace (the default on most
+            # distributions) do not record them in the command history.
+            # See: https://github.com/pypa/pipenv/issues/6627
             _STARTUP_SENTINEL = "__PIPENV_STARTUP_READY__"
-            c.sendline(f"echo {_STARTUP_SENTINEL}")
+            c.sendline(f" echo {_STARTUP_SENTINEL}")
             try:
                 c.expect(_STARTUP_SENTINEL, timeout=30)
             except Exception:
@@ -231,7 +235,7 @@ class Shell:
             # Wrap the deactivate function to also unset PIPENV_ACTIVE
             deactivate_wrapper = _get_deactivate_wrapper_script(self.cmd)
             if deactivate_wrapper:
-                c.sendline(deactivate_wrapper)
+                c.sendline(f" {deactivate_wrapper}")
 
             if args:
                 c.sendline(" ".join(args))
@@ -252,7 +256,7 @@ class Shell:
             # the user (PTY echo is still off at this point).
             # See: https://github.com/pypa/pipenv/issues/6572
             _SENTINEL = "__PIPENV_SHELL_READY__"
-            c.sendline(f"echo {_SENTINEL}")
+            c.sendline(f" echo {_SENTINEL}")
             try:
                 c.expect(_SENTINEL, timeout=10)
             except Exception:

--- a/pipenv/utils/shell.py
+++ b/pipenv/utils/shell.py
@@ -264,6 +264,17 @@ def expand_url_credentials(url):
     # Matches both '${VAR}' (single-quoted legacy) and ${VAR} / $VAR.
     _env_var_re = re.compile(r"'?\$\{([^}]+)\}'?|\$([A-Za-z_][A-Za-z0-9_]*)")
 
+    def _expand_only(s):
+        """Expand env-var references without URL-encoding."""
+        def _sub(m):
+            var_name = m.group(1) or m.group(2)
+            value = os.environ.get(var_name)
+            if value is None:
+                return m.group(0)  # var not set — leave token unchanged
+            return value
+
+        return _env_var_re.sub(_sub, s)
+
     def _expand_and_encode(s):
         def _sub(m):
             var_name = m.group(1) or m.group(2)
@@ -278,14 +289,20 @@ def expand_url_credentials(url):
     # doesn't confuse the split.
     userinfo, _, hostinfo = parsed.netloc.rpartition("@")
 
-    # Split userinfo on the FIRST ':' to isolate username and password.
-    if ":" in userinfo:
-        raw_user, _, raw_pass = userinfo.partition(":")
+    # Expand env vars in userinfo FIRST (without encoding) so that we can
+    # correctly detect the user:password separator.  A single env var like
+    # ``${TOKEN}`` may expand to ``__token__:glpat-xxx`` and the ``:``
+    # must be treated as the delimiter, not URL-encoded.  (#6625)
+    expanded_userinfo = _expand_only(userinfo)
+
+    # Split expanded userinfo on the FIRST ':' to isolate username and password.
+    if ":" in expanded_userinfo:
+        raw_user, _, raw_pass = expanded_userinfo.partition(":")
         encoded_userinfo = (
-            f"{_expand_and_encode(raw_user)}:{_expand_and_encode(raw_pass)}"
+            f"{quote(raw_user, safe='')}:{quote(raw_pass, safe='')}"
         )
     else:
-        encoded_userinfo = _expand_and_encode(userinfo)
+        encoded_userinfo = quote(expanded_userinfo, safe="")
 
     # Expand the host without encoding (it may contain ${VAR} for the
     # registry hostname but must not be percent-encoded).

--- a/pipenv/utils/shell.py
+++ b/pipenv/utils/shell.py
@@ -295,8 +295,13 @@ def expand_url_credentials(url):
     # must be treated as the delimiter, not URL-encoded.  (#6625)
     expanded_userinfo = _expand_only(userinfo)
 
+    # If _expand_only() did not change anything we likely still have only
+    # unexpanded placeholders like ``${VAR}``.  Do not percent-encode them
+    # so that the URL structure is preserved and they can be expanded later.
+    if expanded_userinfo == userinfo:
+        encoded_userinfo = expanded_userinfo
     # Split expanded userinfo on the FIRST ':' to isolate username and password.
-    if ":" in expanded_userinfo:
+    elif ":" in expanded_userinfo:
         raw_user, _, raw_pass = expanded_userinfo.partition(":")
         encoded_userinfo = (
             f"{quote(raw_user, safe='')}:{quote(raw_pass, safe='')}"

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -904,3 +904,161 @@ def test_detect_info_falls_back_to_shell_env_when_shellingham_fails():
         name, path = detect_info(mock_project)
         assert name == "bash"
         assert path == "/bin/bash"
+
+
+
+# --- Regression tests for argparse migration (GH-6628, GH-6626) ---
+
+
+@pytest.mark.core
+def test_python_flag_before_subcommand_is_preserved():
+    """Regression test for GH-6628: ``pipenv --python 3.11 sync`` must not
+    lose the ``--python`` value when the subparser's default overwrites it.
+    """
+    from pipenv.cli.options import build_parser
+
+    parser = build_parser()
+    args, _ = parser.parse_known_args(["--python", "3.11", "sync"])
+
+    # Fill in SUPPRESS defaults the same way cli() does.
+    for attr in ("python", "pypi_mirror", "verbose", "quiet", "clear", "system"):
+        if not hasattr(args, attr):
+            setattr(args, attr, None)
+
+    assert args.python == "3.11"
+
+
+@pytest.mark.core
+def test_python_flag_after_subcommand_is_preserved():
+    """Regression test for GH-6628: ``pipenv sync --python 3.11`` must work."""
+    from pipenv.cli.options import build_parser
+
+    parser = build_parser()
+    args, _ = parser.parse_known_args(["sync", "--python", "3.11"])
+
+    for attr in ("python", "pypi_mirror", "verbose", "quiet", "clear", "system"):
+        if not hasattr(args, attr):
+            setattr(args, attr, None)
+
+    assert args.python == "3.11"
+
+
+@pytest.mark.core
+def test_python_flag_defaults_to_none_when_absent():
+    """When ``--python`` is not provided at all, state.python must be None."""
+    from pipenv.cli.options import build_parser
+
+    parser = build_parser()
+    args, _ = parser.parse_known_args(["sync"])
+
+    for attr in ("python", "pypi_mirror", "verbose", "quiet", "clear", "system"):
+        if not hasattr(args, attr):
+            setattr(args, attr, None)
+
+    assert args.python is None
+
+
+@pytest.mark.core
+def test_run_passes_verbose_to_remaining():
+    """Regression test for GH-6626: ``pipenv run ./manage.py test --verbose``
+    must put ``--verbose`` into *remaining*, not consume it as a pipenv flag.
+    """
+    from pipenv.cli.options import build_parser
+
+    parser = build_parser()
+    args, remaining = parser.parse_known_args(
+        ["run", "./manage.py", "test", "--verbose"]
+    )
+    assert "--verbose" in remaining
+
+
+@pytest.mark.core
+def test_run_passes_short_v_to_remaining():
+    """Regression test for GH-6626: ``-v`` after the run command must be
+    passed through to the user's process.
+    """
+    from pipenv.cli.options import build_parser
+
+    parser = build_parser()
+    args, remaining = parser.parse_known_args(
+        ["run", "./manage.py", "test", "-v"]
+    )
+    assert "-v" in remaining
+
+
+@pytest.mark.core
+def test_run_passes_quiet_to_remaining():
+    """Regression test for GH-6626: ``--quiet`` / ``-q`` must pass through."""
+    from pipenv.cli.options import build_parser
+
+    parser = build_parser()
+    args, remaining = parser.parse_known_args(
+        ["run", "pytest", "-q", "--tb=short"]
+    )
+    assert "-q" in remaining
+    assert "--tb=short" in remaining
+
+
+@pytest.mark.core
+def test_run_system_flag_still_works():
+    """``pipenv run --system python -c '...'`` must still recognise --system."""
+    from pipenv.cli.options import build_parser
+
+    parser = build_parser()
+    args, remaining = parser.parse_known_args(
+        ["run", "--system", "python", "-c", "print('hi')"]
+    )
+
+    for attr in ("python", "pypi_mirror", "verbose", "quiet", "clear", "system"):
+        if not hasattr(args, attr):
+            setattr(args, attr, None)
+
+    assert args.system is True
+    assert args.run_command == "python"
+    assert remaining == ["-c", "print('hi')"]
+
+
+# --- Regression test for shell history pollution (GH-6627) ---
+
+
+@pytest.mark.core
+def test_fork_compat_sendline_commands_have_leading_space():
+    """Regression test for GH-6627: internal sendline commands in fork_compat
+    must be prefixed with a space so they are not recorded in shell history
+    (most shells honour HISTCONTROL=ignorespace by default).
+    """
+    from pipenv.shells import Shell
+
+    shell = Shell("/bin/bash")
+
+    mock_child = MagicMock()
+    mock_child.setecho.return_value = None
+    mock_child.expect.return_value = 0
+    mock_child.interact.return_value = None
+    mock_child.exitstatus = 0
+
+    sent_lines = []
+
+    def _sendline(line):
+        sent_lines.append(line)
+
+    mock_child.sendline.side_effect = _sendline
+
+    with patch("pipenv.vendor.pexpect.spawn", return_value=mock_child), \
+         patch("pipenv.shells._get_activate_script",
+               return_value=" source /venv/bin/activate"), \
+         patch("pipenv.shells._get_deactivate_wrapper_script",
+               return_value='eval "deactivate() { builtin deactivate; }"'), \
+         patch("pipenv.shells.get_terminal_size") as mock_size, \
+         patch("pipenv.shells.temp_environ"), \
+         patch("pipenv.shells.signal.signal"), \
+         patch("sys.exit"):
+        mock_size.return_value = MagicMock(lines=24, columns=80)
+
+        shell.fork_compat("/path/to/venv", "/project", [])
+
+    # Every internal sendline must start with a space.
+    for line in sent_lines:
+        assert line.startswith(" "), (
+            f"sendline {line!r} must start with a space to avoid history pollution"
+        )

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -2170,10 +2170,11 @@ def test_expand_url_credentials_literal_credentials():
 
 @pytest.mark.utils
 def test_expand_url_credentials_unset_var_left_unchanged():
-    """An unset env var is left as its raw ``${VAR}`` token (URL-encoded)."""
+    """An unset env var must be left as its raw ``${VAR}`` token — not
+    percent-encoded — so it can still be expanded later.
+    """
     result = shell.expand_url_credentials(
         "https://${NONEXISTENT_VAR_12345}@pypi.example.com/simple"
     )
-    # The raw token is preserved but URL-encoded in the userinfo position.
-    assert "pypi.example.com" in result
-    assert "@pypi.example.com" in result
+    # The raw placeholder must survive intact (no %24, %7B, %7D encoding).
+    assert "${NONEXISTENT_VAR_12345}@" in result

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -2117,3 +2117,63 @@ class TestResolverCreateCrossGroupIndexLookup:
         assert index_lookup.get("shared-lib") == "testpypi", (
             "Current category's index must not be overridden by another section's entry."
         )
+
+
+
+# --- Regression tests for env-var expansion in source URLs (GH-6625) ---
+
+
+@pytest.mark.utils
+def test_expand_url_credentials_single_token_with_colon(monkeypatch):
+    """Regression test for GH-6625: a single ``${TOKEN}`` env var whose value
+    contains ``user:password`` must keep the ``:`` as the URL delimiter, not
+    URL-encode it to ``%3A``.
+    """
+    monkeypatch.setenv("MY_TOKEN", "__token__:glpat-secret123")
+
+    result = shell.expand_url_credentials(
+        "https://${MY_TOKEN}@gitlab.example.com/api/v4/projects/123/packages/pypi/simple"
+    )
+    assert "__token__:glpat-secret123@" in result
+    assert "%3A" not in result  # colon must NOT be encoded
+
+
+@pytest.mark.utils
+def test_expand_url_credentials_separate_user_and_password(monkeypatch):
+    """Standard ``${USER}:${PASS}`` syntax must still work and URL-encode
+    special characters in each part independently.
+    """
+    monkeypatch.setenv("MY_USER", "myuser")
+    monkeypatch.setenv("MY_PASS", "p@ssw0rd!")
+
+    result = shell.expand_url_credentials(
+        "https://${MY_USER}:${MY_PASS}@pypi.example.com/simple"
+    )
+    assert "myuser:" in result
+    assert "p%40ssw0rd%21" in result  # @ → %40, ! → %21
+
+
+@pytest.mark.utils
+def test_expand_url_credentials_no_auth():
+    """A URL without credentials must be returned unchanged (plain expansion)."""
+    result = shell.expand_url_credentials("https://pypi.org/simple")
+    assert result == "https://pypi.org/simple"
+
+
+@pytest.mark.utils
+def test_expand_url_credentials_literal_credentials():
+    """Literal (non-env-var) credentials must pass through unchanged."""
+    url = "https://user:pass@pypi.example.com/simple"
+    result = shell.expand_url_credentials(url)
+    assert result == url
+
+
+@pytest.mark.utils
+def test_expand_url_credentials_unset_var_left_unchanged():
+    """An unset env var is left as its raw ``${VAR}`` token (URL-encoded)."""
+    result = shell.expand_url_credentials(
+        "https://${NONEXISTENT_VAR_12345}@pypi.example.com/simple"
+    )
+    # The raw token is preserved but URL-encoded in the userinfo position.
+    assert "pypi.example.com" in result
+    assert "@pypi.example.com" in result


### PR DESCRIPTION
## Summary

Fixes five reported issues in a single PR — most are regressions from the Click → argparse migration.

### Fixes

- **#6628** — `--python` flag ignored during `sync` (and other subcommands when passed before the subcommand). Shared CLI options now use `argparse.SUPPRESS` as their default so subparser defaults never overwrite values already parsed by the root parser.

- **#6626** — `pipenv run` no longer passes all arguments to the target process. Removed `_add_common_options()` from the `run` subparser so flags like `--verbose`, `-v`, `--quiet`, `--python` are passed through to the user's command instead of being consumed by argparse.

- **#6625** — `Could not find a version that satisfies the requirement` when installing from a private GitLab Package Repository using `${TOKEN}` env var containing `user:password`. Fixed `expand_url_credentials()` to expand env vars *before* splitting on `:` to separate username from password.

- **#6627** — `pipenv shell` adds unexpected lines to command history. Prefixed all internal `sendline()` commands with a space character to leverage `HISTCONTROL=ignorespace` (the default on most distributions).

- **#6167** — Fedora 40 dropped the `pipenv` package. Removed the Fedora `dnf install pipenv` instructions from `docs/installation.md`.

### Testing

- All 398 unit tests pass
- Manual verification of argparse flag propagation (`--python 3.11 sync`, `sync --python 3.11`)
- Manual verification that `pipenv run` passes `-v`/`--verbose` through to user commands
- Manual verification of URL credential expansion with single `${TOKEN}` containing `user:pass`

Closes #6628, closes #6626, closes #6625, closes #6627, closes #6167

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author