### PR TITLE
docs: added git+ssh package source documentation for Pipfile

### DIFF
--- a/docs/pipfile.md
+++ b/docs/pipfile.md
@@ -77,6 +77,7 @@ sentry-sdk = {version = ">=1.0.0", extras = ["flask"]}
 
 # Git repositories
 flask-login = {git = "https://github.com/maxcountryman/flask-login.git", ref = "master"}
+my-package = {git = "ssh://git@github.com/bob/my-package.git", ref = "main"}
 
 # Local paths (relative filesystem path)
 my-package = { path = "./path/to/local/package" }
@@ -395,12 +396,15 @@ django = {version = "*", extras = ["bcrypt"]}
 
 ### Git Dependencies
 
-You can install packages directly from Git repositories:
+You can install packages directly from Git repositories.
+It supports both HTTPS and SSH URLs.
+SSH is generally preferred for private repositories, as they can require SSH authentication.
 
 ```toml
 [packages]
 flask-login = {git = "https://github.com/maxcountryman/flask-login.git", ref = "master"}
 custom-package = {git = "https://github.com/user/repo.git", editable = true}
+my-private-package = {git = "ssh://git@github.com/bob/my-package.git", ref = "main"}
 ```
 
 ### Local and Remote File Dependencies

--- a/news/6651.doc.rst
+++ b/news/6651.doc.rst
@@ -1,0 +1,1 @@
+Pipfile documentation now includes git+ssh examples.


### PR DESCRIPTION
### The issue

See #6650

In Pipfile, many users want to use Git repositories in [packages].
In some case, for example for a Github private repo, you can't use GIT+HTTPS.
This end in timeout after 10 minutes with pipenv install :

my_private_package = {ref = "dev", git = "https://github.com/elixir-sante/my_private_package.git"}

GIT+SSH works well but is not documented.

### The fix

For private repo / everything else that force you to use GIT+SSH, you can use this :

`my_private_package = {ref = "dev", git = "ssh://git@github.com/elixir-sante/my_private_package.git"}`

This is currently not documented.

### The checklist

* [ ] Associated issue
* [x] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.
