### PR TITLE
Fix Pipfile script expansion for PIPENV_PROJECT_DIR

### DIFF
--- a/news/6652.bugfix.rst
+++ b/news/6652.bugfix.rst
@@ -1,0 +1,3 @@
+``pipenv run`` now expands ``$PIPENV_PROJECT_DIR`` and other Pipenv-managed
+environment variables inside Pipfile script arguments before direct command
+execution, so project-relative script paths resolve correctly.

--- a/pipenv/routines/shell.py
+++ b/pipenv/routines/shell.py
@@ -1,11 +1,10 @@
 import os
 import subprocess
 import sys
-from os.path import expandvars
 
 from pipenv.utils import err
 from pipenv.utils.project import ensure_project
-from pipenv.utils.shell import cmd_list_to_shell, system_which
+from pipenv.utils.shell import cmd_list_to_shell, safe_expandvars, system_which
 from pipenv.utils.virtualenv import virtualenv_scripts_dir
 
 
@@ -172,7 +171,8 @@ def _run_script_sequence(script, env, verbose=False):
         sub, sub_inline_env = sub.with_extracted_env_vars()
         sub_string_env = {**string_env, **sub_inline_env}
 
-        cmd_args = [sub.command] + [expandvars(arg) for arg in sub.args]
+        expanded_args = [safe_expandvars(arg, env=sub_string_env) for arg in sub.args]
+        cmd_args = [sub.command] + expanded_args
         if verbose:
             err.print(f"$ {cmd_list_to_shell(cmd_args)}", style="cyan")
 
@@ -180,7 +180,7 @@ def _run_script_sequence(script, env, verbose=False):
             # On Windows mirror _launch_windows_subprocess: try direct
             # CreateProcess first, fall back to shell=True.
             command_path = system_which(sub.command, path=path)
-            sub.cmd_args[1:] = [expandvars(arg) for arg in sub.args]
+            sub.cmd_args[1:] = expanded_args
             if command_path:
                 try:
                     result = subprocess.run(
@@ -200,7 +200,7 @@ def _run_script_sequence(script, env, verbose=False):
             command_path = system_which(sub.command, path=path)
             if command_path:
                 result = subprocess.run(
-                    [command_path, *(expandvars(arg) for arg in sub.args)],
+                    [command_path, *expanded_args],
                     env=sub_string_env,
                     check=False,
                 )
@@ -224,19 +224,20 @@ def do_run_posix(project, script, command, env):
 
     # Ensure all environment variables are strings
     string_env = {k: str(v) for k, v in env.items() if v is not None}
+    expanded_args = [safe_expandvars(arg, env=string_env) for arg in script.args]
 
     if command_path:
         # Command found in PATH, use os.execve for direct execution
         os.execve(
             command_path,
-            [command_path, *(expandvars(arg) for arg in script.args)],
+            [command_path, *expanded_args],
             string_env,
         )
     else:
         # Command not found in PATH, maybe it's a shell builtin (cd, echo, export, etc.)
         # Fall back to running through the shell, similar to Windows behavior.
         # See: https://github.com/pypa/pipenv/issues/6186
-        cmd_args = [script.command] + [expandvars(arg) for arg in script.args]
+        cmd_args = [script.command] + expanded_args
         cmd_string = cmd_list_to_shell(cmd_args)
         result = subprocess.run(cmd_string, shell=True, env=string_env, check=False)
         sys.exit(result.returncode)
@@ -255,7 +256,7 @@ def _launch_windows_subprocess(script, env):
     # Ensure all environment variables are strings
     string_env = {k: str(v) for k, v in env.items() if v is not None}
     options = {"universal_newlines": True, "env": string_env}
-    script.cmd_args[1:] = [expandvars(arg) for arg in script.args]
+    script.cmd_args[1:] = [safe_expandvars(arg, env=string_env) for arg in script.args]
 
     # Command not found, maybe this is a shell built-in?
     if not command:

--- a/pipenv/utils/shell.py
+++ b/pipenv/utils/shell.py
@@ -217,20 +217,46 @@ def escape_cmd(cmd):
     return cmd
 
 
+# $VAR or ${VAR} — matches os.path.expandvars (posixpath) semantics.
+_VAR_PROG = re.compile(r"\$(\w+|\{[^}]*\})")
+# %VAR% — Windows-only form, also recognised by os.path.expandvars on nt.
+_VAR_PROG_PERCENT = re.compile(r"%([^%]*)%")
+
+
+def _expand_with_mapping(text, mapping):
+    """Expand ``$VAR`` / ``${VAR}`` (and ``%VAR%`` on Windows) against an
+    explicit mapping, leaving unknown names unchanged. Pure-Python — does not
+    touch ``os.environ`` and is therefore thread-safe."""
+
+    def _sub(match):
+        name = match.group(1)
+        if name.startswith("{") and name.endswith("}"):
+            name = name[1:-1]
+        if name in mapping:
+            return str(mapping[name])
+        return match.group(0)
+
+    result = _VAR_PROG.sub(_sub, text)
+    if os.name == "nt":
+        result = _VAR_PROG_PERCENT.sub(_sub, result)
+    return result
+
+
 def safe_expandvars(value, env=None):
     """
     Expand environment variables in a string value, do nothing for non-strings.
 
-    Note: pathlib.Path doesn't have an expandvars method, so we still use os.path.expandvars
-    for the actual expansion.
+    When ``env`` is provided, expansion uses *only* that mapping — variables
+    inherited from the ambient process environment are not visible. This avoids
+    leaking vars from an outer pipenv invocation into a nested run.
     """
     if env is not None:
-        with temp_environ():
-            # Expand against exactly the provided env mapping so inherited
-            # variables from an outer pipenv invocation do not leak in.
-            os.environ.clear()
-            os.environ.update({k: str(v) for k, v in env.items() if v is not None})
-            return safe_expandvars(value)
+        mapping = {k: v for k, v in env.items() if v is not None}
+        if isinstance(value, str):
+            return _expand_with_mapping(value, mapping)
+        if isinstance(value, Path):
+            return Path(_expand_with_mapping(str(value), mapping))
+        return value
     if isinstance(value, str):
         return os.path.expandvars(value)
     # Handle Path objects

--- a/pipenv/utils/shell.py
+++ b/pipenv/utils/shell.py
@@ -217,13 +217,17 @@ def escape_cmd(cmd):
     return cmd
 
 
-def safe_expandvars(value):
+def safe_expandvars(value, env=None):
     """
     Expand environment variables in a string value, do nothing for non-strings.
 
     Note: pathlib.Path doesn't have an expandvars method, so we still use os.path.expandvars
     for the actual expansion.
     """
+    if env is not None:
+        with temp_environ():
+            os.environ.update({k: str(v) for k, v in env.items() if v is not None})
+            return safe_expandvars(value)
     if isinstance(value, str):
         return os.path.expandvars(value)
     # Handle Path objects

--- a/pipenv/utils/shell.py
+++ b/pipenv/utils/shell.py
@@ -226,6 +226,9 @@ def safe_expandvars(value, env=None):
     """
     if env is not None:
         with temp_environ():
+            # Expand against exactly the provided env mapping so inherited
+            # variables from an outer pipenv invocation do not leak in.
+            os.environ.clear()
             os.environ.update({k: str(v) for k, v in env.items() if v is not None})
             return safe_expandvars(value)
     if isinstance(value, str):

--- a/tests/integration/test_run.py
+++ b/tests/integration/test_run.py
@@ -233,20 +233,20 @@ def test_run_script_expands_pipenv_project_dir(pipenv_instance_pypi):
     with pipenv_instance_pypi() as p:
         p.pipenv("install")
 
-        marker_path = os.path.join(p.path, "marker.txt")
-        with open(marker_path, "w") as f:
+        with open(os.path.join(p.path, "marker.txt"), "w") as f:
             f.write("marker")
 
         with open(p.pipfile_path, "w") as f:
             f.write(
                 "[scripts]\n"
-                'show_project_file = "python -c \\"import pathlib, sys; path = pathlib.Path(sys.argv[1]); print(path); print(path.is_file())\\" $PIPENV_PROJECT_DIR/marker.txt"\n'
+                'show_project_file = "python -c \\"import pathlib, sys; print(pathlib.Path(sys.argv[1]).read_text())\\" $PIPENV_PROJECT_DIR/marker.txt"\n'
             )
 
-        c = p.pipenv("run show_project_file")
+        with temp_environ():
+            os.environ["PIPENV_PROJECT_DIR"] = "/definitely/wrong"
+            c = p.pipenv("run show_project_file")
         assert c.returncode == 0, c.stderr
-        lines = [line.strip() for line in c.stdout.splitlines()]
-        assert lines == [marker_path, "True"]
+        assert c.stdout.strip() == "marker"
 
 
 @pytest.mark.run

--- a/tests/integration/test_run.py
+++ b/tests/integration/test_run.py
@@ -226,33 +226,6 @@ def test_run_inline_env_vars(pipenv_instance_pypi):
         assert c.returncode == 0, c.stderr
         assert "hello world" in c.stdout
 
-
-@pytest.mark.run
-@pytest.mark.skip_windows
-def test_run_script_expands_pipenv_project_dir(pipenv_instance_pypi):
-    with pipenv_instance_pypi() as p:
-        p.pipenv("install")
-
-        with open(os.path.join(p.path, "marker.txt"), "w") as f:
-            f.write("marker")
-
-        with open(p.pipfile_path, "w") as f:
-            f.write(
-                "[scripts]\n"
-                'show_project_file = "python -c \\"import pathlib, sys; print(pathlib.Path(sys.argv[1]).read_text())\\" $PIPENV_PROJECT_DIR/marker.txt"\n'
-            )
-
-        with temp_environ():
-            # CI runs the test suite under ``pipenv run pytest``, which injects
-            # the outer project's ``PIPENV_PROJECT_DIR`` into worker envs.
-            # Clear only that marker so the temp project can define its own
-            # without tripping nested-virtualenv courtesy behavior.
-            os.environ.pop("PIPENV_PROJECT_DIR", None)
-            c = p.pipenv("run show_project_file")
-        assert c.returncode == 0, c.stderr
-        assert c.stdout.strip() == "marker"
-
-
 @pytest.mark.run
 @pytest.mark.skip_windows
 def test_run_shell_builtins(pipenv_instance_pypi):

--- a/tests/integration/test_run.py
+++ b/tests/integration/test_run.py
@@ -229,6 +229,28 @@ def test_run_inline_env_vars(pipenv_instance_pypi):
 
 @pytest.mark.run
 @pytest.mark.skip_windows
+def test_run_script_expands_pipenv_project_dir(pipenv_instance_pypi):
+    with pipenv_instance_pypi() as p:
+        p.pipenv("install")
+
+        marker_path = os.path.join(p.path, "marker.txt")
+        with open(marker_path, "w") as f:
+            f.write("marker")
+
+        with open(p.pipfile_path, "w") as f:
+            f.write(
+                "[scripts]\n"
+                'show_project_file = "python -c \\"import pathlib, sys; path = pathlib.Path(sys.argv[1]); print(path); print(path.is_file())\\" $PIPENV_PROJECT_DIR/marker.txt"\n'
+            )
+
+        c = p.pipenv("run show_project_file")
+        assert c.returncode == 0, c.stderr
+        lines = [line.strip() for line in c.stdout.splitlines()]
+        assert lines == [marker_path, "True"]
+
+
+@pytest.mark.run
+@pytest.mark.skip_windows
 def test_run_shell_builtins(pipenv_instance_pypi):
     """Test that shell builtins work with pipenv run.
 

--- a/tests/integration/test_run.py
+++ b/tests/integration/test_run.py
@@ -244,9 +244,9 @@ def test_run_script_expands_pipenv_project_dir(pipenv_instance_pypi):
 
         with temp_environ():
             # CI runs the test suite under ``pipenv run pytest``, which injects
-            # outer-project markers into the worker environment. Drop them so
-            # this regression exercises the temp project directly.
-            os.environ.pop("PIPENV_ACTIVE", None)
+            # the outer project's ``PIPENV_PROJECT_DIR`` into worker envs.
+            # Clear only that marker so the temp project can define its own
+            # without tripping nested-virtualenv courtesy behavior.
             os.environ.pop("PIPENV_PROJECT_DIR", None)
             c = p.pipenv("run show_project_file")
         assert c.returncode == 0, c.stderr

--- a/tests/integration/test_run.py
+++ b/tests/integration/test_run.py
@@ -243,7 +243,11 @@ def test_run_script_expands_pipenv_project_dir(pipenv_instance_pypi):
             )
 
         with temp_environ():
-            os.environ["PIPENV_PROJECT_DIR"] = "/definitely/wrong"
+            # CI runs the test suite under ``pipenv run pytest``, which injects
+            # outer-project markers into the worker environment. Drop them so
+            # this regression exercises the temp project directly.
+            os.environ.pop("PIPENV_ACTIVE", None)
+            os.environ.pop("PIPENV_PROJECT_DIR", None)
             c = p.pipenv("run show_project_file")
         assert c.returncode == 0, c.stderr
         assert c.stdout.strip() == "marker"

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -4,7 +4,9 @@ from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
 
+from pipenv.cmdparse import Script
 from pipenv.project import NON_CATEGORY_SECTIONS
+from pipenv.routines.shell import do_run_posix
 from pipenv.shells import _get_activate_script, _get_deactivate_wrapper_script
 from pipenv.utils.environment import load_dot_env
 from pipenv.utils.shell import temp_environ
@@ -144,6 +146,24 @@ def test_load_dot_env_suppresses_message_when_pipenv_active(monkeypatch, capsys,
         assert os.environ[key] == val
         # But the "Loading .env" message should be suppressed
         assert "Loading .env" not in err
+
+
+@pytest.mark.core
+def test_do_run_posix_expands_project_dir_from_child_env():
+    script = Script("python", ["-c", "print('ok')", "$PIPENV_PROJECT_DIR/marker.txt"])
+    env = {"PATH": "/usr/bin", "PIPENV_PROJECT_DIR": "/tmp/project-root"}
+
+    with temp_environ():
+        os.environ["PIPENV_PROJECT_DIR"] = "/outer/project"
+        with patch("pipenv.routines.shell.system_which", return_value="/usr/bin/python"):
+            with patch("os.execve") as execve:
+                do_run_posix(project=MagicMock(), script=script, command="python", env=env)
+
+    execve.assert_called_once_with(
+        "/usr/bin/python",
+        ["/usr/bin/python", "-c", "print('ok')", "/tmp/project-root/marker.txt"],
+        {"PATH": "/usr/bin", "PIPENV_PROJECT_DIR": "/tmp/project-root"},
+    )
 
 
 @pytest.mark.core

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -2259,10 +2259,12 @@ def test_expand_url_credentials_unset_var_left_unchanged():
 @pytest.mark.utils
 def test_safe_expandvars_with_explicit_env_does_not_leak_ambient_vars(monkeypatch):
     monkeypatch.setenv("PIPENV_PROJECT_DIR", "/outer/project")
+    path_value = "/usr/bin:/bin"
+    monkeypatch.setenv("PATH", path_value)
 
     result = shell.safe_expandvars(
         "$PIPENV_PROJECT_DIR/marker.txt",
-        env={"PATH": os.environ["PATH"]},
+        env={"PATH": path_value},
     )
 
     assert result == "$PIPENV_PROJECT_DIR/marker.txt"

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -2256,6 +2256,18 @@ def test_expand_url_credentials_unset_var_left_unchanged():
     assert "${NONEXISTENT_VAR_12345}@" in result
 
 
+@pytest.mark.utils
+def test_safe_expandvars_with_explicit_env_does_not_leak_ambient_vars(monkeypatch):
+    monkeypatch.setenv("PIPENV_PROJECT_DIR", "/outer/project")
+
+    result = shell.safe_expandvars(
+        "$PIPENV_PROJECT_DIR/marker.txt",
+        env={"PATH": os.environ["PATH"]},
+    )
+
+    assert result == "$PIPENV_PROJECT_DIR/marker.txt"
+
+
 class TestTargetMarkerEnvironment:
     """Tests for _target_marker_environment (GH-6647).
 


### PR DESCRIPTION
Thank you for contributing to Pipenv!

### The issue

Fixes #6652.

Pipfile scripts that reference ``$PIPENV_PROJECT_DIR`` fail when ``pipenv run``
executes a command directly instead of through a shell. Argument expansion was
reading the parent process environment, so Pipenv-managed variables added only
to the child environment stayed unexpanded.

### The fix

This change routes script argument expansion through an env-aware helper that
uses the environment Pipenv is about to pass to the child process.

It updates the direct run paths on POSIX and Windows, and also covers script
sequences so inline ``KEY=value`` prefixes remain scoped to each subcommand.
A regression test now exercises a Pipfile script that reads a file through
``$PIPENV_PROJECT_DIR``. A news fragment is included.

### Verification

- ``pytest -q tests/unit/test_cmdparse.py``
- ``pytest -q tests/integration/test_run.py``

### The checklist

* [x] Associated issue
* [x] A news fragment in the `news/` directory to describe this fix with the extension `.bugfix.rst`, `.feature.rst`, `.behavior.rst`, `.doc.rst`. `.vendor.rst`. or `.trivial.rst` (this will appear in the release changelog). Use semantic line breaks and name the file after the issue number or the PR #.
