### PR TITLE
Make interrupted releases resumable

### DIFF
--- a/news/+release-pipeline-recovery.process.rst
+++ b/news/+release-pipeline-recovery.process.rst
@@ -1,0 +1,3 @@
+Make the release task resumable after a completed version bump, consume Towncrier
+fragments non-interactively, and avoid trailing whitespace in generated release
+notes.

--- a/news/towncrier_template.rst
+++ b/news/towncrier_template.rst
@@ -24,7 +24,7 @@
 
 {% if definitions[category]['showcontent'] %}
 {% for text, values in sections[section][category]|dictsort(by='value') %}
-- {{ text }}  {% if category != 'process' %}{{ values|sort|join(',\n  ') }}{% endif %}
+- {{ text }}{% if category != 'process' and values %}  {{ values|sort|join(',\n  ') }}{% endif %}
 
 {% endfor %}
 {% else %}

--- a/tasks/release.py
+++ b/tasks/release.py
@@ -63,6 +63,7 @@ def _render_log(ctx=None, version=None):
 release_help = {
     "dry_run": "No-op, simulate what would happen if run for real.",
     "pre": "Build a pre-release version, must be paired with a tag.",
+    "resume": "Resume a release after the version has already been bumped.",
 }
 
 
@@ -71,13 +72,18 @@ def release(
     ctx,
     dry_run=False,
     pre=False,
+    resume=False,
 ):
     drop_dist_dirs(ctx)
-    version = bump_version(
-        ctx,
-        dry_run=dry_run,
-        pre=pre,
-    )
+    if resume:
+        version = find_version(ctx)
+        log(f"Resuming release for {version}")
+    else:
+        version = bump_version(
+            ctx,
+            dry_run=dry_run,
+            pre=pre,
+        )
     tag_content = _render_log(ctx, version)
     if dry_run:
         # Use the correct version when generating the draft
@@ -94,7 +100,7 @@ def release(
             ctx.run(f"git add {get_version_file(ctx).as_posix()}")
         else:
             # Use the correct version when generating the changelog
-            ctx.run(f"towncrier build --version {version}")
+            ctx.run(f"towncrier build --version {version} --yes")
             ctx.run(f"git add CHANGELOG.md news/ {get_version_file(ctx).as_posix()}")
             log("removing changelog draft if present")
             draft_changelog = pathlib.Path("CHANGELOG.draft.md")
@@ -204,7 +210,7 @@ def generate_changelog(ctx, commit=False, draft=False):
         log("Writing draft to file...")
         ctx.run(f"towncrier build --draft --version {version} > CHANGELOG.draft.md")
     else:
-        ctx.run(f"towncrier build --version {version}")
+        ctx.run(f"towncrier build --version {version} --yes")
     if commit:
         log("Committing...")
         ctx.run("git add CHANGELOG.md")

--- a/tests/unit/test_release_tasks.py
+++ b/tests/unit/test_release_tasks.py
@@ -1,0 +1,40 @@
+from pathlib import Path
+from unittest.mock import Mock
+
+from tasks import release as release_tasks
+
+
+def test_release_can_resume_existing_version(monkeypatch, tmp_path):
+    ctx = Mock()
+    bump_version = Mock()
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(release_tasks, "drop_dist_dirs", Mock())
+    monkeypatch.setattr(release_tasks, "find_version", lambda ctx: "2026.7.0")
+    monkeypatch.setattr(release_tasks, "bump_version", bump_version)
+    monkeypatch.setattr(release_tasks, "_render_log", lambda ctx, version: "notes")
+    monkeypatch.setattr(release_tasks, "generate_manual", Mock())
+    monkeypatch.setattr(
+        release_tasks,
+        "get_version_file",
+        lambda ctx: Path("pipenv/__version__.py"),
+    )
+
+    release_tasks.release.body(ctx, resume=True)
+
+    bump_version.assert_not_called()
+    commands = [call.args[0] for call in ctx.run.call_args_list]
+    assert "towncrier build --version 2026.7.0 --yes" in commands
+    assert 'git commit -m "Release v2026.7.0"' in commands
+    assert any(command.startswith("git tag -a v2026.7.0") for command in commands)
+
+
+def test_generate_changelog_removes_consumed_fragments(monkeypatch):
+    ctx = Mock()
+    monkeypatch.setattr(release_tasks, "find_version", lambda ctx: "2026.7.0")
+
+    release_tasks.generate_changelog.body(ctx)
+
+    ctx.run.assert_called_once_with(
+        "towncrier build --version 2026.7.0 --yes"
+    )


### PR DESCRIPTION
Fixes the partial-release failure exposed while preparing v2026.7.0.\n\n- adds `release.release --resume` so an already-committed version bump is not bumped again\n- runs the destructive Towncrier build with `--yes` inside the already-interactive release task\n- avoids trailing whitespace emitted for fragments without issue links, which caused the release commit pre-commit hook to fail\n- adds focused release-task tests\n\nValidation: 2 focused tests pass; Ruff and pre-commit pass; a disposable full Towncrier build removes the expected fragments and passes the trailing-whitespace hook.