### PR TITLE
Align Python version guidance with supported versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Table Of Contents
 Installation
 ------------
 
-**Pipenv can be installed with Python 3.7 and above.**
+**Pipenv can be installed with Python 3.10 and above.**
 
 For most users, we recommend installing Pipenv using `pip`:
 
@@ -191,8 +191,8 @@ Usage
 
    ### Usage Examples:
 
-      Create a new project using Python 3.7, specifically:
-      $ pipenv --python 3.7
+      Create a new project using Python 3.10, specifically:
+      $ pipenv --python 3.10
 
       Remove project virtualenv (inferred from current directory):
       $ pipenv --rm

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -36,7 +36,7 @@ Windows is **pipx**, which installs Pipenv in an isolated environment and makes 
 
 ### Recommended: pipx (Windows)
 
-1. **Install pipx** (requires Python 3.7+):
+1. **Install pipx** (use Python 3.10+ for Pipenv):
    ```powershell
    > python -m pip install --user pipx
    > python -m pipx ensurepath
@@ -390,7 +390,7 @@ If you encounter permission errors during installation:
 
 ### Python Version Compatibility
 
-Pipenv requires Python 3.7 or newer. If you're using an older version, you'll need to upgrade Python first.
+Pipenv requires Python 3.10 or newer. If you're using an older version, you'll need to upgrade Python first.
 
 ### pip Not Found
 


### PR DESCRIPTION

**Repo:** pypa/pipenv (⭐ 25000)
**Type:** docs
**Files changed:** 2
**Lines:** +5/-5

## What
Updated the public installation and usage docs so they match Pipenv's declared Python support floor in `pyproject.toml`. The patch changes the README installation note and example `pipenv --python` command from Python 3.7 to 3.10, and updates `docs/installation.md` to state that Pipenv requires Python 3.10+.

## Why
The existing docs contradicted the package metadata, which currently declares `requires-python = ">=3.10"`. That mismatch can mislead users on unsupported Python versions into trying to install or bootstrap Pipenv with 3.7, only to hit avoidable installation failures. This patch makes the first-run documentation consistent with the actual supported versions.

## Testing
Verified the changed documentation against `pyproject.toml` locally and checked the committed diff for the touched files. No automated tests were run because the change is docs-only.

## Risk
Low / Docs-only change that aligns existing guidance with repository metadata.
