### PR TITLE
fix(update): re-lock all Pipfile entries when no packages are given (#6672)

### DIFF
--- a/news/6672.bugfix.rst
+++ b/news/6672.bugfix.rst
@@ -1,0 +1,8 @@
+Restored documented ``pipenv update`` (no args) semantics of ``lock + sync``.
+Since 2026.0.0, ``pipenv update`` only re-resolved Pipfile entries whose
+locked version no longer satisfied the Pipfile specifier, so relaxing a
+pin (e.g. ``urllib3 = "<2.7.0"`` → ``urllib3 = "*"``) would not pick up
+newer allowed releases — the lockfile silently stayed at the existing
+pin. ``pipenv update`` now routes through ``do_lock`` when no packages
+are given, re-resolving every Pipfile entry. The targeted
+``pipenv update <pkg>`` path is unchanged.

--- a/pipenv/routines/update.py
+++ b/pipenv/routines/update.py
@@ -8,7 +8,7 @@ from typing import Dict, Set, Tuple
 from pipenv.exceptions import JSONParseError, PipenvCmdError
 from pipenv.patched.pip._vendor.packaging.specifiers import SpecifierSet
 from pipenv.patched.pip._vendor.packaging.version import InvalidVersion, Version
-from pipenv.routines.lock import overwrite_with_default
+from pipenv.routines.lock import do_lock, overwrite_with_default
 from pipenv.routines.outdated import do_outdated
 from pipenv.routines.sync import do_sync
 from pipenv.utils import err
@@ -69,33 +69,49 @@ def do_update(
     )
 
     if not outdated:
-        # Pre-sync packages for pipdeptree resolution to avoid conflicts
-        if project.any_lockfile_exists:
-            do_sync(
+        if not packages and not editable:
+            # Documented behavior of `pipenv update` (no args) is `lock + sync`:
+            # re-resolve every package against the Pipfile, then sync. The
+            # partial-upgrade path in `upgrade()` only re-resolves Pipfile
+            # entries whose locked version no longer satisfies the spec, which
+            # silently skips picking up newer allowed releases (gh-6672).
+            do_lock(
                 project,
-                dev=dev,
-                categories=categories,
-                python=python,
-                bare=bare,
-                clear=clear,
-                pypi_mirror=pypi_mirror,
-                extra_pip_args=extra_pip_args,
                 system=system,
+                clear=clear,
+                pre=pre,
+                pypi_mirror=pypi_mirror,
+                categories=_prepare_categories(categories, dev, packages=[]),
+                extra_pip_args=extra_pip_args,
             )
-        upgrade(
-            project,
-            pre=pre,
-            system=system,
-            packages=packages,
-            editable_packages=editable,
-            pypi_mirror=pypi_mirror,
-            categories=categories,
-            index_url=index_url,
-            dev=dev,
-            lock_only=lock_only,
-            extra_pip_args=extra_pip_args,
-        )
-        # Finally sync packages after upgrade
+        else:
+            # Pre-sync packages for pipdeptree resolution to avoid conflicts
+            if project.any_lockfile_exists:
+                do_sync(
+                    project,
+                    dev=dev,
+                    categories=categories,
+                    python=python,
+                    bare=bare,
+                    clear=clear,
+                    pypi_mirror=pypi_mirror,
+                    extra_pip_args=extra_pip_args,
+                    system=system,
+                )
+            upgrade(
+                project,
+                pre=pre,
+                system=system,
+                packages=packages,
+                editable_packages=editable,
+                pypi_mirror=pypi_mirror,
+                categories=categories,
+                index_url=index_url,
+                dev=dev,
+                lock_only=lock_only,
+                extra_pip_args=extra_pip_args,
+            )
+        # Finally sync packages after lock/upgrade
         do_sync(
             project,
             dev=dev,

--- a/tests/unit/test_update.py
+++ b/tests/unit/test_update.py
@@ -1,7 +1,11 @@
 """Unit tests for pipenv.routines.update helpers."""
 from unittest.mock import MagicMock, patch
 
-from pipenv.routines.update import _clean_unused_dependencies, _process_package_args
+from pipenv.routines.update import (
+    _clean_unused_dependencies,
+    _process_package_args,
+    do_update,
+)
 
 
 def _make_project(verbose=False):
@@ -415,3 +419,98 @@ def test_process_package_args_writes_to_pipfile_when_package_in_correct_category
         "requests", "requests", "==2.31.0", category="packages"
     )
 
+
+# ---------------------------------------------------------------------------
+# do_update routing – `pipenv update` (no args) must do lock + sync (issue #6672)
+# ---------------------------------------------------------------------------
+
+
+def _do_update_project_mock():
+    """Project mock for exercising do_update routing decisions."""
+    project = MagicMock()
+    project.s.PIPENV_USE_SYSTEM = False
+    project.any_lockfile_exists = True
+    return project
+
+
+def test_do_update_no_args_goes_through_do_lock():
+    """Regression for gh-6672.
+
+    `pipenv update` with no package arguments must re-resolve every package
+    against the Pipfile (documented behavior: ``lock + sync``). The partial
+    ``upgrade()`` path only re-resolves Pipfile entries whose locked version
+    no longer satisfies the spec, which silently skips picking up newer
+    allowed releases (e.g. relaxing ``urllib3 = "<2.7.0"`` to
+    ``urllib3 = "*"`` would not bump the locked 2.6.3).
+    """
+    project = _do_update_project_mock()
+    with patch("pipenv.routines.update.do_lock") as mock_lock, patch(
+        "pipenv.routines.update.upgrade"
+    ) as mock_upgrade, patch("pipenv.routines.update.do_sync") as mock_sync, patch(
+        "pipenv.routines.update.ensure_project"
+    ):
+        do_update(project, packages=[], editable_packages=[])
+
+    mock_lock.assert_called_once()
+    mock_upgrade.assert_not_called()
+    # Lock runs once, then a single sync to install what was locked.
+    assert mock_sync.call_count == 1
+
+
+def test_do_update_with_packages_uses_upgrade_path():
+    """`pipenv update <pkg>` keeps the targeted ``upgrade()`` flow."""
+    project = _do_update_project_mock()
+    with patch("pipenv.routines.update.do_lock") as mock_lock, patch(
+        "pipenv.routines.update.upgrade"
+    ) as mock_upgrade, patch("pipenv.routines.update.do_sync") as mock_sync, patch(
+        "pipenv.routines.update.ensure_project"
+    ):
+        do_update(project, packages=["requests"], editable_packages=[])
+
+    mock_lock.assert_not_called()
+    mock_upgrade.assert_called_once()
+    # Pre-sync (lockfile already exists) + post-sync.
+    assert mock_sync.call_count == 2
+
+
+def test_do_update_no_args_with_dev_locks_default_and_develop():
+    """`pipenv update --dev` (no args) must lock both default and develop."""
+    project = _do_update_project_mock()
+    with patch("pipenv.routines.update.do_lock") as mock_lock, patch(
+        "pipenv.routines.update.upgrade"
+    ), patch("pipenv.routines.update.do_sync"), patch(
+        "pipenv.routines.update.ensure_project"
+    ):
+        do_update(project, packages=[], editable_packages=[], dev=True)
+
+    _, kwargs = mock_lock.call_args
+    assert kwargs["categories"] == ["default", "develop"]
+
+
+def test_do_update_no_args_default_locks_default_only():
+    """`pipenv update` (no args, no --dev) locks the default category only."""
+    project = _do_update_project_mock()
+    with patch("pipenv.routines.update.do_lock") as mock_lock, patch(
+        "pipenv.routines.update.upgrade"
+    ), patch("pipenv.routines.update.do_sync"), patch(
+        "pipenv.routines.update.ensure_project"
+    ):
+        do_update(project, packages=[], editable_packages=[])
+
+    _, kwargs = mock_lock.call_args
+    assert kwargs["categories"] == ["default"]
+
+
+def test_do_update_outdated_skips_both_lock_and_upgrade():
+    """`pipenv update --outdated` routes to do_outdated, not lock/upgrade."""
+    project = _do_update_project_mock()
+    with patch("pipenv.routines.update.do_lock") as mock_lock, patch(
+        "pipenv.routines.update.upgrade"
+    ) as mock_upgrade, patch("pipenv.routines.update.do_outdated") as mock_outdated, patch(
+        "pipenv.routines.update.do_sync"
+    ), patch("pipenv.routines.update.ensure_project"):
+        do_update(project, packages=[], editable_packages=[], outdated=True)
+
+    mock_lock.assert_not_called()
+    mock_upgrade.assert_not_called()
+    mock_outdated.assert_called_once()


### PR DESCRIPTION
## Summary

- Fixes #6672. Since 2026.0.0, `pipenv update` (no args) silently became a no-op when relaxing a Pipfile pin — the lockfile stayed at the previously pinned version even when the spec allowed newer releases.
- Root cause: gh-6455 routed `do_update` through the partial `upgrade()` path, which only re-resolves Pipfile entries whose locked version no longer satisfies the spec. Relaxing `urllib3 = "<2.7.0"` → `urllib3 = "*"` doesn't trigger that condition because `2.6.3` still satisfies `*`.
- `docs/commands.md:241` describes `pipenv update` (no args) as `lock + sync`. This PR restores that semantics by routing `do_update` through `do_lock` when no packages/editables are given, scoped to the same categories `_prepare_categories` would pick (default + develop on `--dev`, default otherwise). The targeted `pipenv update <pkg>` flow is unchanged.

## Test plan

- [x] New unit tests in `tests/unit/test_update.py` covering: no-args routes through `do_lock`; `<pkg>` routes through `upgrade`; `--dev` locks default + develop; default locks default only; `--outdated` still bypasses both paths.
- [x] All existing `tests/unit/test_update.py` tests still pass (16/16).
- [x] Verified end-to-end against the issue's reproducer in a scratch project: `urllib3 = "<2.7.0"` locked at `2.6.3`, then changed to `urllib3 = "*"` and ran `pipenv update` — lockfile re-resolved to `urllib3==2.7.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)