### PR TITLE
Accept a major-only python_version such as "3"

### DIFF
--- a/news/6687.bugfix.rst
+++ b/news/6687.bugfix.rst
@@ -1,0 +1,8 @@
+Restored support for a major-only ``python_version`` such as ``python_version
+= "3"`` in the Pipfile ``[requires]`` section, which the documentation lists as
+valid. The version check added in 6535 compared the major and minor components
+whenever fewer than three were given, but ``"3"`` parses to ``3.0``, so every
+3.x interpreter but 3.0 was reported as a mismatch. That produced a spurious
+warning on install and a fatal ``DeployException`` under ``--deploy``. Only the
+components actually given are compared now, so ``"3"`` matches any 3.x while
+``"3.13"`` and ``"3.13.1"`` keep their existing meaning.

--- a/pipenv/utils/project.py
+++ b/pipenv/utils/project.py
@@ -30,6 +30,8 @@ def _python_version_matches_required(actual_ver_str, required_ver_str):
 
     ``actual_ver_str`` is the full version string reported by the Python
     interpreter (e.g. ``"3.13.1"``).
+
+    ``required_ver_str`` may also come from the ``--python`` CLI argument.
     """
     if not actual_ver_str or not required_ver_str:
         return False

--- a/pipenv/utils/project.py
+++ b/pipenv/utils/project.py
@@ -24,7 +24,9 @@ def _python_version_matches_required(actual_ver_str, required_ver_str):
 
     * A PEP 440 version specifier string like ``">=3.8"`` or ``">=3.9,<4"``
       (the ``python_version`` field contains an operator).
-    * A plain ``"X.Y"`` (major.minor) or ``"X.Y.Z"`` (full version) string.
+    * A plain ``"X"`` (major), ``"X.Y"`` (major.minor) or ``"X.Y.Z"`` (full
+      version) string. Only the components actually given are compared, so
+      ``"3"`` is satisfied by any 3.x interpreter.
 
     ``actual_ver_str`` is the full version string reported by the Python
     interpreter (e.g. ``"3.13.1"``).
@@ -44,12 +46,17 @@ def _python_version_matches_required(actual_ver_str, required_ver_str):
     try:
         actual = parse_version(actual_ver_str)
         required = parse_version(required_ver_str)
-        if len(required_ver_str.split(".")) >= 3:
+        given_components = len(required_ver_str.split("."))
+        if given_components >= 3:
             # python_full_version specified — must match exactly.
             return actual == required
-        else:
+        elif given_components == 2:
             # python_version (major.minor only) — compare only those components.
             return actual.major == required.major and actual.minor == required.minor
+        else:
+            # Major only, e.g. "3". parse_version fills in a 0 minor, so
+            # comparing the minor here would reject every 3.x but 3.0.
+            return actual.major == required.major
     except Exception:
         # Fallback for any unparseable version strings.
         return actual_ver_str == required_ver_str

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1023,6 +1023,17 @@ class TestPythonVersionMatchesRequired:
             ("3.11.0", "3.11.1", False),
             ("3.13.11", "3.11.0", False),
             ("3.11.10", "3.11.1", False),  # "3.11.1" is substring of "3.11.10"
+            # --- Major-only cases (https://github.com/pypa/pipenv/issues/6687) ---
+            # "3" is documented as a valid python_version, but parse_version
+            # fills in a 0 minor, so comparing the minor rejected every 3.x
+            # except 3.0.
+            ("3.13.14", "3", True),
+            ("3.9.1", "3", True),
+            ("3.0.0", "3", True),
+            ("3.11", "3", True),
+            ("2.7.18", "3", False),
+            ("4.0.0", "3", False),
+            ("2.7.18", "2", True),
             # --- Edge / guard cases ---
             ("", "3.11", False),
             ("3.11.0", "", False),


### PR DESCRIPTION
## Summary

Fixes #6687. `python_version = "3"` in the Pipfile `[requires]` section — which [the docs list as valid](https://pipenv.pypa.io/en/latest/specifiers.html#python-version-vs-full-version) — produced a spurious mismatch warning on install and a fatal `DeployException` under `--deploy`.

`_python_version_matches_required` branches on how many components the requirement has, but only distinguished "3 or more" from "everything else":

```python
if len(required_ver_str.split(".")) >= 3:
    return actual == required            # full version, exact
else:
    return actual.major == required.major and actual.minor == required.minor
```

`"3"` has one component, so it took the second branch — and `parse_version("3")` fills in a **zero minor**, so the comparison became `actual.minor == 0`. Every 3.x interpreter except 3.0 was rejected:

```
parse_version("3") -> 3 | major 3 | minor 0
actual=3.13.14  required='3'  -> False
```

## Change

Compare only the components actually given:

| requirement | compared |
| --- | --- |
| `"3"` | major only |
| `"3.13"` | major + minor |
| `"3.13.1"` | exact |

The PEP 440 specifier path (`">=3.9"`, `">=3.9,<4"`) is untouched.

## Tests

`TestPythonVersionMatchesRequired` already has a parametrized table, so the major-only cases go in alongside the existing #6514 substring-regression rows: `3.13.14`/`3.9.1`/`3.0.0`/`3.11` all satisfy `"3"`, while `2.7.18` and `4.0.0` don't, plus `2.7.18` against `"2"` so the rule isn't special-cased to Python 3.

Reverting only `pipenv/` fails exactly the new rows and nothing else:

```
FAILED ...test_version_match[3.13.14-3-True]
FAILED ...test_version_match[3.9.1-3-True]
FAILED ...test_version_match[3.11-3-True]
FAILED ...test_version_match[2.7.18-2-True]
4 failed, 22 passed
```

## Verification

- `pytest tests/unit/test_utils.py -k PythonVersionMatchesRequired` → 26 passed
- `pytest tests/unit/test_utils.py` → **210 passed, 5 skipped** (skips are POSIX-only path tests, I'm on Windows)
- `ruff check` on both changed files → all checks passed
- Added `news/6687.bugfix.rst`

One note: `ruff format --check` reports both changed files as needing reformatting, but that's **pre-existing on a clean tree** (verified by stashing), so I left it alone rather than mixing unrelated reformatting into this diff.
