### PR TITLE
Skip fork_compat shell history test on Windows (no pexpect.spawn)

### DIFF
--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -1022,6 +1022,7 @@ def test_run_system_flag_still_works():
 
 
 @pytest.mark.core
+@pytest.mark.skipif(os.name == "nt", reason="PTY/pexpect not available on Windows")
 def test_fork_compat_sendline_commands_have_leading_space():
     """Regression test for GH-6627: internal sendline commands in fork_compat
     must be prefixed with a space so they are not recorded in shell history


### PR DESCRIPTION
Follow-up to #6629.

The `test_fork_compat_sendline_commands_have_leading_space` test (regression test for #6627) uses `pexpect.spawn` which is not available on Windows. Adds the same `@pytest.mark.skipif(os.name == "nt", ...)` guard used by the existing `test_fork_compat_*` tests.

Fixes the Windows CI failure.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author