### PR TITLE
Add missing `-r` flag to README requirements.txt example

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,7 +381,7 @@ pipenv shell
 
 If you would like to convert a project that currently uses a requirements.txt file to use Pipenv, install Pipenv and run:
 
-pipenv install requirements.txt
+pipenv install -r requirements.txt
 
 This will create a Pipfile and install the specified requirements.
 

--- a/news/6689.doc.rst
+++ b/news/6689.doc.rst
@@ -1,0 +1,1 @@
+Corrected the requirements.txt import example in the README, which was missing the ``-r`` flag.


### PR DESCRIPTION
## Summary

The README's requirements.txt migration example omits the `-r` flag:

```
pipenv install requirements.txt
```

Without `-r`, pipenv treats `requirements.txt` as a package name rather than a requirements file, so the command does not do what the surrounding sentence describes ("This will create a Pipfile and install the specified requirements").

Closes #6689.

## Verification

The README is the only place in the repository that gets this wrong. Every other occurrence already uses `-r`:

- `docs/best_practices.md:301`
- `docs/cli.md:80`
- `docs/commands.md:69`
- `docs/migrating.md` (lines 18, 47, 61, 86, 169, 191, 250)
- `docs/pipfile.md:357`
- `docs/troubleshooting.md:585`
- `docs/workflows.md:39`

Added a `news/` fragment under `doc`, per CONTRIBUTING.
