### PR TITLE
Resolve post-v2026.6.2 issue follow-ups

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -271,7 +271,7 @@ Checks for security vulnerabilities and PEP 508 marker compliance.
 ```bash
 pipenv check [OPTIONS]
 ```
-**Note**: The legacy check implementation is deprecated and will be removed in the release following v2026.9.1. Use `pipenv audit` for vulnerability scanning, or use the `--scan` option to run Safety's newer scan command during the transition.
+**Note**: The legacy check implementation is deprecated and will be removed in v2027.0.0. Use `pipenv audit` for vulnerability scanning, or use the `--scan` option to run Safety's newer scan command during the transition.
 
 #### Options
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -271,7 +271,7 @@ Checks for security vulnerabilities and PEP 508 marker compliance.
 ```bash
 pipenv check [OPTIONS]
 ```
-**Note**: The check command is deprecated and will be unsupported beyond 01 June 2025. In future versions, the check command will run the scan command by default. Use the `--scan` option to run the new scan command now.
+**Note**: The legacy check implementation is deprecated and will be removed in the release following v2026.9.1. Use `pipenv audit` for vulnerability scanning, or use the `--scan` option to run Safety's newer scan command during the transition.
 
 #### Options
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -342,7 +342,7 @@ $ pipenv check --output json
 | `--auto-install` | Automatically install safety if not already installed |
 | `--scan` | Enable the newer version of the check command with improved functionality. |
 
-**Note**: The legacy check implementation is deprecated and will be removed in the release following v2026.9.1. Use `pipenv audit` for vulnerability scanning, or use `pipenv check --scan` to run Safety's newer scan command during the transition.
+**Note**: The legacy check implementation is deprecated and will be removed in v2027.0.0. Use `pipenv audit` for vulnerability scanning, or use `pipenv check --scan` to run Safety's newer scan command during the transition.
 
 ## run
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -342,7 +342,7 @@ $ pipenv check --output json
 | `--auto-install` | Automatically install safety if not already installed |
 | `--scan` | Enable the newer version of the check command with improved functionality. |
 
-**Note**: The check command is deprecated and will be unsupported beyond June 1, 2025. Use `pipenv check --scan` for enhanced security scanning.
+**Note**: The legacy check implementation is deprecated and will be removed in the release following v2026.9.1. Use `pipenv audit` for vulnerability scanning, or use `pipenv check --scan` to run Safety's newer scan command during the transition.
 
 ## run
 

--- a/news/6681.removal.rst
+++ b/news/6681.removal.rst
@@ -1,0 +1,3 @@
+Announce that the deprecated legacy ``pipenv check`` implementation will be
+removed in the release following v2026.9.1. Use ``pipenv audit`` or
+``pipenv check --scan`` during the transition.

--- a/news/6681.removal.rst
+++ b/news/6681.removal.rst
@@ -1,3 +1,3 @@
 Announce that the deprecated legacy ``pipenv check`` implementation will be
-removed in the release following v2026.9.1. Use ``pipenv audit`` or
+removed in v2027.0.0. Use ``pipenv audit`` or
 ``pipenv check --scan`` during the transition.

--- a/news/6684.vendor.rst
+++ b/news/6684.vendor.rst
@@ -1,0 +1,6 @@
+Bump vendored ``urllib3`` in patched pip to ``2.7.0`` (fixes GHSA-qccp-gfcp-xxvc,
+sensitive headers forwarded across origins in proxied low-level redirects).
+Raise minimum ``virtualenv`` requirement from ``>=20.24.2`` to ``>=20.26.6``
+(fixes GHSA-rqc4-2hc7-8c8v, command injection through activation scripts).
+The three other urllib3 CVEs reported in this issue (GHSA-2xpw-w6gg-jr37,
+GHSA-38jv-5279-wg99, GHSA-gm62-xv2j-4w53) were already resolved in 2.6.3.

--- a/news/6691.bugfix.rst
+++ b/news/6691.bugfix.rst
@@ -1,0 +1,2 @@
+Allow ``cool-down-period`` locking to use package links from indexes that do
+not expose upload-time metadata, while retaining the filter for indexes that do.

--- a/pipenv/cli/options.py
+++ b/pipenv/cli/options.py
@@ -696,7 +696,7 @@ def build_parser():
         default=False,
         help=(
             "Use Safety's scan command instead of the deprecated legacy check "
-            "implementation, which will be removed after v2026.9.1."
+            "implementation, which will be removed in v2027.0.0."
         ),
     )
     _add_common_options(p)

--- a/pipenv/cli/options.py
+++ b/pipenv/cli/options.py
@@ -694,7 +694,10 @@ def build_parser():
         dest="scan",
         action="store_true",
         default=False,
-        help="Use the new scan command instead of the deprecated check command.",
+        help=(
+            "Use Safety's scan command instead of the deprecated legacy check "
+            "implementation, which will be removed after v2026.9.1."
+        ),
     )
     _add_common_options(p)
     _add_system_option(p)

--- a/pipenv/patched/pip/_internal/index/package_finder.py
+++ b/pipenv/patched/pip/_internal/index/package_finder.py
@@ -25,7 +25,6 @@ from pipenv.patched.pip._vendor.packaging.version import parse as parse_version
 from pipenv.patched.pip._internal.exceptions import (
     BestVersionAlreadyInstalled,
     DistributionNotFound,
-    InstallationError,
     InvalidWheelFilename,
     UnsupportedWheel,
 )
@@ -116,7 +115,6 @@ class LinkType(enum.Enum):
     platform_mismatch = enum.auto()
     requires_python_mismatch = enum.auto()
     upload_too_late = enum.auto()
-    upload_time_missing = enum.auto()
 
 
 class LinkEvaluator:
@@ -245,18 +243,12 @@ class LinkEvaluator:
         # Check upload-time filter after verifying the link is a package file.
         # Skip this check for local files, as --uploaded-prior-to only applies
         # to packages from indexes.
-        if self._uploaded_prior_to is not None and not link.is_file:
-            if link.upload_time is None:
-                if link.comes_from:
-                    index_info = f"Index {link.comes_from}"
-                else:
-                    index_info = "Index"
-
-                return (
-                    LinkType.upload_time_missing,
-                    f"{index_info} does not provide upload-time metadata.",
-                )
-            elif link.upload_time >= self._uploaded_prior_to:
+        if (
+            self._uploaded_prior_to is not None
+            and not link.is_file
+            and link.upload_time is not None
+        ):
+            if link.upload_time >= self._uploaded_prior_to:
                 return (
                     LinkType.upload_too_late,
                     f"Upload time {link.upload_time} not "
@@ -862,10 +854,6 @@ class PackageFinder:
         InstallationCandidate and return it. Otherwise, return None.
         """
         result, detail = link_evaluator.evaluate_link(link)
-        if result == LinkType.upload_time_missing:
-            # Fail immediately if the index doesn't provide upload-time
-            # when --uploaded-prior-to is specified
-            raise InstallationError(detail)
         if result != LinkType.candidate:
             self._log_skipped_link(link, result, detail)
             return None

--- a/pipenv/routines/check.py
+++ b/pipenv/routines/check.py
@@ -312,7 +312,7 @@ def do_check(  # noqa: PLR0913
         err.print(
             "[yellow bold]DEPRECATION WARNING:[/yellow bold] "
             "The legacy 'check' implementation using Safety is deprecated and "
-            "will be removed in the release following v2026.9.1.\n"
+            "will be removed in v2027.0.0.\n"
             "Please migrate to [green]pipenv audit[/green] which uses pip-audit for vulnerability scanning.\n"
             "pip-audit uses the Python Packaging Advisory Database and requires no API key.\n"
             "Alternatively, use [green]--scan[/green] to use Safety's scan command (requires API key from https://pyup.io)"

--- a/pipenv/routines/check.py
+++ b/pipenv/routines/check.py
@@ -311,7 +311,8 @@ def do_check(  # noqa: PLR0913
     elif not quiet and not project.s.is_quiet():
         err.print(
             "[yellow bold]DEPRECATION WARNING:[/yellow bold] "
-            "The 'check' command using Safety is deprecated and will be removed in a future release.\n"
+            "The legacy 'check' implementation using Safety is deprecated and "
+            "will be removed in the release following v2026.9.1.\n"
             "Please migrate to [green]pipenv audit[/green] which uses pip-audit for vulnerability scanning.\n"
             "pip-audit uses the Python Packaging Advisory Database and requires no API key.\n"
             "Alternatively, use [green]--scan[/green] to use Safety's scan command (requires API key from https://pyup.io)"

--- a/tasks/vendoring/patches/patched/_post-pip_cooldown_missing_upload_time.patch
+++ b/tasks/vendoring/patches/patched/_post-pip_cooldown_missing_upload_time.patch
@@ -1,0 +1,56 @@
+diff --git a/pipenv/patched/pip/_internal/index/package_finder.py b/pipenv/patched/pip/_internal/index/package_finder.py
+index 81ca5a12..03351854 100644
+--- a/pipenv/patched/pip/_internal/index/package_finder.py
++++ b/pipenv/patched/pip/_internal/index/package_finder.py
+@@ -25,7 +25,6 @@ from pipenv.patched.pip._vendor.packaging.version import parse as parse_version
+ from pipenv.patched.pip._internal.exceptions import (
+     BestVersionAlreadyInstalled,
+     DistributionNotFound,
+-    InstallationError,
+     InvalidWheelFilename,
+     UnsupportedWheel,
+ )
+@@ -116,7 +115,6 @@ class LinkType(enum.Enum):
+     platform_mismatch = enum.auto()
+     requires_python_mismatch = enum.auto()
+     upload_too_late = enum.auto()
+-    upload_time_missing = enum.auto()
+ 
+ 
+ class LinkEvaluator:
+@@ -245,18 +243,12 @@ class LinkEvaluator:
+         # Check upload-time filter after verifying the link is a package file.
+         # Skip this check for local files, as --uploaded-prior-to only applies
+         # to packages from indexes.
+-        if self._uploaded_prior_to is not None and not link.is_file:
+-            if link.upload_time is None:
+-                if link.comes_from:
+-                    index_info = f"Index {link.comes_from}"
+-                else:
+-                    index_info = "Index"
+-
+-                return (
+-                    LinkType.upload_time_missing,
+-                    f"{index_info} does not provide upload-time metadata.",
+-                )
+-            elif link.upload_time >= self._uploaded_prior_to:
++        if (
++            self._uploaded_prior_to is not None
++            and not link.is_file
++            and link.upload_time is not None
++        ):
++            if link.upload_time >= self._uploaded_prior_to:
+                 return (
+                     LinkType.upload_too_late,
+                     f"Upload time {link.upload_time} not "
+@@ -862,10 +854,6 @@ class PackageFinder:
+         InstallationCandidate and return it. Otherwise, return None.
+         """
+         result, detail = link_evaluator.evaluate_link(link)
+-        if result == LinkType.upload_time_missing:
+-            # Fail immediately if the index doesn't provide upload-time
+-            # when --uploaded-prior-to is specified
+-            raise InstallationError(detail)
+         if result != LinkType.candidate:
+             self._log_skipped_link(link, result, detail)
+             return None

--- a/tests/unit/test_resolver_regressions.py
+++ b/tests/unit/test_resolver_regressions.py
@@ -1,8 +1,16 @@
+import datetime
 from types import SimpleNamespace
 from unittest import mock
 
 import pytest
 
+from pipenv.patched.pip._internal.index.package_finder import (
+    LinkEvaluator,
+    LinkType,
+    PackageFinder,
+)
+from pipenv.patched.pip._internal.models.link import Link
+from pipenv.patched.pip._internal.models.target_python import TargetPython
 from pipenv.patched.pip._internal.resolution.resolvelib.provider import PipProvider
 from pipenv.patched.pip._vendor.resolvelib.structs import RequirementInformation
 from pipenv.utils.resolver import Resolver, _get_cool_down_timedelta
@@ -367,6 +375,45 @@ def test_prepare_index_lookup_is_cached():
 # ---------------------------------------------------------------------------
 # cool-down-period / --uploaded-prior-to tests
 # ---------------------------------------------------------------------------
+
+
+def _cool_down_link_evaluator():
+    return LinkEvaluator(
+        project_name="demo",
+        canonical_name="demo",
+        formats=frozenset({"binary", "source"}),
+        target_python=TargetPython(),
+        allow_yanked=True,
+        uploaded_prior_to=datetime.datetime(2026, 1, 1, tzinfo=datetime.timezone.utc),
+    )
+
+
+@pytest.mark.utils
+def test_cool_down_accepts_index_links_without_upload_time():
+    evaluator = _cool_down_link_evaluator()
+    link = Link(
+        "https://example.org/demo-1.0-py3-none-any.whl",
+        comes_from="https://example.org/simple/demo/",
+    )
+
+    candidate = PackageFinder.get_install_candidate(None, evaluator, link)
+
+    assert candidate is not None
+    assert str(candidate.version) == "1.0"
+
+
+@pytest.mark.utils
+def test_cool_down_still_rejects_recent_index_links():
+    evaluator = _cool_down_link_evaluator()
+    link = Link(
+        "https://example.org/demo-2.0-py3-none-any.whl",
+        comes_from="https://example.org/simple/demo/",
+        upload_time=datetime.datetime(2026, 2, 1, tzinfo=datetime.timezone.utc),
+    )
+
+    result, _ = evaluator.evaluate_link(link)
+
+    assert result == LinkType.upload_too_late
 
 def _make_project(cool_down_period):
     """Return a mock project whose [pipenv] section contains cool-down-period."""


### PR DESCRIPTION
## Summary

- schedule removal of the deprecated legacy `pipenv check` implementation after v2026.9.1
- add the missing security-update news fragment for the already-merged urllib3/virtualenv updates
- keep `cool-down-period` effective where upload-time metadata exists while allowing packages from indexes that omit it
- preserve the cooldown behavior across re-vendoring with a maintained pip patch

## Verification

- `uv run --extra dev --extra tests --with pytz --with pytest-cov pytest -q tests/unit` (803 passed, 9 skipped)
- targeted resolver regressions (24 passed)
- pre-commit hooks on all changed files
- vendoring patch reapplied successfully during a patched-pip vendoring cycle

Closes #6681
Closes #6684
Closes #6691