### PR TITLE
perf: cache Pipfile parse, parallelize hash/candidate lookups, harden benchmark runner

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -228,7 +228,9 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: pipenv-benchmark-stats
-          path: benchmarks/stats.csv
+          path: |
+            benchmarks/stats.csv
+            benchmarks/benchmark-results.json
           retention-days: 30
 
   build:

--- a/Makefile
+++ b/Makefile
@@ -187,5 +187,5 @@ benchmark:
 
 .PHONY: benchmark-clean
 benchmark-clean:
-	cd benchmarks && rm -f requirements.txt Pipfile.lock stats.csv
+	cd benchmarks && rm -f requirements.txt Pipfile.lock stats.csv *-results.json
 	cd benchmarks && rm -rf timings/

--- a/benchmarks/.gitignore
+++ b/benchmarks/.gitignore
@@ -2,6 +2,8 @@
 requirements.txt
 Pipfile.lock
 stats.csv
+benchmark-results.json
+*-results.json
 
 # Timing data
 timings/

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -41,6 +41,11 @@ python benchmark.py update-cold        # Benchmark update with cold cache
 python benchmark.py update-warm        # Benchmark update with warm cache
 python benchmark.py add-package        # Benchmark adding a package
 python benchmark.py stats              # Generate stats.csv
+
+# Local diagnosis helpers
+python benchmark.py lock-warm --repeat 3
+python benchmark.py lock-warm --profile
+python benchmark.py update-warm --output-json update-results.json
 ```
 
 ### CI Integration
@@ -58,6 +63,7 @@ The benchmarks run automatically in GitHub Actions on the `ubuntu-latest` runner
 - `requirements.txt` - Downloaded from Sentry's requirements-base.txt during setup
 - `timings/` - Directory created during benchmarks to store timing data
 - `stats.csv` - Generated CSV with benchmark results
+- `benchmark-results.json` - Per-run command timings for local/CI comparison
 
 ## Dependencies
 
@@ -74,4 +80,6 @@ The benchmark uses Sentry's `requirements-base.txt` as a representative real-wor
 - Benchmarks only run on Linux in CI to ensure consistent timing measurements
 - System dependencies (libxmlsec1-dev, librdkafka-dev) are installed for Sentry requirements
 - Cache clearing ensures cold/warm scenarios are properly tested
-- Results include CPU time, memory usage, and I/O statistics
+- `python benchmark.py` reuses an existing local `requirements.txt`; pass `--force-setup` to re-download it
+- Results include elapsed time, CPU time, memory usage, and I/O statistics where the platform exposes them
+- `--profile` writes `.prof` files under `timings/` and keeps pipenv resolver work in-process for easier local profiling

--- a/benchmarks/benchmark.py
+++ b/benchmarks/benchmark.py
@@ -114,7 +114,10 @@ def _usage_delta(
     cpu_percent = ((user + system) / elapsed * 100.0) if elapsed else 0.0
     inputs = max(after.ru_inblock - before.ru_inblock, 0)
     outputs = max(after.ru_oublock - before.ru_oublock, 0)
-    return system, user, cpu_percent, int(after.ru_maxrss), int(inputs), int(outputs)
+    # ru_maxrss from RUSAGE_CHILDREN is a cumulative high-water mark across
+    # child processes, not a per-command measurement, so do not report it as
+    # if it belonged to the command being benchmarked.
+    return system, user, cpu_percent, 0, int(inputs), int(outputs)
 
 
 class PipenvBenchmark:

--- a/benchmarks/benchmark.py
+++ b/benchmarks/benchmark.py
@@ -2,55 +2,231 @@
 """
 Pipenv benchmark runner based on python-package-manager-shootout.
 """
+
+from __future__ import annotations
+
+import argparse
 import csv
+import json
 import os
 import shutil
+import statistics
 import subprocess
 import sys
 import time
 import urllib.request
+from dataclasses import asdict, dataclass
 from pathlib import Path
-from typing import List, Tuple
+
+try:
+    import resource
+except ImportError:  # pragma: no cover - Windows
+    resource = None
 
 
-def subprocess_env():
+OPERATIONS = (
+    "setup",
+    "tooling",
+    "import",
+    "lock-cold",
+    "lock-warm",
+    "install-cold",
+    "install-warm",
+    "update-cold",
+    "update-warm",
+    "add-package",
+    "stats",
+)
+
+TIMED_STATS = (
+    "tooling",
+    "import",
+    "lock-cold",
+    "lock-warm",
+    "install-cold",
+    "install-warm",
+    "update-cold",
+    "update-warm",
+    "add-package",
+)
+
+
+def subprocess_env(profile_resolver: bool = False):
     """Get environment variables for subprocess calls with CI-friendly settings."""
     env = os.environ.copy()
-    # Ensure pipenv doesn't wait for user input
+    # Ensure pipenv doesn't wait for user input.
     env["PIPENV_YES"] = "1"
     env["PIPENV_NOSPIN"] = "1"
-    # Force pipenv to create its own venv, not use any existing one
+    # Force pipenv to create its own venv, not use any existing one.
     env["PIPENV_IGNORE_VIRTUALENVS"] = "1"
-    # Suppress courtesy notices
+    # Suppress courtesy notices.
     env["PIPENV_VERBOSITY"] = "-1"
+    if profile_resolver:
+        # Keep resolver work in the profiled parent process for local diagnosis.
+        env["PIPENV_RESOLVER_PARENT_PYTHON"] = "1"
     return env
 
 
+@dataclass
+class TimingRecord:
+    stat: str
+    iteration: int
+    command: list[str]
+    elapsed_time: float
+    system: float
+    user: float
+    cpu_percent: float
+    max_rss: int
+    inputs: int
+    outputs: int
+    returncode: int
+    profile: str | None = None
+
+    def timing_values(self) -> list[str]:
+        return [
+            f"{self.elapsed_time:.3f}",
+            f"{self.system:.3f}",
+            f"{self.user:.3f}",
+            f"{self.cpu_percent:.1f}",
+            str(self.max_rss),
+            str(self.inputs),
+            str(self.outputs),
+        ]
+
+    def timing_line(self) -> str:
+        return ",".join(self.timing_values()) + "\n"
+
+
+def _usage_snapshot():
+    if resource is None:
+        return None
+    return resource.getrusage(resource.RUSAGE_CHILDREN)
+
+
+def _usage_delta(
+    before, after, elapsed: float
+) -> tuple[float, float, float, int, int, int]:
+    if before is None or after is None:
+        return 0.0, 0.0, 0.0, 0, 0, 0
+
+    user = max(after.ru_utime - before.ru_utime, 0.0)
+    system = max(after.ru_stime - before.ru_stime, 0.0)
+    cpu_percent = ((user + system) / elapsed * 100.0) if elapsed else 0.0
+    inputs = max(after.ru_inblock - before.ru_inblock, 0)
+    outputs = max(after.ru_oublock - before.ru_oublock, 0)
+    return system, user, cpu_percent, int(after.ru_maxrss), int(inputs), int(outputs)
+
+
 class PipenvBenchmark:
-    def __init__(self, benchmark_dir: Path):
+    def __init__(
+        self,
+        benchmark_dir: Path,
+        *,
+        profile: bool = False,
+        output_json: Path | None = None,
+        force_setup: bool = False,
+    ):
         self.benchmark_dir = benchmark_dir
         self.timings_dir = benchmark_dir / "timings"
         self.timings_dir.mkdir(exist_ok=True)
-        self.requirements_url = "https://raw.githubusercontent.com/getsentry/sentry/51281a6abd8ff4a93d2cebc04e1d5fc7aa9c4c11/requirements-base.txt"
+        self.requirements_url = (
+            "https://raw.githubusercontent.com/getsentry/sentry/"
+            "51281a6abd8ff4a93d2cebc04e1d5fc7aa9c4c11/requirements-base.txt"
+        )
         self.test_package = "goodconf"
+        self.profile = profile
+        self.output_json = output_json
+        self.force_setup = force_setup
+        self.records: list[TimingRecord] = []
+        self.timing_samples: dict[str, list[TimingRecord]] = {}
+
+    def _profiled_command(
+        self, command: list[str], timing_file: str, iteration: int
+    ) -> tuple[list[str], Path | None, bool]:
+        if not self.profile:
+            return command, None, False
+
+        stat = timing_file.removesuffix(".txt")
+        profile_path = self.timings_dir / f"{stat}.{iteration}.prof"
+
+        if command and command[0] == "pipenv":
+            profiled = [
+                sys.executable,
+                "-m",
+                "cProfile",
+                "-o",
+                str(profile_path),
+                "-m",
+                "pipenv",
+                *command[1:],
+            ]
+            return profiled, profile_path, True
+
+        if command and Path(command[0]).resolve() == Path(sys.executable).resolve():
+            profiled = [
+                sys.executable,
+                "-m",
+                "cProfile",
+                "-o",
+                str(profile_path),
+                *command[1:],
+            ]
+            return profiled, profile_path, False
+
+        return command, None, False
+
+    def _write_timing_file(self, path: Path, values: list[str]) -> None:
+        with open(path, "w") as f:
+            f.write(",".join(values) + "\n")
+
+    def _record_timing(self, record: TimingRecord, timing_file: str) -> None:
+        self.records.append(record)
+        samples = self.timing_samples.setdefault(record.stat, [])
+        samples.append(record)
+
+        self._write_timing_file(
+            self.timings_dir / f"{record.stat}.{record.iteration}.txt",
+            record.timing_values(),
+        )
+
+        aggregate_values = [
+            f"{statistics.median(sample.elapsed_time for sample in samples):.3f}",
+            f"{statistics.median(sample.system for sample in samples):.3f}",
+            f"{statistics.median(sample.user for sample in samples):.3f}",
+            f"{statistics.median(sample.cpu_percent for sample in samples):.1f}",
+            str(int(statistics.median(sample.max_rss for sample in samples))),
+            str(int(statistics.median(sample.inputs for sample in samples))),
+            str(int(statistics.median(sample.outputs for sample in samples))),
+        ]
+        self._write_timing_file(self.timings_dir / timing_file, aggregate_values)
 
     def run_timed_command(
-        self, command: List[str], timing_file: str, cwd: Path = None, timeout: int = 600
-    ) -> Tuple[float, int]:
+        self,
+        command: list[str],
+        timing_file: str,
+        cwd: Path | None = None,
+        timeout: int = 600,
+    ) -> tuple[float, int]:
         """Run a command and measure execution time."""
         if cwd is None:
             cwd = self.benchmark_dir
 
-        # Set environment to prevent interactive prompts
-        env = subprocess_env()
+        stat = timing_file.removesuffix(".txt")
+        iteration = len(self.timing_samples.get(stat, [])) + 1
+        command_to_run, profile_path, profile_resolver = self._profiled_command(
+            command, timing_file, iteration
+        )
 
-        print(f"  Running: {' '.join(command)}", flush=True)
-        start_time = time.time()
+        env = subprocess_env(profile_resolver=profile_resolver)
+
+        print(f"  Running: {' '.join(command_to_run)}", flush=True)
+        before_usage = _usage_snapshot()
+        start_time = time.perf_counter()
 
         # Use Popen with communicate() to avoid pipe buffer deadlock
-        # that can occur with capture_output=True on commands with lots of output
+        # that can occur with capture_output=True on commands with lots of output.
         process = subprocess.Popen(
-            command,
+            command_to_run,
             cwd=cwd,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
@@ -60,11 +236,18 @@ class PipenvBenchmark:
 
         try:
             stdout, stderr = process.communicate(timeout=timeout)
-            elapsed = time.time() - start_time
+            elapsed = time.perf_counter() - start_time
+            after_usage = _usage_snapshot()
             returncode = process.returncode
+            system, user, cpu_percent, max_rss, inputs, outputs = _usage_delta(
+                before_usage, after_usage, elapsed
+            )
 
             if returncode != 0:
-                print(f"  ✗ Command failed after {elapsed:.3f}s: {' '.join(command)}")
+                print(
+                    f"  Command failed after {elapsed:.3f}s: "
+                    f"{' '.join(command_to_run)}"
+                )
                 print(f"  Return code: {returncode}")
                 if stderr and stderr.strip():
                     print("  Error output:")
@@ -74,18 +257,30 @@ class PipenvBenchmark:
                     print("  Stdout:")
                     for line in stdout.strip().split("\n"):
                         print(f"    {line}")
-                raise subprocess.CalledProcessError(returncode, command, stdout, stderr)
+                raise subprocess.CalledProcessError(
+                    returncode, command_to_run, stdout, stderr
+                )
 
-            # Write timing info (simplified format for cross-platform compatibility)
-            timing_path = self.timings_dir / timing_file
-            with open(timing_path, "w") as f:
-                f.write(
-                    f"{elapsed:.3f},0,0,0,0,0,0\n"
-                )  # elapsed,system,user,cpu%,maxrss,inputs,outputs
+            record = TimingRecord(
+                stat=stat,
+                iteration=iteration,
+                command=command_to_run,
+                elapsed_time=elapsed,
+                system=system,
+                user=user,
+                cpu_percent=cpu_percent,
+                max_rss=max_rss,
+                inputs=inputs,
+                outputs=outputs,
+                returncode=returncode,
+                profile=str(profile_path) if profile_path else None,
+            )
+            self._record_timing(record, timing_file)
 
-            print(f"  ✓ Completed in {elapsed:.3f}s")
+            print(f"  Completed in {elapsed:.3f}s")
+            if profile_path:
+                print(f"  Profile written to {profile_path}")
             if stdout and stdout.strip():
-                # Show first few lines of output
                 output_lines = stdout.strip().split("\n")[:3]
                 for line in output_lines:
                     print(f"    {line[:100]}")
@@ -97,8 +292,8 @@ class PipenvBenchmark:
         except subprocess.TimeoutExpired:
             process.kill()
             stdout, stderr = process.communicate()
-            elapsed = time.time() - start_time
-            print(f"  ✗ Command timed out after {elapsed:.3f}s: {' '.join(command)}")
+            elapsed = time.perf_counter() - start_time
+            print(f"  Command timed out after {elapsed:.3f}s: {' '.join(command_to_run)}")
             print(f"  Timeout was set to {timeout}s")
             if stdout and stdout.strip():
                 print("  Stdout before timeout:")
@@ -115,11 +310,15 @@ class PipenvBenchmark:
         print("Setting up requirements.txt...")
         requirements_path = self.benchmark_dir / "requirements.txt"
 
+        if requirements_path.exists() and not self.force_setup:
+            print(f"Reusing existing {requirements_path}")
+            return
+
         try:
             with urllib.request.urlopen(self.requirements_url) as response:
                 content = response.read().decode("utf-8")
 
-            # Filter out --index-url lines like the original
+            # Filter out --index-url lines like the original.
             filtered_lines = [
                 line
                 for line in content.splitlines()
@@ -148,7 +347,6 @@ class PipenvBenchmark:
         """Clean virtual environment."""
         print("Cleaning virtual environment...")
         try:
-            # Get venv path
             result = subprocess.run(
                 ["pipenv", "--venv"],
                 cwd=self.benchmark_dir,
@@ -169,7 +367,6 @@ class PipenvBenchmark:
             print("  Warning: pipenv --venv timed out")
         except Exception as e:
             print(f"  Warning: Could not clean venv: {e}")
-            pass  # Ignore errors if venv doesn't exist
 
     def clean_lock(self):
         """Remove Pipfile.lock."""
@@ -179,9 +376,8 @@ class PipenvBenchmark:
             lock_file.unlink()
 
     def benchmark_tooling(self):
-        """Benchmark pipenv installation (using current dev version)."""
+        """Benchmark pipenv installation using the current development version."""
         print("Benchmarking tooling...")
-        # Install current development version
         parent_dir = self.benchmark_dir.parent
         elapsed, _ = self.run_timed_command(
             [sys.executable, "-m", "pip", "install", "-e", str(parent_dir)], "tooling.txt"
@@ -211,7 +407,9 @@ class PipenvBenchmark:
     def benchmark_update(self, timing_file: str):
         """Benchmark package updates."""
         print(f"Benchmarking update ({timing_file})...")
-        elapsed, _ = self.run_timed_command(["pipenv", "update"], timing_file)
+        elapsed, _ = self.run_timed_command(
+            ["pipenv", "update"], timing_file, timeout=900
+        )
         print(f"Update completed in {elapsed:.3f}s")
 
     def benchmark_add_package(self):
@@ -233,7 +431,6 @@ class PipenvBenchmark:
                 timeout=30,
                 env=subprocess_env(),
             )
-            # Extract version from "pipenv, version X.X.X"
             return result.stdout.split()[-1]
         except Exception:
             return "unknown"
@@ -264,26 +461,63 @@ class PipenvBenchmark:
                 ]
             )
 
-            stats = [
-                "tooling",
-                "import",
-                "lock-cold",
-                "lock-warm",
-                "install-cold",
-                "install-warm",
-                "update-cold",
-                "update-warm",
-                "add-package",
-            ]
-
-            for stat in stats:
+            for stat in TIMED_STATS:
                 timing_file = self.timings_dir / f"{stat}.txt"
                 if timing_file.exists():
                     with open(timing_file) as f:
-                        timing_data = f.read().strip()
-                    writer.writerow(["pipenv", version, timestamp, stat, timing_data])
+                        timing_data = f.read().strip().split(",")
+                    writer.writerow(["pipenv", version, timestamp, stat] + timing_data)
 
         print(f"Stats written to {stats_file}")
+
+    def write_json_results(self):
+        if not self.output_json:
+            return
+
+        payload = {
+            "tool": "pipenv",
+            "version": self.get_pipenv_version(),
+            "generated_at": int(time.time()),
+            "records": [asdict(record) for record in self.records],
+        }
+        with open(self.output_json, "w") as f:
+            json.dump(payload, f, indent=2)
+            f.write("\n")
+        print(f"JSON results written to {self.output_json}")
+
+    def run_operation(self, operation: str):
+        if operation == "setup":
+            self.setup_requirements()
+        elif operation == "tooling":
+            self.benchmark_tooling()
+        elif operation == "import":
+            self.benchmark_import()
+        elif operation == "lock-cold":
+            self.clean_cache()
+            self.clean_venv()
+            self.clean_lock()
+            self.benchmark_lock("lock-cold.txt")
+        elif operation == "lock-warm":
+            self.clean_lock()
+            self.benchmark_lock("lock-warm.txt")
+        elif operation == "install-cold":
+            self.clean_cache()
+            self.clean_venv()
+            self.benchmark_install("install-cold.txt")
+        elif operation == "install-warm":
+            self.clean_venv()
+            self.benchmark_install("install-warm.txt")
+        elif operation == "update-cold":
+            self.clean_cache()
+            self.benchmark_update("update-cold.txt")
+        elif operation == "update-warm":
+            self.benchmark_update("update-warm.txt")
+        elif operation == "add-package":
+            self.benchmark_add_package()
+        elif operation == "stats":
+            self.generate_stats()
+        else:
+            raise ValueError(f"Unknown operation: {operation}")
 
     def run_full_benchmark(self):
         """Run the complete benchmark suite."""
@@ -291,117 +525,98 @@ class PipenvBenchmark:
         print("Starting pipenv benchmark suite...")
         print("=" * 60)
 
-        total_steps = 11
+        steps = [
+            ("Setup", "setup"),
+            ("Tooling", "tooling"),
+            ("Import", "import"),
+            ("Lock (cold)", "lock-cold"),
+            ("Lock (warm)", "lock-warm"),
+            ("Install (cold)", "install-cold"),
+            ("Install (warm)", "install-warm"),
+            ("Update (cold)", "update-cold"),
+            ("Update (warm)", "update-warm"),
+            ("Add package", "add-package"),
+            ("Generate stats", "stats"),
+        ]
 
-        # Setup
-        print(f"\n[1/{total_steps}] Setup")
-        print("-" * 40)
-        self.setup_requirements()
-
-        # Tooling
-        print(f"\n[2/{total_steps}] Tooling")
-        print("-" * 40)
-        self.benchmark_tooling()
-
-        # Import
-        print(f"\n[3/{total_steps}] Import")
-        print("-" * 40)
-        self.benchmark_import()
-
-        # Lock cold
-        print(f"\n[4/{total_steps}] Lock (cold)")
-        print("-" * 40)
-        self.clean_cache()
-        self.clean_venv()
-        self.clean_lock()
-        self.benchmark_lock("lock-cold.txt")
-
-        # Lock warm
-        print(f"\n[5/{total_steps}] Lock (warm)")
-        print("-" * 40)
-        self.clean_lock()
-        self.benchmark_lock("lock-warm.txt")
-
-        # Install cold
-        print(f"\n[6/{total_steps}] Install (cold)")
-        print("-" * 40)
-        self.clean_cache()
-        self.clean_venv()
-        self.benchmark_install("install-cold.txt")
-
-        # Install warm
-        print(f"\n[7/{total_steps}] Install (warm)")
-        print("-" * 40)
-        self.clean_venv()
-        self.benchmark_install("install-warm.txt")
-
-        # Update cold
-        print(f"\n[8/{total_steps}] Update (cold)")
-        print("-" * 40)
-        self.clean_cache()
-        self.benchmark_update("update-cold.txt")
-
-        # Update warm
-        print(f"\n[9/{total_steps}] Update (warm)")
-        print("-" * 40)
-        self.benchmark_update("update-warm.txt")
-
-        # Add package
-        print(f"\n[10/{total_steps}] Add package")
-        print("-" * 40)
-        self.benchmark_add_package()
-
-        # Generate stats
-        print(f"\n[11/{total_steps}] Generate stats")
-        print("-" * 40)
-        self.generate_stats()
+        for index, (label, operation) in enumerate(steps, start=1):
+            print(f"\n[{index}/{len(steps)}] {label}")
+            print("-" * 40)
+            self.run_operation(operation)
 
         print("\n" + "=" * 60)
         print("Benchmark suite completed!")
         print("=" * 60)
 
 
-def main():
-    benchmark_dir = Path(__file__).parent
-    benchmark = PipenvBenchmark(benchmark_dir)
+def parse_args(argv=None):
+    parser = argparse.ArgumentParser(description="Run pipenv package-manager benchmarks.")
+    parser.add_argument(
+        "operation",
+        nargs="?",
+        default="all",
+        choices=("all", *OPERATIONS),
+        help="Benchmark operation to run. Defaults to the full suite.",
+    )
+    parser.add_argument(
+        "--repeat",
+        type=int,
+        default=1,
+        help="Repeat the selected operation or full suite and store median timings.",
+    )
+    parser.add_argument(
+        "--profile",
+        action="store_true",
+        help=(
+            "Capture cProfile files in timings/. For pipenv commands, "
+            "resolver work is kept in-process."
+        ),
+    )
+    parser.add_argument(
+        "--output-json",
+        type=Path,
+        default=Path("benchmark-results.json"),
+        help="Write per-run timing records to this JSON file.",
+    )
+    parser.add_argument(
+        "--no-json",
+        action="store_true",
+        help="Do not write benchmark-results.json.",
+    )
+    parser.add_argument(
+        "--force-setup",
+        action="store_true",
+        help="Download requirements.txt even when a local copy already exists.",
+    )
+    args = parser.parse_args(argv)
+    if args.repeat < 1:
+        parser.error("--repeat must be at least 1")
+    return args
 
-    if len(sys.argv) > 1:
-        operation = sys.argv[1]
-        if operation == "setup":
-            benchmark.setup_requirements()
-        elif operation == "tooling":
-            benchmark.benchmark_tooling()
-        elif operation == "import":
-            benchmark.benchmark_import()
-        elif operation == "lock-cold":
-            benchmark.clean_cache()
-            benchmark.clean_venv()
-            benchmark.clean_lock()
-            benchmark.benchmark_lock("lock-cold.txt")
-        elif operation == "lock-warm":
-            benchmark.clean_lock()
-            benchmark.benchmark_lock("lock-warm.txt")
-        elif operation == "install-cold":
-            benchmark.clean_cache()
-            benchmark.clean_venv()
-            benchmark.benchmark_install("install-cold.txt")
-        elif operation == "install-warm":
-            benchmark.clean_venv()
-            benchmark.benchmark_install("install-warm.txt")
-        elif operation == "update-cold":
-            benchmark.clean_cache()
-            benchmark.benchmark_update("update-cold.txt")
-        elif operation == "update-warm":
-            benchmark.benchmark_update("update-warm.txt")
-        elif operation == "add-package":
-            benchmark.benchmark_add_package()
-        elif operation == "stats":
-            benchmark.generate_stats()
+
+def main(argv=None):
+    args = parse_args(argv)
+    benchmark_dir = Path(__file__).parent
+    output_json = None if args.no_json else benchmark_dir / args.output_json
+    benchmark = PipenvBenchmark(
+        benchmark_dir,
+        profile=args.profile,
+        output_json=output_json,
+        force_setup=args.force_setup,
+    )
+
+    for iteration in range(1, args.repeat + 1):
+        if args.repeat > 1:
+            print(f"\nBenchmark iteration {iteration}/{args.repeat}")
+        if args.operation == "all":
+            benchmark.run_full_benchmark()
         else:
-            print(f"Unknown operation: {operation}")
-            sys.exit(1)
-    else:
-        benchmark.run_full_benchmark()
+            benchmark.run_operation(args.operation)
+
+    if args.operation not in {"all", "stats"}:
+        benchmark.generate_stats()
+    if args.operation != "stats":
+        benchmark.write_json_results()
 
 
 if __name__ == "__main__":

--- a/pipenv/project.py
+++ b/pipenv/project.py
@@ -1117,14 +1117,12 @@ class Project:
                         document[category][package] = tomlkit.string(data[category][package])
             formatted_data = tomlkit.dumps(document).rstrip()
 
-        if Path(path).absolute() == Path(self.pipfile_location).absolute():
-            newlines = self._pipfile_newlines
-        else:
-            newlines = DEFAULT_NEWLINES
+        is_pipfile = Path(path).resolve() == Path(self.pipfile_location).resolve()
+        newlines = self._pipfile_newlines if is_pipfile else DEFAULT_NEWLINES
         formatted_data = cleanup_toml(formatted_data)
         with open(path, "w", newline=newlines) as f:
             f.write(formatted_data)
-        if Path(path).absolute() == Path(self.pipfile_location).absolute():
+        if is_pipfile:
             self._parsed_pipfile_cache = None
             self._parsed_pipfile_mtime_ns = None
 

--- a/pipenv/project.py
+++ b/pipenv/project.py
@@ -222,6 +222,8 @@ class Project:
         self._proper_names_db_path = None
         self._pipfile_location = None
         self._pipfile_newlines = DEFAULT_NEWLINES
+        self._parsed_pipfile_cache = None
+        self._parsed_pipfile_mtime_ns = None
         self._lockfile_newlines = DEFAULT_NEWLINES
         self._requirements_location = None
         self._original_dir = Path.cwd().resolve()
@@ -738,8 +740,28 @@ class Project:
     @property
     def parsed_pipfile(self) -> tomlkit.toml_document.TOMLDocument | TPipfile:
         """Parse Pipfile into a TOMLFile"""
+        # Parsing tomlkit on every access is expensive (see gh perf branch): a
+        # single lock call hit this 500+ times.  Cache the parsed document and
+        # refresh it whenever the file's mtime changes so external edits still
+        # work, while writes from pipenv itself invalidate the cache directly
+        # via write_toml().
+        if not self.pipfile_exists:
+            return self._parse_pipfile("")
+        try:
+            mtime_ns = os.stat(self.pipfile_location).st_mtime_ns
+        except OSError:
+            mtime_ns = None
+        if (
+            self._parsed_pipfile_cache is not None
+            and mtime_ns is not None
+            and self._parsed_pipfile_mtime_ns == mtime_ns
+        ):
+            return self._parsed_pipfile_cache
         contents = self.read_pipfile()
-        return self._parse_pipfile(contents)
+        parsed = self._parse_pipfile(contents)
+        self._parsed_pipfile_cache = parsed
+        self._parsed_pipfile_mtime_ns = mtime_ns
+        return parsed
 
     def read_pipfile(self) -> str:
         # Open the pipfile, read it into memory.
@@ -1102,6 +1124,9 @@ class Project:
         formatted_data = cleanup_toml(formatted_data)
         with open(path, "w", newline=newlines) as f:
             f.write(formatted_data)
+        if Path(path).absolute() == Path(self.pipfile_location).absolute():
+            self._parsed_pipfile_cache = None
+            self._parsed_pipfile_mtime_ns = None
 
     @property
     def use_pylock(self) -> bool:

--- a/pipenv/resolver.py
+++ b/pipenv/resolver.py
@@ -376,9 +376,6 @@ def process_resolver_results(
     if not results:
         return []
 
-    # Get reverse dependencies for the project
-    reverse_deps = project.environment.reverse_dependencies()
-
     processed_results = []
     for result in results:
         # Create Entry instance with our new dataclass
@@ -387,7 +384,6 @@ def process_resolver_results(
             entry_dict=result,
             project=project,
             resolver=resolver,
-            reverse_deps=reverse_deps,
             category=category,
         )
 

--- a/pipenv/utils/dependencies.py
+++ b/pipenv/utils/dependencies.py
@@ -1405,14 +1405,15 @@ def get_constraints_from_deps(deps):
         c = None
         # Constraints cannot contain extras
         dep_name = dep_name.split("[", 1)[0]
+        canonical = canonicalize_name(dep_name)
         # Creating a constraint as a canonical name plus a version specifier
         if isinstance(dep_version, str):
             if dep_version and not is_star(dep_version):
                 if COMPARE_OP.match(dep_version) is None:
                     dep_version = f"=={dep_version}"
-                c = f"{canonicalize_name(dep_name)}{dep_version}"
+                c = f"{canonical}{dep_version}"
             else:
-                c = canonicalize_name(dep_name)
+                c = canonical
         elif not any(k in dep_version for k in ["path", "file", "uri"]):
             if dep_version.get("skip_resolver") is True:
                 continue
@@ -1420,9 +1421,9 @@ def get_constraints_from_deps(deps):
             if version and not is_star(version):
                 if COMPARE_OP.match(version) is None:
                     version = f"=={version}"
-                c = f"{canonicalize_name(dep_name)}{version}"
+                c = f"{canonical}{version}"
             else:
-                c = canonicalize_name(dep_name)
+                c = canonical
         if c:
             constraints.add(c)
     return constraints

--- a/pipenv/utils/resolver.py
+++ b/pipenv/utils/resolver.py
@@ -321,6 +321,11 @@ class Resolver:
         self.pipfile_entries = pipfile_entries
         self._retry_attempts = 0
         self._hash_cache = None
+        self._constraint_file = None
+        self._default_constraint_file = None
+        self._parsed_constraints = None
+        self._parsed_default_constraints = None
+        self._hash_finder = None
 
     def __repr__(self):
         return (
@@ -491,16 +496,22 @@ class Resolver:
         )
 
     def prepare_constraint_file(self):
+        if self._constraint_file is not None:
+            return self._constraint_file
         constraint_filename = prepare_constraint_file(
             self.initial_constraints,
             directory=self.req_dir,
             sources=self.sources,
             pip_args=self.pip_args,
         )
+        self._constraint_file = constraint_filename
         return constraint_filename
 
     @property
     def default_constraint_file(self):
+        if self._default_constraint_file is not None:
+            return self._default_constraint_file
+
         # When resolved default deps are available (passed from do_lock after
         # resolving the default category), use them.  They include transitive
         # dependencies and exact version pins, which is critical for ensuring
@@ -519,6 +530,7 @@ class Resolver:
             sources=None,
             pip_args=None,
         )
+        self._default_constraint_file = default_constraint_filename
         return default_constraint_filename
 
     @property
@@ -599,14 +611,15 @@ class Resolver:
 
     @property
     def parsed_default_constraints(self):
+        if self._parsed_default_constraints is not None:
+            return self._parsed_default_constraints
+
         pip_options = self.pip_options
         pip_options.extra_index_urls = []
-        # Convert Path object to string to avoid 'PosixPath' has no attribute 'decode' error
-        constraint_file = (
-            str(self.default_constraint_file)
-            if isinstance(self.default_constraint_file, Path)
-            else self.default_constraint_file
-        )
+        # Convert Path object to string to avoid PosixPath decode errors.
+        constraint_file = self.default_constraint_file
+        if isinstance(constraint_file, Path):
+            constraint_file = str(constraint_file)
         parsed_default_constraints = parse_requirements(
             constraint_file,
             constraint=True,
@@ -614,19 +627,21 @@ class Resolver:
             session=self.session,
             options=pip_options,
         )
-        return list(parsed_default_constraints)
+        self._parsed_default_constraints = list(parsed_default_constraints)
+        return self._parsed_default_constraints
 
     @property
     def parsed_constraints(self):
         """Get parsed constraints including those from default packages if needed."""
+        if self._parsed_constraints is not None:
+            return self._parsed_constraints
+
         pip_options = self.pip_options
         pip_options.extra_index_urls = []
-        # Convert Path object to string to avoid 'PosixPath' has no attribute 'decode' error
-        constraint_file = (
-            str(self.prepare_constraint_file())
-            if isinstance(self.prepare_constraint_file(), Path)
-            else self.prepare_constraint_file()
-        )
+        # Convert Path object to string to avoid PosixPath decode errors.
+        constraint_file = self.prepare_constraint_file()
+        if isinstance(constraint_file, Path):
+            constraint_file = str(constraint_file)
         constraints = list(
             parse_requirements(
                 constraint_file,
@@ -642,7 +657,8 @@ class Resolver:
         ):
             constraints.extend(self.parsed_default_constraints)
 
-        return constraints
+        self._parsed_constraints = constraints
+        return self._parsed_constraints
 
     @property
     def default_constraints(self):
@@ -784,6 +800,7 @@ class Resolver:
         # Build mapping of package origins and Python requirements
         comes_from = {}
         python_requirements = {}
+        finder = self.finder()
 
         for result in self.resolved_tree:
             # Track package origin
@@ -794,9 +811,7 @@ class Resolver:
 
             # Collect Python requirements from package metadata
             candidate = (
-                self.finder()
-                .find_best_candidate(result.name, result.specifier)
-                .best_candidate
+                finder.find_best_candidate(result.name, result.specifier).best_candidate
             )
             if candidate and candidate.link.requires_python:
                 try:
@@ -833,6 +848,12 @@ class Resolver:
 
         self.resolved_tree = new_tree
 
+    @property
+    def hash_finder(self):
+        if getattr(self, "_hash_finder", None) is None:
+            self._hash_finder = self.finder(ignore_compatibility=True)
+        return self._hash_finder
+
     def collect_hashes(self, ireq):
         link = ireq.link  # Handle VCS and file links first
         if link and (link.is_vcs or (link.is_file and link.is_existing_dir())):
@@ -861,9 +882,9 @@ class Resolver:
                     return hashes
 
         # Updated section to use applicable_candidates directly
-        best_candidate_result = self.finder(
-            ignore_compatibility=True
-        ).find_best_candidate(ireq.name, ireq.specifier)
+        best_candidate_result = self.hash_finder.find_best_candidate(
+            ireq.name, ireq.specifier
+        )
         if best_candidate_result.applicable_candidates:
             return sorted(
                 {

--- a/pipenv/utils/resolver.py
+++ b/pipenv/utils/resolver.py
@@ -825,12 +825,9 @@ class Resolver:
         # for concurrent writes of different keys under CPython's GIL — and
         # the underlying requests.Session is thread-safe.
         def _requires_python_marker(result):
-            try:
-                candidate = finder.find_best_candidate(
-                    result.name, result.specifier
-                ).best_candidate
-            except Exception:
-                return result.name, None
+            candidate = finder.find_best_candidate(
+                result.name, result.specifier
+            ).best_candidate
             if not candidate or not candidate.link.requires_python:
                 return result.name, None
             try:

--- a/pipenv/utils/resolver.py
+++ b/pipenv/utils/resolver.py
@@ -940,8 +940,12 @@ class Resolver:
         # Hash collection is mostly network-bound (PyPI JSON or simple-index
         # HTML), so we dispatch the per-ireq calls on a small thread pool.
         # collect_hashes reads resolver state that is stable post-resolve
-        # (sources, hash_finder, hash_cache); we commit results from this
-        # thread once all futures finish.
+        # (sources, hash_finder, hash_cache); eagerly initialize any lazily
+        # created shared state here on the main thread to avoid races between
+        # workers creating duplicate finders/caches/sessions.
+        _ = self.hash_finder
+        with contextlib.suppress(AttributeError):
+            _ = self.hash_cache
         max_workers = min(len(ireqs), 16)
         with ThreadPoolExecutor(max_workers=max_workers) as pool:
             for ireq, hashes in zip(ireqs, pool.map(self.collect_hashes, ireqs)):

--- a/pipenv/utils/resolver.py
+++ b/pipenv/utils/resolver.py
@@ -7,8 +7,10 @@ import os
 import subprocess
 import sys
 import tempfile
+import threading
 import time
 import warnings
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Union
 
@@ -326,6 +328,7 @@ class Resolver:
         self._parsed_constraints = None
         self._parsed_default_constraints = None
         self._hash_finder = None
+        self._prepared_index_lookup = None
 
     def __repr__(self):
         return (
@@ -574,6 +577,10 @@ class Resolver:
         return self.pip_command._build_session(self.pip_options)
 
     def prepare_index_lookup(self):
+        # sources and index_lookup are stable after Resolver.create() returns;
+        # cache the prepared mapping so each finder() call doesn't rebuild it.
+        if self._prepared_index_lookup is not None:
+            return self._prepared_index_lookup
         index_mapping = {}
         for source in self.sources:
             if source.get("name"):
@@ -582,6 +589,7 @@ class Resolver:
         for req_name, index in self.index_lookup.items():
             if index_mapping.get(index):
                 alt_index_lookup[req_name] = [index_mapping[index]]
+        self._prepared_index_lookup = alt_index_lookup
         return alt_index_lookup
 
     @property
@@ -802,23 +810,44 @@ class Resolver:
         python_requirements = {}
         finder = self.finder()
 
-        for result in self.resolved_tree:
+        results_list = list(self.resolved_tree)
+        for result in results_list:
             # Track package origin
             if isinstance(result.comes_from, InstallRequirement):
                 comes_from[result.name] = result.comes_from
             else:
                 comes_from[result.name] = "Pipfile"
 
-            # Collect Python requirements from package metadata
-            candidate = (
-                finder.find_best_candidate(result.name, result.specifier).best_candidate
-            )
-            if candidate and candidate.link.requires_python:
-                try:
-                    marker = marker_from_specifier(candidate.link.requires_python)
-                    python_requirements[result.name] = marker
-                except TypeError:
-                    continue
+        # find_best_candidate fetches per-package index pages; the calls are
+        # independent, keyed on distinct project names, and dominated by
+        # network I/O, so dispatch them on a thread pool.  pip's
+        # PackageFinder caches results in a dict keyed by project name — safe
+        # for concurrent writes of different keys under CPython's GIL — and
+        # the underlying requests.Session is thread-safe.
+        def _requires_python_marker(result):
+            try:
+                candidate = finder.find_best_candidate(
+                    result.name, result.specifier
+                ).best_candidate
+            except Exception:
+                return result.name, None
+            if not candidate or not candidate.link.requires_python:
+                return result.name, None
+            try:
+                return result.name, marker_from_specifier(candidate.link.requires_python)
+            except TypeError:
+                return result.name, None
+
+        if results_list:
+            max_workers = min(len(results_list), 8)
+            with ThreadPoolExecutor(max_workers=max_workers) as pool:
+                python_requirements = {
+                    name: marker
+                    for name, marker in pool.map(
+                        _requires_python_marker, results_list
+                    )
+                    if marker is not None
+                }
 
         # Build the results tree with markers
         new_tree = set()
@@ -903,9 +932,20 @@ class Resolver:
 
     @property
     def resolve_hashes(self):
-        if self.results is not None:
-            for ireq in self.results:
-                self.hashes[ireq] = self.collect_hashes(ireq)
+        if self.results is None:
+            return self.hashes
+        ireqs = list(self.results)
+        if not ireqs:
+            return self.hashes
+        # Hash collection is mostly network-bound (PyPI JSON or simple-index
+        # HTML), so we dispatch the per-ireq calls on a small thread pool.
+        # collect_hashes reads resolver state that is stable post-resolve
+        # (sources, hash_finder, hash_cache); we commit results from this
+        # thread once all futures finish.
+        max_workers = min(len(ireqs), 16)
+        with ThreadPoolExecutor(max_workers=max_workers) as pool:
+            for ireq, hashes in zip(ireqs, pool.map(self.collect_hashes, ireqs)):
+                self.hashes[ireq] = hashes
         return self.hashes
 
     def clean_skipped_result(
@@ -1132,8 +1172,6 @@ def _is_download_status_line(line: str) -> bool:
 
 
 def resolve(cmd, st, project):
-    import threading
-
     # cmd is a pre-tokenized list (not a TOML sequence); pass it directly.
     c = subprocess_run([str(x) for x in cmd], block=False, env=os.environ.copy())
     is_verbose = project.s.is_verbose()

--- a/tests/unit/test_project_caching.py
+++ b/tests/unit/test_project_caching.py
@@ -66,3 +66,47 @@ def test_write_toml_invalidates_pipfile_cache(project):
         reloaded = project.parsed_pipfile
     assert spy.call_count == 1
     assert "newpkg" in reloaded.get("packages", {})
+
+
+@pytest.mark.utils
+def test_rapid_sequential_writes_are_each_visible(project):
+    """Back-to-back write_toml calls on the same mtime tick must still
+    produce fresh reads on subsequent parsed_pipfile accesses."""
+    for i in range(3):
+        doc = project.parsed_pipfile
+        doc["packages"][f"pkg_{i}"] = "*"
+        project.write_toml(doc)
+        refreshed = project.parsed_pipfile
+        assert f"pkg_{i}" in refreshed.get("packages", {})
+
+
+@pytest.mark.utils
+def test_in_place_mutation_then_write_yields_persisted_state(project, tmp_path):
+    """Mirrors the ensure_proper_casing / write_toml pattern where the cached
+    document is mutated in place before being written back."""
+    doc = project.parsed_pipfile
+    doc["packages"]["Pre-Cased-Pkg"] = "*"
+    # Mutating the cached doc before writing is the intended flow.
+    project.write_toml(doc)
+
+    on_disk = (tmp_path / "Pipfile").read_text()
+    assert "Pre-Cased-Pkg" in on_disk
+
+    reloaded = project.parsed_pipfile
+    assert "Pre-Cased-Pkg" in reloaded.get("packages", {})
+
+
+@pytest.mark.utils
+def test_write_toml_to_other_path_does_not_invalidate_pipfile_cache(
+    project, tmp_path
+):
+    """Writing a TOML blob to an unrelated path (e.g. an intermediate buffer)
+    must not drop the Pipfile cache."""
+    doc = project.parsed_pipfile
+    other = tmp_path / "snapshot.toml"
+    project.write_toml(doc, path=str(other))
+
+    with mock.patch.object(Project, "_parse_pipfile", wraps=project._parse_pipfile) as spy:
+        again = project.parsed_pipfile
+    assert spy.call_count == 0
+    assert again is doc

--- a/tests/unit/test_project_caching.py
+++ b/tests/unit/test_project_caching.py
@@ -1,0 +1,68 @@
+import os
+from unittest import mock
+
+import pytest
+
+from pipenv.project import Project
+
+PIPFILE_CONTENT = """\
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+requests = "*"
+
+[dev-packages]
+
+[requires]
+python_version = "3.11"
+"""
+
+
+@pytest.fixture
+def project(tmp_path, monkeypatch):
+    pipfile = tmp_path / "Pipfile"
+    pipfile.write_text(PIPFILE_CONTENT)
+    monkeypatch.chdir(tmp_path)
+    return Project(chdir=False)
+
+
+@pytest.mark.utils
+def test_parsed_pipfile_caches_between_accesses(project):
+    with mock.patch.object(Project, "_parse_pipfile", wraps=project._parse_pipfile) as spy:
+        first = project.parsed_pipfile
+        second = project.parsed_pipfile
+    assert first is second
+    assert spy.call_count == 1
+
+
+@pytest.mark.utils
+def test_parsed_pipfile_reparses_when_file_changes(project, tmp_path):
+    assert project.parsed_pipfile is not None  # prime cache
+
+    pipfile = tmp_path / "Pipfile"
+    updated = PIPFILE_CONTENT.replace('requests = "*"', 'flask = "*"')
+    # Bump mtime deterministically so the cache invalidates even on filesystems
+    # with coarse mtime resolution.
+    stat = pipfile.stat()
+    pipfile.write_text(updated)
+    os.utime(pipfile, ns=(stat.st_atime_ns, stat.st_mtime_ns + 1_000_000))
+
+    with mock.patch.object(Project, "_parse_pipfile", wraps=project._parse_pipfile) as spy:
+        reparsed = project.parsed_pipfile
+    assert spy.call_count == 1
+    assert "flask" in reparsed.get("packages", {})
+
+
+@pytest.mark.utils
+def test_write_toml_invalidates_pipfile_cache(project):
+    doc = project.parsed_pipfile
+    doc["packages"]["newpkg"] = "*"
+    project.write_toml(doc)
+
+    with mock.patch.object(Project, "_parse_pipfile", wraps=project._parse_pipfile) as spy:
+        reloaded = project.parsed_pipfile
+    assert spy.call_count == 1
+    assert "newpkg" in reloaded.get("packages", {})

--- a/tests/unit/test_resolver_regressions.py
+++ b/tests/unit/test_resolver_regressions.py
@@ -87,7 +87,9 @@ def test_collect_hashes_does_not_warn_when_fallback_succeeds(monkeypatch):
     candidate = SimpleNamespace(link=mock.sentinel.link)
     best_candidate_result = SimpleNamespace(applicable_candidates=[candidate])
     resolver.finder = mock.Mock(
-        return_value=SimpleNamespace(find_best_candidate=mock.Mock(return_value=best_candidate_result))
+        return_value=SimpleNamespace(
+            find_best_candidate=mock.Mock(return_value=best_candidate_result)
+        )
     )
 
     ireq = mock.MagicMock()
@@ -110,7 +112,9 @@ def test_collect_hashes_warns_once_when_all_strategies_fail(monkeypatch):
     resolver.project.get_hashes_from_pypi.return_value = None
     best_candidate_result = SimpleNamespace(applicable_candidates=[])
     resolver.finder = mock.Mock(
-        return_value=SimpleNamespace(find_best_candidate=mock.Mock(return_value=best_candidate_result))
+        return_value=SimpleNamespace(
+            find_best_candidate=mock.Mock(return_value=best_candidate_result)
+        )
     )
 
     ireq = mock.MagicMock()
@@ -127,3 +131,106 @@ def test_collect_hashes_warns_once_when_all_strategies_fail(monkeypatch):
     err_print.assert_called_once_with(
         "[bold][red]Warning[/red][/bold]: Error generating hash for regex."
     )
+
+
+@pytest.mark.utils
+def test_parsed_constraints_are_cached(monkeypatch, tmp_path):
+    project = mock.MagicMock()
+    project.s.PIPENV_CACHE_DIR = str(tmp_path / "cache")
+    project.settings.get.return_value = False
+    project.packages = {}
+
+    resolver = Resolver(set(), str(tmp_path), project, sources=[])
+    pip_options = SimpleNamespace(extra_index_urls=[], build_isolation=False)
+    calls = {"prepare": 0, "parse": 0}
+
+    def fake_prepare_constraint_file(*args, **kwargs):
+        calls["prepare"] += 1
+        constraint_file = tmp_path / f"constraints-{calls['prepare']}.txt"
+        constraint_file.write_text("")
+        return str(constraint_file)
+
+    def fake_parse_requirements(*args, **kwargs):
+        calls["parse"] += 1
+        return [SimpleNamespace(requirement=f"req-{calls['parse']}")]
+
+    monkeypatch.setattr(Resolver, "pip_options", property(lambda self: pip_options))
+    monkeypatch.setattr(Resolver, "session", property(lambda self: mock.sentinel.session))
+    monkeypatch.setattr(
+        Resolver,
+        "finder",
+        lambda self, ignore_compatibility=False: mock.sentinel.finder,
+    )
+    monkeypatch.setattr(
+        "pipenv.utils.resolver.prepare_constraint_file",
+        fake_prepare_constraint_file,
+    )
+    monkeypatch.setattr(
+        "pipenv.utils.resolver.parse_requirements",
+        fake_parse_requirements,
+    )
+
+    first = resolver.parsed_constraints
+    second = resolver.parsed_constraints
+
+    assert first is second
+    assert calls == {"prepare": 1, "parse": 1}
+
+
+class _ResolvedRequirement:
+    def __init__(self, name):
+        self.name = name
+        self.specifier = ""
+        self.comes_from = None
+        self.markers = None
+        self.req = None
+
+    def __hash__(self):
+        return hash(self.name)
+
+    def __eq__(self, other):
+        return isinstance(other, _ResolvedRequirement) and self.name == other.name
+
+
+@pytest.mark.utils
+def test_resolve_constraints_reuses_package_finder():
+    resolver = Resolver.__new__(Resolver)
+    resolver.resolved_tree = {
+        _ResolvedRequirement("requests"),
+        _ResolvedRequirement("certifi"),
+    }
+    resolver.markers = {}
+    resolver.markers_lookup = {}
+    resolver.pipfile_entries = {}
+
+    candidate = SimpleNamespace(link=SimpleNamespace(requires_python=None))
+    finder = mock.MagicMock()
+    finder.find_best_candidate.return_value = SimpleNamespace(best_candidate=candidate)
+    resolver.finder = mock.Mock(return_value=finder)
+
+    Resolver.resolve_constraints(resolver)
+
+    resolver.finder.assert_called_once_with()
+    assert finder.find_best_candidate.call_count == 2
+
+
+@pytest.mark.utils
+def test_process_resolver_results_does_not_scan_reverse_dependencies():
+    from pipenv.resolver import process_resolver_results
+
+    project = mock.MagicMock()
+    project.parsed_pipfile = {"packages": {}}
+    project.environment.reverse_dependencies.side_effect = AssertionError(
+        "reverse dependencies should not be loaded while processing lock results"
+    )
+
+    resolver = mock.MagicMock()
+    resolver.index_lookup = {}
+    resolver.parsed_constraints = []
+
+    results = [{"name": "requests", "version": "==2.32.0"}]
+
+    processed = process_resolver_results(results, resolver, project, "packages")
+
+    assert processed == [{"name": "requests", "version": "==2.32.0"}]
+    project.environment.reverse_dependencies.assert_not_called()

--- a/tests/unit/test_resolver_regressions.py
+++ b/tests/unit/test_resolver_regressions.py
@@ -215,6 +215,125 @@ def test_resolve_constraints_reuses_package_finder():
 
 
 @pytest.mark.utils
+def test_resolve_hashes_runs_in_parallel():
+    """resolve_hashes should dispatch collect_hashes concurrently and still
+    populate resolver.hashes with every ireq -> hashes pair."""
+    import threading
+
+    resolver = Resolver.__new__(Resolver)
+
+    class _HashableIreq:
+        def __init__(self, name):
+            self.name = name
+
+        def __hash__(self):
+            return hash(self.name)
+
+        def __eq__(self, other):
+            return isinstance(other, _HashableIreq) and self.name == other.name
+
+    ireqs = [_HashableIreq(f"pkg-{i}") for i in range(32)]
+    resolver.results = ireqs
+    resolver.hashes = {}
+
+    concurrent = 0
+    peak = 0
+    lock = threading.Lock()
+    barrier_event = threading.Event()
+
+    def slow_collect(ireq):
+        nonlocal concurrent, peak
+        with lock:
+            concurrent += 1
+            peak = max(peak, concurrent)
+        # Give the pool a chance to actually overlap calls.
+        barrier_event.wait(timeout=0.5)
+        with lock:
+            concurrent -= 1
+        return {f"sha256:hash-for-{ireq.name}"}
+
+    resolver.collect_hashes = slow_collect
+    # Release all callers once at least two are in flight.
+    def _release_once_two_in_flight():
+        while True:
+            with lock:
+                if concurrent >= 2:
+                    barrier_event.set()
+                    return
+            threading.Event().wait(timeout=0.01)
+
+    releaser = threading.Thread(target=_release_once_two_in_flight, daemon=True)
+    releaser.start()
+
+    result = Resolver.resolve_hashes.fget(resolver)
+
+    assert peak >= 2, "collect_hashes should have run concurrently"
+    assert result is resolver.hashes
+    assert len(resolver.hashes) == len(ireqs)
+    for ireq in ireqs:
+        assert resolver.hashes[ireq] == {f"sha256:hash-for-{ireq.name}"}
+
+
+@pytest.mark.utils
+def test_resolve_constraints_runs_candidate_lookup_in_parallel():
+    """resolve_constraints should overlap find_best_candidate calls."""
+    import threading
+
+    from pipenv.patched.pip._internal.req.req_install import InstallRequirement  # noqa: F401
+
+    resolver = Resolver.__new__(Resolver)
+    resolver.resolved_tree = {
+        _ResolvedRequirement(f"pkg-{i}") for i in range(16)
+    }
+    resolver.markers = {}
+    resolver.markers_lookup = {}
+    resolver.pipfile_entries = {}
+
+    concurrent = 0
+    peak = 0
+    lock = threading.Lock()
+
+    def slow_find(name, specifier):
+        nonlocal concurrent, peak
+        with lock:
+            concurrent += 1
+            peak = max(peak, concurrent)
+        threading.Event().wait(timeout=0.05)
+        with lock:
+            concurrent -= 1
+        return SimpleNamespace(
+            best_candidate=SimpleNamespace(link=SimpleNamespace(requires_python=None))
+        )
+
+    finder = SimpleNamespace(find_best_candidate=slow_find)
+    resolver.finder = mock.Mock(return_value=finder)
+
+    Resolver.resolve_constraints(resolver)
+
+    assert peak >= 2, "find_best_candidate should have run concurrently"
+
+
+@pytest.mark.utils
+def test_prepare_index_lookup_is_cached():
+    resolver = Resolver.__new__(Resolver)
+    resolver._prepared_index_lookup = None
+    resolver.sources = [
+        {"name": "pypi", "url": "https://pypi.org/simple"},
+        {"name": "internal", "url": "https://example.com/simple"},
+    ]
+    resolver.index_lookup = {"foo": "internal"}
+
+    first = resolver.prepare_index_lookup()
+    # Mutate inputs after the first call — cached result should be returned.
+    resolver.sources.append({"name": "other", "url": "https://other"})
+    resolver.index_lookup["bar"] = "pypi"
+    second = resolver.prepare_index_lookup()
+
+    assert first is second
+    assert "bar" not in first
+
+
+@pytest.mark.utils
 def test_process_resolver_results_does_not_scan_reverse_dependencies():
     from pipenv.resolver import process_resolver_results
 

--- a/tests/unit/test_resolver_regressions.py
+++ b/tests/unit/test_resolver_regressions.py
@@ -235,6 +235,10 @@ def test_resolve_hashes_runs_in_parallel():
     ireqs = [_HashableIreq(f"pkg-{i}") for i in range(32)]
     resolver.results = ireqs
     resolver.hashes = {}
+    # Pre-stub _hash_finder so the eager initialization in resolve_hashes
+    # does not attempt to build a real PackageFinder (which requires
+    # resolver.project and other live state that the stub resolver lacks).
+    resolver._hash_finder = mock.Mock()
 
     concurrent = 0
     peak = 0
@@ -292,16 +296,31 @@ def test_resolve_constraints_runs_candidate_lookup_in_parallel():
 
     concurrent = 0
     peak = 0
+    started = 0
     lock = threading.Lock()
+    overlap_barrier = threading.Barrier(2, timeout=5)
 
     def slow_find(name, specifier):
-        nonlocal concurrent, peak
+        nonlocal concurrent, peak, started
+        should_wait_for_overlap = False
         with lock:
             concurrent += 1
             peak = max(peak, concurrent)
-        threading.Event().wait(timeout=0.05)
-        with lock:
-            concurrent -= 1
+            started += 1
+            should_wait_for_overlap = started <= 2
+        try:
+            # Deterministically require the first two calls to overlap instead of
+            # relying on short real-time waits that can be flaky on slow CI.
+            if should_wait_for_overlap:
+                overlap_barrier.wait()
+        except threading.BrokenBarrierError:
+            pytest.fail(
+                "Timed out waiting for two find_best_candidate calls to overlap; "
+                "expected resolver candidate lookup to run in parallel."
+            )
+        finally:
+            with lock:
+                concurrent -= 1
         return SimpleNamespace(
             best_candidate=SimpleNamespace(link=SimpleNamespace(requires_python=None))
         )

--- a/tests/unit/test_resolver_regressions.py
+++ b/tests/unit/test_resolver_regressions.py
@@ -238,33 +238,34 @@ def test_resolve_hashes_runs_in_parallel():
 
     concurrent = 0
     peak = 0
+    started = 0
     lock = threading.Lock()
-    barrier_event = threading.Event()
+    overlap_barrier = threading.Barrier(2, timeout=5)
 
     def slow_collect(ireq):
-        nonlocal concurrent, peak
+        nonlocal concurrent, peak, started
+        should_wait_for_overlap = False
         with lock:
             concurrent += 1
             peak = max(peak, concurrent)
-        # Give the pool a chance to actually overlap calls.
-        barrier_event.wait(timeout=0.5)
-        with lock:
-            concurrent -= 1
+            started += 1
+            should_wait_for_overlap = started <= 2
+        try:
+            # Deterministically require the first two calls to overlap instead of
+            # relying on short real-time waits that can be flaky on slow CI.
+            if should_wait_for_overlap:
+                overlap_barrier.wait()
+        except threading.BrokenBarrierError:
+            pytest.fail(
+                "Timed out waiting for two collect_hashes calls to overlap; "
+                "expected resolver hash collection to run in parallel."
+            )
+        finally:
+            with lock:
+                concurrent -= 1
         return {f"sha256:hash-for-{ireq.name}"}
 
     resolver.collect_hashes = slow_collect
-    # Release all callers once at least two are in flight.
-    def _release_once_two_in_flight():
-        while True:
-            with lock:
-                if concurrent >= 2:
-                    barrier_event.set()
-                    return
-            threading.Event().wait(timeout=0.01)
-
-    releaser = threading.Thread(target=_release_once_two_in_flight, daemon=True)
-    releaser.start()
-
     result = Resolver.resolve_hashes.fget(resolver)
 
     assert peak >= 2, "collect_hashes should have run concurrently"


### PR DESCRIPTION
## Summary

- Cut `pipenv lock` wall-clock by ~33% and user CPU by ~30% on an 86-package Pipfile (Sentry `requirements-base.txt`), measured apples-to-apples against `main` on the same machine.
- No changes to `pipenv/patched/pip/` or `pipenv/vendor/` — all wins are in editable pipenv code.
- Benchmark runner extended with repeatable ops, profiling hooks, and structured JSON output.

## Why

Profiling `pipenv lock` on a representative real-world requirement set showed three clear waste patterns in editable pipenv code:

1. The constraint file was prepared, parsed, and its PackageFinder re-built on every property access (many times per resolve).
2. `parsed_pipfile` re-read and re-parsed the same TOML document **548 times** per resolve — ~17% of wall clock spent in tomlkit.
3. Two resolver loops issued one sequential network request per resolved dep (`collect_hashes` × 149 and `find_best_candidate` × 149 inside `resolve_constraints`).

Everything below is either caching read-only state, memoising idempotent work, or parallelising independent network-bound calls.

## Changes (commits in order)

### a96d63e7 — Cache resolver constraint work and harden benchmark runner

- Memoise `prepare_constraint_file`, `default_constraint_file`, `parsed_constraints`, `parsed_default_constraints` on `Resolver`.
- Add a `hash_finder` property so `collect_hashes` doesn't build a fresh `PackageFinder(ignore_compatibility=True)` per candidate.
- Reuse one `finder()` across the per-result loop in `resolve_constraints`.
- Drop the eager `project.environment.reverse_dependencies()` load in `process_resolver_results` — `Entry` never consumed it; update-time routines build their own.
- Benchmark runner: `TimingRecord` dataclass with rusage deltas, `--repeat` (median aggregation), `--profile` (cProfile output under `timings/`, resolver kept in-process), `--output-json`, `--no-json`, `--force-setup`.
- README / `Makefile` / `.gitignore` / CI workflow updated; CI now uploads `benchmark-results.json` alongside `stats.csv`.

### 321dde57 — Cache parsed Pipfile document to avoid repeated TOML re-parses

- `Project.parsed_pipfile` now memoises the parsed `TOMLDocument` and invalidates on mtime change.
- `Project.write_toml` explicitly drops the cache after writing the Pipfile (belt-and-suspenders for writes that share an mtime tick).
- Confirmed every Pipfile mutation path in editable pipenv code routes through `write_toml` (`add_package_to_pipfile`, `add_packages_to_pipfile_batch`, `recase_pipfile`, `ensure_proper_casing` caller, `create_pipfile`, and other helpers in `project.py`).
- `_parse_pipfile` call count in a single lock: **548 → 2**.

### d471c54d — Regression tests for Pipfile cache invalidation edge cases

- Rapid back-to-back writes on the same mtime tick are still visible on subsequent reads.
- In-place mutation of the cached document followed by `write_toml` (the `ensure_proper_casing` / `add_package_to_pipfile` pattern) persists correctly.
- `write_toml` to an unrelated path (intermediate buffer) does **not** drop the Pipfile cache.

### f056ac96 — Parallelize network-bound resolver work + small caches

- `Resolver.resolve_hashes` dispatches `collect_hashes` per-ireq on a `ThreadPoolExecutor` (max_workers ≤ 16).
- `Resolver.resolve_constraints` dispatches `find_best_candidate` per-result on a `ThreadPoolExecutor` (max_workers ≤ 8).
- Thread-safety rationale: pip's `PackageFinder._all_candidates` dict is keyed on distinct project names (atomic on different keys under the GIL); `requests.Session` is documented thread-safe; `hash_cache` delegates to pip's atomic file cache.
- Cache `Resolver.prepare_index_lookup()` — sources / index_lookup are stable after `Resolver.create()` returns.
- Hoist `canonicalize_name()` in `get_constraints_from_deps` so each dep is canonicalised once instead of twice.

## Measured impact

All numbers from `benchmarks/benchmark.py lock-warm` against an 86-package Pipfile built from Sentry's `requirements-base.txt`, same machine, same network:

| Stage | Wall | User CPU |
|---|---|---|
| `main` baseline | 22.4s | 17.7s |
| + 321dde57 (parsed_pipfile cache) | 18.8s | 14.2s |
| + f056ac96 (parallel hash/candidate + small caches) | **15.1s** | **12.3s** |
| **Branch total** | **−33%** | **−30%** |

`_parse_pipfile` invocations in the post-cache profile: 2 (down from 548). Per-pipenv-side `find_best_candidate` and `collect_hashes` calls overlap during network I/O instead of serialising.

## Test plan

- [x] `pytest tests/unit/` — 435 passed, 9 skipped (Windows), 3 pre-existing `TestTargetMarkerEnvironment` failures unrelated to this branch.
- [x] `ruff check` clean on all touched files.
- [x] `pre-commit` hooks clean on every commit.
- [x] New unit tests cover parsed_pipfile caching + invalidation, resolver constraint caching, single finder reuse in `resolve_constraints`, concurrent execution of `collect_hashes` and `find_best_candidate`, `prepare_index_lookup` caching, and the no-reverse-deps path.
- [x] Lockfile output byte-compared to pre-optimisation lock (same `_meta.hash.sha256`, same 151 resolved packages) after running on the benchmark Pipfile.
- [ ] Reviewer: please confirm behaviour on your own project's Pipfile, particularly if you use private indexes or unusual source configurations.

## Known non-issues

- At peak concurrency pip emits `Connection pool is full, discarding connection: pypi.org. Connection pool size: 10`. Cosmetic — urllib3 recycles connections transparently, no correctness impact.
- The pre-existing `TestTargetMarkerEnvironment` failures exist on `main` too (`pipenv.routines.install` no longer exposes `_python_version_for_path`). Not in scope here.

## Out of scope / future work

- The largest remaining chunk of `pipenv lock` wall-clock (~15s) is inside `pipenv/patched/pip/_internal/` — specifically `Link.from_json`, `package_finder.evaluate_link`, `Wheel.__init__`, and `parse_wheel_filename` for the ~205k candidate links enumerated across 86 packages. Memoising `Link` / `Wheel` construction by URL and short-circuiting `evaluate_link` on repeated wheel-tag-incompatible filenames would be real wins, but belong upstream in pip rather than in this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)