### PR TITLE
fix(auth): Pipfile creds win netrc; expand env vars in pylock sources (#6670)

### DIFF
--- a/news/6670.bugfix.rst
+++ b/news/6670.bugfix.rst
@@ -1,0 +1,11 @@
+Restored authentication to private indexes when ``[[source]]`` URLs use
+environment-variable placeholders. The GHSA-8xgg-v3jj-95m2 fix moved
+credentials off pip's argv onto a merged netrc, but
+``write_credentials_netrc`` wrote our Pipfile-derived ``machine`` blocks
+BEFORE the appended user netrc — and ``netrc.authenticators()`` returns
+the LAST matching entry, so a stale system entry for the same host
+silently overrode the freshly-expanded creds. Our blocks now come AFTER
+the user's existing content. Additionally, the ``pylock.toml`` reader
+now runs ``expand_url_credentials`` over its sources so users with
+``[pipenv] use_pylock = true`` see the same env-var expansion that
+``Pipfile.lock`` reads have always had.

--- a/pipenv/utils/internet.py
+++ b/pipenv/utils/internet.py
@@ -234,7 +234,13 @@ def write_credentials_netrc(sources, directory) -> Optional[str]:
     existing = _read_existing_netrc_content().strip()
     body = "\n".join(machine_blocks)
     if existing:
-        body = f"{body}\n{existing}\n"
+        # ``netrc.authenticators()`` returns the LAST matching entry for a
+        # host, so our Pipfile-derived blocks must come AFTER the user's
+        # existing netrc; otherwise a stale system entry for the same host
+        # silently overrides the credentials the user just supplied via
+        # Pipfile env-vars (regression seen after GHSA-8xgg-v3jj-95m2 moved
+        # auth off argv onto netrc — gh-6670).
+        body = f"{existing}\n\n{body}"
 
     netrc_path = os.path.join(str(directory), "pipenv-netrc")
     # Write with restrictive permissions: netrc parsers (and pip's vendored

--- a/pipenv/utils/pylock.py
+++ b/pipenv/utils/pylock.py
@@ -666,7 +666,20 @@ class PylockFile:
 
         # Add sources if present
         if "sources" in self.data:
-            lockfile["_meta"]["sources"] = self.data["sources"]
+            # Expand ${VAR} tokens in source URLs at read time so that
+            # callers downstream (resolver, finder, netrc-writer) see the
+            # real credentials.  Mirrors the legacy ``Pipfile.lock`` reader
+            # (``Lockfile.load``); without this, users with ``[pipenv]
+            # use_pylock = true`` lose env-var expansion in private-index
+            # URLs (gh-6670).
+            from pipenv.utils.shell import expand_url_credentials
+
+            sources = []
+            for source in self.data["sources"]:
+                if isinstance(source, dict) and "url" in source:
+                    source = {**source, "url": expand_url_credentials(source["url"])}
+                sources.append(source)
+            lockfile["_meta"]["sources"] = sources
         # If no sources in pylock.toml, add a default source
         else:
             lockfile["_meta"]["sources"] = [

--- a/tests/unit/test_credential_safety.py
+++ b/tests/unit/test_credential_safety.py
@@ -129,6 +129,73 @@ def test_write_credentials_netrc_decodes_url_encoded_password(tmp_path):
     assert "password p@ss!" in contents
 
 
+@pytest.mark.utils
+def test_write_credentials_netrc_pipfile_wins_over_existing_system_netrc(
+    tmp_path, monkeypatch
+):
+    """Pipfile-derived creds must beat a duplicate entry from the user's
+    pre-existing system netrc.
+
+    Regression test for gh-6670: after GHSA-8xgg-v3jj-95m2 moved auth from
+    URL-embedded argv onto a merged netrc, a stale ``machine`` block in
+    ``~/.netrc`` (or ``$NETRC``) for the same host silently overrode the
+    Pipfile's credentials because ``netrc.authenticators()`` returns the
+    LAST matching entry. Our blocks must come AFTER the appended existing
+    content so they win that tie-break.
+    """
+    import netrc
+
+    system_netrc = tmp_path / "system.netrc"
+    system_netrc.write_text(
+        "machine private.example.com\n  login STALE\n  password STALE\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("NETRC", str(system_netrc))
+
+    sources = [{"url": "https://fresh:freshpass@private.example.com/simple"}]
+    netrc_path = write_credentials_netrc(sources, tmp_path)
+    assert netrc_path is not None
+
+    login, _account, password = netrc.netrc(netrc_path).authenticators(
+        "private.example.com"
+    )
+    assert (login, password) == ("fresh", "freshpass"), (
+        "Pipfile-supplied creds must override the user's existing netrc"
+    )
+
+
+@pytest.mark.utils
+def test_write_credentials_netrc_from_env_var_expanded_url(tmp_path, monkeypatch):
+    """The expand_url_credentials → write_credentials_netrc round-trip must
+    produce a netrc with the expanded (real) credentials, not the literal
+    ``${VAR}`` placeholders.
+
+    Regression test for gh-6670: ensures that env-var-bearing source URLs
+    flow through ``pipfile_sources()`` (which calls
+    ``expand_url_credentials``) and yield a netrc with the actual user/pass,
+    matching the hardcoded-credentials behavior the GHSA fix preserved.
+    """
+    import netrc
+
+    from pipenv.utils.shell import expand_url_credentials
+
+    monkeypatch.setenv("NEXUS_USERNAME", "real-user")
+    monkeypatch.setenv("NEXUS_PASSWORD", "real-pass!@#")
+
+    raw_url = (
+        "https://${NEXUS_USERNAME}:${NEXUS_PASSWORD}"
+        "@nexus.example.com/repository/pypi/simple"
+    )
+    expanded = expand_url_credentials(raw_url)
+    netrc_path = write_credentials_netrc([{"url": expanded}], tmp_path)
+    assert netrc_path is not None
+
+    login, _account, password = netrc.netrc(netrc_path).authenticators(
+        "nexus.example.com"
+    )
+    assert (login, password) == ("real-user", "real-pass!@#")
+
+
 # --- pip_install_deps integration -------------------------------------------
 
 

--- a/tests/unit/test_pylock.py
+++ b/tests/unit/test_pylock.py
@@ -166,6 +166,36 @@ def test_convert_to_pipenv_lockfile(pylock_file):
     assert lockfile["develop"]["pytest"]["markers"] == "'dev' in dependency_groups or 'test' in dependency_groups"
 
 
+def test_convert_to_pipenv_lockfile_expands_env_vars_in_source_urls(
+    tmp_path, monkeypatch
+):
+    """Regression test for gh-6670: pylock-converted sources must expand
+    ``${VAR}`` tokens in URLs just like ``Pipfile.lock`` reads do, otherwise
+    users with ``[pipenv] use_pylock = true`` see env-var auth silently
+    fall through to literal placeholders.
+    """
+    pylock_path = tmp_path / "pylock.toml"
+    pylock_path.write_text(
+        'lock-version = "1.0"\n'
+        'created-by = "pipenv"\n'
+        "\n"
+        "[[sources]]\n"
+        'name = "nexus"\n'
+        'url = "https://${NEXUS_USERNAME}:${NEXUS_PASSWORD}@nexus.example.com/repository/pypi/simple"\n'
+        "verify_ssl = true\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("NEXUS_USERNAME", "alice")
+    monkeypatch.setenv("NEXUS_PASSWORD", "s3cret")
+
+    pylock = PylockFile.from_path(pylock_path)
+    lockfile = pylock.convert_to_pipenv_lockfile()
+    sources = lockfile["_meta"]["sources"]
+    assert sources[0]["url"] == (
+        "https://alice:s3cret@nexus.example.com/repository/pypi/simple"
+    )
+
+
 def test_from_lockfile(tmp_path):
     """Test creating a PylockFile from a Pipfile.lock file."""
     # Create a simple Pipfile.lock


### PR DESCRIPTION
## Summary

Closes #6670 — restores authentication to private indexes when `[[source]]` URLs use environment-variable placeholders, regressed in 2026.6.1 by the GHSA-8xgg-v3jj-95m2 fix.

- **netrc precedence**: `write_credentials_netrc` wrote our Pipfile-derived `machine` blocks BEFORE the appended existing user netrc. Python's `netrc.authenticators()` returns the LAST matching entry, so any stale system entry for the same host silently overrode the freshly-expanded creds. Reverse the order so our blocks come last and win the tie-break.
- **pylock expansion**: `PylockFile.convert_to_pipenv_lockfile` assigned `self.data[\"sources\"]` raw, dropping env-var expansion on the `[pipenv] use_pylock = true` path. Mirror the legacy `Lockfile.load` behavior by running `expand_url_credentials` over each source URL.

## Test plan

- [x] `pytest tests/unit/test_credential_safety.py tests/unit/test_pylock.py` (37 passed)
- [x] `pytest tests/unit/test_utils.py tests/unit/test_lockfile.py tests/unit/test_pep691_client.py tests/unit/test_resolver_auth.py` (broader sweep, 373 passed)
- [x] New regression tests:
  - `test_write_credentials_netrc_pipfile_wins_over_existing_system_netrc`
  - `test_write_credentials_netrc_from_env_var_expanded_url`
  - `test_convert_to_pipenv_lockfile_expands_env_vars_in_source_urls`

🤖 Generated with [Claude Code](https://claude.com/claude-code)