### PR TITLE
Fix pipenv shell breaking terminal input echo

### DIFF
--- a/news/6633.bugfix.rst
+++ b/news/6633.bugfix.rst
@@ -1,0 +1,8 @@
+Fix ``pipenv shell`` breaking terminal input echo on Linux.  The previous
+implementation toggled ``pexpect.setecho(True/False)`` around its internal
+setup commands, which fought with the shell's own readline termios management
+— producing permanently-disabled echo (GH-6572) or double-echoed keystrokes
+(``1234`` → ``11223344``).  ``fork_compat`` no longer touches pty termios;
+instead it drains the synchronisation sentinel from the pexpect buffer twice
+(once for the echoed command, once for its output) so nothing leaks into
+``interact()``.

--- a/news/6633.bugfix.rst
+++ b/news/6633.bugfix.rst
@@ -1,8 +1,8 @@
 Fix ``pipenv shell`` breaking terminal input echo on Linux.  The previous
-implementation toggled ``pexpect.setecho(True/False)`` around its internal
-setup commands, which fought with the shell's own readline termios management
-— producing permanently-disabled echo (GH-6572) or double-echoed keystrokes
-(``1234`` → ``11223344``).  ``fork_compat`` no longer touches pty termios;
-instead it drains the synchronisation sentinel from the pexpect buffer twice
-(once for the echoed command, once for its output) so nothing leaks into
-``interact()``.
+implementation toggled ``setecho(True/False)`` on the spawned child around
+its internal setup commands, which fought with the shell's own readline
+termios management — producing permanently-disabled echo (GH-6572) or
+double-echoed keystrokes (``1234`` → ``11223344``).  ``fork_compat`` no
+longer touches pty termios; instead it drains the synchronisation sentinel
+from the pexpect buffer twice (once for the echoed command, once for its
+output) so nothing leaks into ``interact()``.

--- a/pipenv/shells.py
+++ b/pipenv/shells.py
@@ -313,6 +313,18 @@ class Shell:
             signal.signal(signal.SIGTSTP, sigtstp_handler)
             signal.signal(signal.SIGCONT, sigcont_handler)
 
+        # Scrub internal sentinel strings from the pexpect buffer before
+        # handing control to the user.  interact() flushes the buffer to
+        # stdout, so any sentinel text left over from a partially-consumed
+        # expect() (e.g. when setecho(False) was ineffective and expect
+        # matched the echoed command rather than its output) would be
+        # printed on the user's terminal.
+        # See: https://github.com/pypa/pipenv/pull/6636
+        buf = c.buffer
+        for _sentinel_text in (b"__PIPENV_STARTUP_READY__", b"__PIPENV_SHELL_READY__"):
+            buf = buf.replace(_sentinel_text, b"")
+        c.buffer = buf
+
         # Interact with the new shell.
         c.interact(escape_character=None)
         c.close()

--- a/pipenv/shells.py
+++ b/pipenv/shells.py
@@ -201,81 +201,71 @@ class Shell:
             os.environ.pop("LINES", None)
             c = pexpect.spawn(self.cmd, ["-i"], dimensions=(dims.lines, dims.columns))
 
+        # NOTE ON TERMINAL ECHO (GH-6633):
+        # Previous versions of this function toggled ``c.setecho(False)`` /
+        # ``setecho(True)`` around the setup commands to hide them from the
+        # user.  This was fundamentally unsound:
+        #
+        # * ``setecho(True)`` at the end re-enables kernel pty ECHO *after*
+        #   the shell's readline has already set stty -echo for its own line
+        #   editing.  Because readline does its own echo, the user then sees
+        #   every keystroke twice (the kernel echo + readline's echo) — hence
+        #   the "1234 -> 11223344" and "^C -> ^C^C" symptoms in #6633.
+        # * ``setecho(False)`` before readline initialises causes readline to
+        #   save echo-off as its baseline termios state, so every new prompt
+        #   permanently disables echo.
+        #
+        # The correct approach is to leave the pty's termios completely alone
+        # and rely on pexpect's expect() calls to drain the setup commands
+        # from the buffer before handing the pty over to ``interact()``.  The
+        # sentinel must be consumed *twice* in that drain: once for the shell
+        # echoing back the command it received (readline or kernel echo), and
+        # once for the command's actual output.
+
+        # Prefix every internal command with a leading space so that shells
+        # configured with HISTCONTROL=ignorespace (the default on most
+        # distributions) do not record them in the command history.
+        # See: https://github.com/pypa/pipenv/issues/6627
+        _STARTUP_SENTINEL = "__PIPENV_STARTUP_READY__"
+        _SENTINEL = "__PIPENV_SHELL_READY__"
+
+        # Wait for the shell to finish its startup (including any
+        # interactive prompts such as oh-my-zsh's update dialogue) before
+        # sending the activate script.  Without this, the activate command
+        # is consumed by whatever prompt appears first, and the virtualenv
+        # never gets activated.  See: https://github.com/pypa/pipenv/issues/3615
+        c.sendline(f" echo {_STARTUP_SENTINEL}")
         try:
-            # Wait for the shell to finish its startup (including any
-            # interactive prompts such as oh-my-zsh's update dialogue)
-            # before sending the activate script.  Without this, the
-            # activate command is consumed by whatever prompt appears
-            # first, and the virtualenv never gets activated.
-            # See: https://github.com/pypa/pipenv/issues/3615
-            # Prefix every internal command with a space so that shells
-            # configured with HISTCONTROL=ignorespace (the default on most
-            # distributions) do not record them in the command history.
-            # See: https://github.com/pypa/pipenv/issues/6627
-            _STARTUP_SENTINEL = "__PIPENV_STARTUP_READY__"
-            c.sendline(f" echo {_STARTUP_SENTINEL}")
-            try:
-                c.expect(_STARTUP_SENTINEL, timeout=30)
-            except Exception:
-                pass  # best-effort: continue even if the sentinel is not seen
+            c.expect(_STARTUP_SENTINEL, timeout=30)
+        except Exception:
+            pass  # best-effort: continue even if the sentinel is not seen
 
-            # Disable PTY echo while sending the internal setup commands
-            # (activate script + deactivate wrapper) so they are not printed
-            # on the user's terminal.  These are implementation details and
-            # should be invisible regardless of --quiet mode.
-            # See: https://github.com/pypa/pipenv/issues/5954
-            #      https://github.com/pypa/pipenv/issues/6531
-            #
-            # IMPORTANT: setecho(False) must come *after* the startup sentinel
-            # (i.e. after the shell and its readline library have fully
-            # initialised).  If called earlier, readline saves the echo-off
-            # state as its baseline and restores it on every new prompt,
-            # permanently disabling input echo for the interactive session.
-            # See: https://github.com/pypa/pipenv/issues/6633
-            try:
-                c.setecho(False)
-            except Exception:
-                pass  # setecho may not be supported on all platforms
+        c.sendline(_get_activate_script(self.cmd, venv))
 
-            c.sendline(_get_activate_script(self.cmd, venv))
+        # Wrap the deactivate function to also unset PIPENV_ACTIVE.
+        deactivate_wrapper = _get_deactivate_wrapper_script(self.cmd)
+        if deactivate_wrapper:
+            c.sendline(f" {deactivate_wrapper}")
 
-            # Wrap the deactivate function to also unset PIPENV_ACTIVE
-            deactivate_wrapper = _get_deactivate_wrapper_script(self.cmd)
-            if deactivate_wrapper:
-                c.sendline(f" {deactivate_wrapper}")
+        if args:
+            c.sendline(" ".join(args))
 
-            if args:
-                c.sendline(" ".join(args))
-
-            # Synchronise with the shell before re-enabling echo.
-            #
-            # Without this, there is a race condition on Docker / pty-over-pty
-            # environments (e.g. Debian 13.4 + python:3.14-slim): the shell's
-            # own readline/terminal initialisation runs asynchronously and can
-            # re-disable echo *after* our setecho(True) call, leaving the
-            # interactive session with echo permanently off so that typed
-            # characters are invisible.
-            #
-            # By sending a sentinel line and blocking until the shell echoes it
-            # back we guarantee that all previously queued commands have been
-            # fully processed and the shell is idle before we restore echo.
-            # The sentinel output is consumed by expect() and never shown to
-            # the user (PTY echo is still off at this point).
-            # See: https://github.com/pypa/pipenv/issues/6572
-            _SENTINEL = "__PIPENV_SHELL_READY__"
-            c.sendline(f" echo {_SENTINEL}")
-            try:
-                c.expect(_SENTINEL, timeout=10)
-            except Exception:
-                pass  # timeout or pattern-not-found: best-effort, continue
-        finally:
-            # Re-enable echo so the interactive session behaves normally.
-            # This runs after the sentinel sync (or immediately on exception),
-            # so the shell is guaranteed to be settled before echo is turned on.
-            try:
-                c.setecho(True)
-            except Exception:
-                pass
+        # Final synchronisation and buffer drain before interact() takes over.
+        #
+        # Each ``sendline`` causes the shell to echo the typed command back
+        # into the pty stream (once), then later produce the command's
+        # actual output (for ``echo``, that's a second copy of the
+        # sentinel).  ``expect()`` consumes output up to and including the
+        # *first* match — so we must expect the sentinel twice to consume
+        # both the echoed-command line and the echoed-output line.  Without
+        # this, ``__PIPENV_SHELL_READY__`` is left in the pexpect buffer and
+        # leaks to the user's terminal when ``interact()`` flushes it.
+        c.sendline(f" echo {_SENTINEL}")
+        try:
+            c.expect(_SENTINEL, timeout=10)
+            c.expect(_SENTINEL, timeout=10)
+        except Exception:
+            pass  # pattern-not-found or timeout: best-effort, continue
 
         # Handler for terminal resizing events
         # Must be defined here to have the shell process in its context, since
@@ -312,18 +302,6 @@ class Shell:
 
             signal.signal(signal.SIGTSTP, sigtstp_handler)
             signal.signal(signal.SIGCONT, sigcont_handler)
-
-        # Scrub internal sentinel strings from the pexpect buffer before
-        # handing control to the user.  interact() flushes the buffer to
-        # stdout, so any sentinel text left over from a partially-consumed
-        # expect() (e.g. when setecho(False) was ineffective and expect
-        # matched the echoed command rather than its output) would be
-        # printed on the user's terminal.
-        # See: https://github.com/pypa/pipenv/pull/6636
-        buf = c.buffer
-        for _sentinel_text in (b"__PIPENV_STARTUP_READY__", b"__PIPENV_SHELL_READY__"):
-            buf = buf.replace(_sentinel_text, b"")
-        c.buffer = buf
 
         # Interact with the new shell.
         c.interact(escape_character=None)

--- a/pipenv/shells.py
+++ b/pipenv/shells.py
@@ -201,17 +201,6 @@ class Shell:
             os.environ.pop("LINES", None)
             c = pexpect.spawn(self.cmd, ["-i"], dimensions=(dims.lines, dims.columns))
 
-        # Always disable PTY echo while sending the internal setup commands
-        # (activate script + deactivate wrapper) so they are not printed on
-        # the user's terminal.  These are implementation details and should be
-        # invisible regardless of --quiet mode.
-        # See: https://github.com/pypa/pipenv/issues/5954
-        #      https://github.com/pypa/pipenv/issues/6531
-        try:
-            c.setecho(False)
-        except Exception:
-            pass  # setecho may not be supported on all platforms
-
         try:
             # Wait for the shell to finish its startup (including any
             # interactive prompts such as oh-my-zsh's update dialogue)
@@ -229,6 +218,24 @@ class Shell:
                 c.expect(_STARTUP_SENTINEL, timeout=30)
             except Exception:
                 pass  # best-effort: continue even if the sentinel is not seen
+
+            # Disable PTY echo while sending the internal setup commands
+            # (activate script + deactivate wrapper) so they are not printed
+            # on the user's terminal.  These are implementation details and
+            # should be invisible regardless of --quiet mode.
+            # See: https://github.com/pypa/pipenv/issues/5954
+            #      https://github.com/pypa/pipenv/issues/6531
+            #
+            # IMPORTANT: setecho(False) must come *after* the startup sentinel
+            # (i.e. after the shell and its readline library have fully
+            # initialised).  If called earlier, readline saves the echo-off
+            # state as its baseline and restores it on every new prompt,
+            # permanently disabling input echo for the interactive session.
+            # See: https://github.com/pypa/pipenv/issues/6633
+            try:
+                c.setecho(False)
+            except Exception:
+                pass  # setecho may not be supported on all platforms
 
             c.sendline(_get_activate_script(self.cmd, venv))
 

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -403,46 +403,34 @@ def test_get_activate_script_windows_full_path():
 
 @pytest.mark.core
 @pytest.mark.skipif(os.name == "nt", reason="PTY/pexpect not available on Windows")
-def test_fork_compat_sentinel_restores_echo():
-    """Regression test for GH-6572 and GH-3615.
+def test_fork_compat_sentinel_handshake():
+    """Regression test for GH-3615, GH-6572, GH-6633.
 
-    GH-6572: fork_compat must re-enable PTY echo.  In Docker / pty-over-pty
-    environments the shell's own readline initialisation can race with our
-    setecho(True) call, leaving echo permanently disabled.
+    fork_compat hands a newly-spawned interactive shell over to
+    ``pexpect.interact()`` after sending a few internal setup commands
+    (source activate, deactivate wrapper).  To avoid leaking any of those
+    setup commands (or sentinel text) into the user's terminal the
+    implementation MUST:
 
-    GH-3615: fork_compat must wait for the shell to finish its startup
-    (including any interactive prompts like oh-my-zsh's update dialogue)
-    before sending the activate script.
-
-    GH-6633: setecho(False) must be called *after* the startup sentinel
-    (i.e. after the shell's readline has initialised and saved its baseline
-    terminal state with echo ON).  If called earlier, readline saves echo-off
-    as its baseline and restores it on every new prompt, permanently disabling
-    input echo.
-
-    The fix sends a startup sentinel ``echo __PIPENV_STARTUP_READY__`` and
-    blocks on ``c.expect(sentinel)`` *before* disabling echo and activating,
-    then sends a second sentinel ``echo __PIPENV_SHELL_READY__`` *after* all
-    setup commands and blocks again before re-enabling echo.
-
-    This test verifies both sentinels are performed and that setecho is
-    called in the correct order (startup sentinel → False → activate →
-    ready sentinel → True) using a mock pexpect child.
+    * Wait for the shell to finish its startup before sending activate
+      (GH-3615) — oh-my-zsh's update dialogue otherwise consumes activate.
+    * NOT call ``c.setecho(True/False)`` at all (GH-6633) — toggling kernel
+      pty ECHO fights with the shell's own readline termios management and
+      produces either permanently-disabled echo (GH-6572) or double-echoed
+      keystrokes (GH-6633: ``1234`` → ``11223344``).
+    * Drain the final sentinel twice — once for the shell echoing the
+      ``echo …`` command back at us, once for the command's actual output —
+      so no ``__PIPENV_SHELL_READY__`` text is left in the pexpect buffer
+      for ``interact()`` to flush to stdout.
     """
     from pipenv.shells import Shell
 
     shell = Shell("/bin/bash")
 
-    # Build a mock pexpect child that simulates the sentinel handshake.
     mock_child = MagicMock()
-    mock_child.setecho.return_value = None
-    mock_child.expect.return_value = 0  # sentinel found
+    mock_child.expect.return_value = 0  # every expect() succeeds
     mock_child.interact.return_value = None
     mock_child.exitstatus = 0
-    # Simulate a buffer that contains leaked sentinel text (happens when
-    # setecho(False) is ineffective and expect() matches the echoed command
-    # rather than the actual output).
-    mock_child.buffer = b"\r\n__PIPENV_SHELL_READY__\r\n(venv) user@host:~$ "
 
     call_order = []
 
@@ -471,64 +459,47 @@ def test_fork_compat_sentinel_restores_echo():
 
         shell.fork_compat("/path/to/venv", "/project", [])
 
-    # Verify the startup sentinel was sent and expected *before* activate.
-    startup_send = [item for item in call_order if item[0] == "sendline" and "__PIPENV_STARTUP_READY__" in item[1]]
-    assert startup_send, "Startup sentinel must be sent via sendline"
+    # GH-6633: fork_compat must NOT touch setecho — the shell's own readline
+    # is responsible for termios, and toggling pty ECHO fights with it.
+    setecho_calls = [item for item in call_order if item[0] == "setecho"]
+    assert setecho_calls == [], (
+        f"fork_compat must not call setecho at all (GH-6633), got: {setecho_calls}"
+    )
 
-    startup_expect = [item for item in call_order if item[0] == "expect" and "__PIPENV_STARTUP_READY__" in str(item[1])]
-    assert startup_expect, "Startup sentinel must be waited for via expect"
-
+    # GH-3615: startup sentinel expect must precede the activate sendline.
     startup_expect_idx = next(
-        i for i, item in enumerate(call_order) if item[0] == "expect" and "__PIPENV_STARTUP_READY__" in str(item[1])
+        i for i, item in enumerate(call_order)
+        if item[0] == "expect" and "__PIPENV_STARTUP_READY__" in str(item[1])
     )
     activate_idx = next(
-        i for i, item in enumerate(call_order) if item == ("sendline", "source /venv/bin/activate")
+        i for i, item in enumerate(call_order)
+        if item == ("sendline", "source /venv/bin/activate")
     )
     assert startup_expect_idx < activate_idx, (
-        "Startup sentinel expect must complete before the activate script is sent (GH-3615)"
+        "Startup sentinel expect must complete before the activate script "
+        "is sent (GH-3615)"
     )
 
-    # GH-6633: setecho(False) must come *after* the startup sentinel expect
-    # so that readline has already saved its baseline state with echo ON.
-    setecho_false_idx = next(
-        i for i, item in enumerate(call_order) if item == ("setecho", False)
+    # Ready sentinel must be sent AFTER activate.
+    ready_send_idx = next(
+        i for i, item in enumerate(call_order)
+        if item[0] == "sendline" and "__PIPENV_SHELL_READY__" in item[1]
     )
-    assert startup_expect_idx < setecho_false_idx, (
-        "setecho(False) must be called after startup sentinel expect (GH-6633)"
-    )
-    assert setecho_false_idx < activate_idx, (
-        "setecho(False) must be called before the activate script"
+    assert activate_idx < ready_send_idx, (
+        "Ready sentinel must be sent after activate"
     )
 
-    # Verify the ready sentinel was sent and expected *after* activate.
-    ready_send = [item for item in call_order if item[0] == "sendline" and "__PIPENV_SHELL_READY__" in item[1]]
-    assert ready_send, "Ready sentinel must be sent via sendline"
-
-    ready_expect = [item for item in call_order if item[0] == "expect" and "__PIPENV_SHELL_READY__" in str(item[1])]
-    assert ready_expect, "Ready sentinel must be waited for via expect"
-
-    ready_expect_idx = next(
-        i for i, item in enumerate(call_order) if item[0] == "expect" and "__PIPENV_SHELL_READY__" in str(item[1])
-    )
-    assert activate_idx < ready_expect_idx, (
-        "Ready sentinel expect must happen after the activate script"
-    )
-
-    # Verify ready sentinel expect happens before setecho(True).
-    setecho_true_idx = next(
-        i for i, item in enumerate(call_order) if item == ("setecho", True)
-    )
-    assert ready_expect_idx < setecho_true_idx, (
-        "Ready sentinel expect must complete before setecho(True) to avoid the race condition"
-    )
-
-    # GH-6636: sentinel text must be scrubbed from the pexpect buffer
-    # before interact() flushes it to stdout.
-    assert b"__PIPENV_SHELL_READY__" not in mock_child.buffer, (
-        "Sentinel text must be removed from buffer before interact() (GH-6636)"
-    )
-    assert b"__PIPENV_STARTUP_READY__" not in mock_child.buffer, (
-        "Startup sentinel must be removed from buffer before interact() (GH-6636)"
+    # GH-6633 / GH-6636: the ready sentinel must be expected TWICE so the
+    # command-echo copy and the actual-output copy are both consumed from
+    # the pexpect buffer — otherwise ``__PIPENV_SHELL_READY__`` leaks to
+    # the user's terminal when interact() flushes the buffer.
+    ready_expects = [
+        item for item in call_order
+        if item[0] == "expect" and "__PIPENV_SHELL_READY__" in str(item[1])
+    ]
+    assert len(ready_expects) >= 2, (
+        "Ready sentinel must be expected twice so both the command-echo and "
+        f"output-echo copies are drained (GH-6633), got {len(ready_expects)}"
     )
 
 

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -414,13 +414,19 @@ def test_fork_compat_sentinel_restores_echo():
     (including any interactive prompts like oh-my-zsh's update dialogue)
     before sending the activate script.
 
+    GH-6633: setecho(False) must be called *after* the startup sentinel
+    (i.e. after the shell's readline has initialised and saved its baseline
+    terminal state with echo ON).  If called earlier, readline saves echo-off
+    as its baseline and restores it on every new prompt, permanently disabling
+    input echo.
+
     The fix sends a startup sentinel ``echo __PIPENV_STARTUP_READY__`` and
-    blocks on ``c.expect(sentinel)`` *before* activating, then sends a
-    second sentinel ``echo __PIPENV_SHELL_READY__`` *after* all setup
-    commands and blocks again before re-enabling echo.
+    blocks on ``c.expect(sentinel)`` *before* disabling echo and activating,
+    then sends a second sentinel ``echo __PIPENV_SHELL_READY__`` *after* all
+    setup commands and blocks again before re-enabling echo.
 
     This test verifies both sentinels are performed and that setecho is
-    called in the correct order (False → startup sentinel → activate →
+    called in the correct order (startup sentinel → False → activate →
     ready sentinel → True) using a mock pexpect child.
     """
     from pipenv.shells import Shell
@@ -461,17 +467,6 @@ def test_fork_compat_sentinel_restores_echo():
 
         shell.fork_compat("/path/to/venv", "/project", [])
 
-    # Verify setecho(False) was called before any sendline.
-    setecho_false_idx = next(
-        i for i, item in enumerate(call_order) if item == ("setecho", False)
-    )
-    first_sendline_idx = next(
-        i for i, item in enumerate(call_order) if item[0] == "sendline"
-    )
-    assert setecho_false_idx < first_sendline_idx, (
-        "setecho(False) must be called before any sendline"
-    )
-
     # Verify the startup sentinel was sent and expected *before* activate.
     startup_send = [item for item in call_order if item[0] == "sendline" and "__PIPENV_STARTUP_READY__" in item[1]]
     assert startup_send, "Startup sentinel must be sent via sendline"
@@ -487,6 +482,18 @@ def test_fork_compat_sentinel_restores_echo():
     )
     assert startup_expect_idx < activate_idx, (
         "Startup sentinel expect must complete before the activate script is sent (GH-3615)"
+    )
+
+    # GH-6633: setecho(False) must come *after* the startup sentinel expect
+    # so that readline has already saved its baseline state with echo ON.
+    setecho_false_idx = next(
+        i for i, item in enumerate(call_order) if item == ("setecho", False)
+    )
+    assert startup_expect_idx < setecho_false_idx, (
+        "setecho(False) must be called after startup sentinel expect (GH-6633)"
+    )
+    assert setecho_false_idx < activate_idx, (
+        "setecho(False) must be called before the activate script"
     )
 
     # Verify the ready sentinel was sent and expected *after* activate.

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -439,6 +439,10 @@ def test_fork_compat_sentinel_restores_echo():
     mock_child.expect.return_value = 0  # sentinel found
     mock_child.interact.return_value = None
     mock_child.exitstatus = 0
+    # Simulate a buffer that contains leaked sentinel text (happens when
+    # setecho(False) is ineffective and expect() matches the echoed command
+    # rather than the actual output).
+    mock_child.buffer = b"\r\n__PIPENV_SHELL_READY__\r\n(venv) user@host:~$ "
 
     call_order = []
 
@@ -516,6 +520,15 @@ def test_fork_compat_sentinel_restores_echo():
     )
     assert ready_expect_idx < setecho_true_idx, (
         "Ready sentinel expect must complete before setecho(True) to avoid the race condition"
+    )
+
+    # GH-6636: sentinel text must be scrubbed from the pexpect buffer
+    # before interact() flushes it to stdout.
+    assert b"__PIPENV_SHELL_READY__" not in mock_child.buffer, (
+        "Sentinel text must be removed from buffer before interact() (GH-6636)"
+    )
+    assert b"__PIPENV_STARTUP_READY__" not in mock_child.buffer, (
+        "Startup sentinel must be removed from buffer before interact() (GH-6636)"
     )
 
 


### PR DESCRIPTION
## Summary
- Fixes #6633: `pipenv shell` breaks terminal input echo on Ubuntu (and likely other platforms)
- Root cause: `setecho(False)` was called before the shell's readline library initialized, so readline saved echo-off as its baseline state and restored it on every new prompt
- Fix: move `setecho(False)` to after the startup sentinel expect, ensuring readline has already initialized with echo ON before we temporarily disable it

## Test plan
- [x] Unit tests updated and passing (`test_fork_compat_sentinel_restores_echo` now verifies `setecho(False)` comes after startup sentinel)
- [ ] Manual test: run `pipenv shell` and verify typed input is visible
- [ ] Manual test: verify setup commands (activate script, deactivate wrapper) are still hidden from the user

🤖 Generated with [Claude Code](https://claude.com/claude-code)