### PR TITLE
Fix Pipenv-owned CodeQL reliability findings

### DIFF
--- a/news/+code-quality-reliability.bugfix.rst
+++ b/news/+code-quality-reliability.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed corrupt Pipfile and lockfile errors so they retain the affected path and
+backup location while reporting the file-specific error message.

--- a/pipenv/routines/check.py
+++ b/pipenv/routines/check.py
@@ -74,7 +74,8 @@ def run_pep508_check(project, system, python):
 
 
 def check_pep508_requirements(project, results, quiet):
-    p = plette.Pipfile.load(open(project.pipfile_location))
+    with open(project.pipfile_location) as pipfile:
+        p = plette.Pipfile.load(pipfile)
     p = plette.Lockfile.with_meta_from(p)
     failed = False
 

--- a/pipenv/routines/scan.py
+++ b/pipenv/routines/scan.py
@@ -160,7 +160,8 @@ def run_pep508_check(project, system, python):
 
 def check_pep508_requirements(project, results, quiet):
     """Verify PEP 508 environment markers in Pipfile match the current environment."""
-    p = plette.Pipfile.load(open(project.pipfile_location))
+    with open(project.pipfile_location) as pipfile:
+        p = plette.Pipfile.load(pipfile)
     p = plette.Lockfile.with_meta_from(p)
     failed = False
 

--- a/pipenv/utils/exceptions.py
+++ b/pipenv/utils/exceptions.py
@@ -56,8 +56,7 @@ class FileCorruptException(OSError):
 
 class LockfileCorruptException(FileCorruptException):
     def __init__(self, path, backup_path=None):
-        self.message = self.get_message(path, backup_path=backup_path)
-        super().__init__(self.message)
+        super().__init__(path, backup_path=backup_path)
 
     def get_message(self, path, backup_path=None):
         message = f"ERROR: Failed to load lockfile at {path}"
@@ -68,14 +67,10 @@ class LockfileCorruptException(FileCorruptException):
         message = f"{message}\nYour lockfile is corrupt, {msg}"
         return message
 
-    def show(self, path, backup_path=None):
-        print(self.message, file=sys.stderr, flush=True)
-
 
 class PipfileCorruptException(FileCorruptException):
     def __init__(self, path, backup_path=None):
-        self.message = self.get_message(path, backup_path=backup_path)
-        super().__init__(self.message)
+        super().__init__(path, backup_path=backup_path)
 
     def get_message(self, path, backup_path=None):
         message = f"ERROR: Failed to load Pipfile at {path}"
@@ -85,9 +80,6 @@ class PipfileCorruptException(FileCorruptException):
             msg = "it will be removed and replaced on the next lock."
         message = f"{message}\nYour Pipfile is corrupt, {msg}"
         return message
-
-    def show(self, path, backup_path=None):
-        print(self.message, file=sys.stderr, flush=True)
 
 
 class PipfileNotFound(FileNotFoundError):

--- a/pipenv/utils/locking.py
+++ b/pipenv/utils/locking.py
@@ -418,7 +418,7 @@ class Lockfile:
             path_obj.rename(backup_path)
 
             # Try loading again after backing up corrupted file
-            cls.load(formatted_path, create=True)
+            return cls.load(formatted_path, create=True)
 
         # Create Path object from projectfile location
         lockfile_path = Path(projectfile.location)

--- a/pipenv/utils/locking.py
+++ b/pipenv/utils/locking.py
@@ -414,7 +414,7 @@ class Lockfile:
             backup_path = f"{formatted_path}.bak"
 
             # Show error and create backup
-            LockfileCorruptException.show(formatted_path, backup_path=backup_path)
+            LockfileCorruptException(formatted_path, backup_path=backup_path).show()
             path_obj.rename(backup_path)
 
             # Try loading again after backing up corrupted file

--- a/tests/integration/test_project.py
+++ b/tests/integration/test_project.py
@@ -29,8 +29,10 @@ pytz = "*"
         os.environ["TEST_HOST"] = "localhost:5000"
         project = Project()
         assert project.sources.all[0]["url"] == "https://localhost:5000/simple"
-        assert "localhost:5000" not in str(Pipfile.load(open(p.pipfile_path)))
-        print(str(Pipfile.load(open(p.pipfile_path))))
+        with open(p.pipfile_path) as pipfile:
+            loaded = Pipfile.load(pipfile)
+        assert "localhost:5000" not in str(loaded)
+        print(str(loaded))
 
 
 @pytest.mark.project

--- a/tests/unit/test_routine_context.py
+++ b/tests/unit/test_routine_context.py
@@ -290,10 +290,14 @@ class TestFromCliKeywordOnly:
     def test_from_cli_positional_raises(self):
         # The first positional after cls would land on `system`.
         with pytest.raises(TypeError):
+            # Deliberately violate the keyword-only API to test its contract.
+            # codeql[py/call/wrong-arguments]
             RoutineContext.from_cli(True)  # type: ignore[misc]
 
     def test_from_cli_two_positionals_raises(self):
         with pytest.raises(TypeError):
+            # Deliberately violate the keyword-only API to test its contract.
+            # codeql[py/call/wrong-arguments]
             RoutineContext.from_cli(True, False)  # type: ignore[misc]
 
 

--- a/tests/unit/test_utils_exceptions.py
+++ b/tests/unit/test_utils_exceptions.py
@@ -2,6 +2,7 @@ from pipenv.utils.exceptions import (
     LockfileCorruptException,
     PipfileCorruptException,
 )
+from pipenv.utils.locking import Lockfile
 
 
 def test_lockfile_corrupt_exception_preserves_specific_message(capsys, tmp_path):
@@ -26,3 +27,17 @@ def test_pipfile_corrupt_exception_preserves_specific_message(capsys, tmp_path):
     assert "Failed to load Pipfile" in error.message
     assert str(path) in error.message
     assert error.message in capsys.readouterr().err
+
+
+def test_lockfile_load_returns_recovered_lockfile(capsys, tmp_path):
+    pipfile_path = tmp_path / "Pipfile"
+    lockfile_path = tmp_path / "Pipfile.lock"
+    backup_path = tmp_path / "Pipfile.lock.bak"
+    pipfile_path.write_text("[packages]\n")
+    lockfile_path.write_text("{corrupted}")
+
+    recovered = Lockfile.load(str(lockfile_path))
+
+    assert recovered.path == lockfile_path
+    assert backup_path.read_text() == "{corrupted}"
+    assert "Your lockfile is corrupt" in capsys.readouterr().err

--- a/tests/unit/test_utils_exceptions.py
+++ b/tests/unit/test_utils_exceptions.py
@@ -1,0 +1,28 @@
+from pipenv.utils.exceptions import (
+    LockfileCorruptException,
+    PipfileCorruptException,
+)
+
+
+def test_lockfile_corrupt_exception_preserves_specific_message(capsys, tmp_path):
+    path = tmp_path / "Pipfile.lock"
+    backup_path = tmp_path / "Pipfile.lock.bak"
+
+    error = LockfileCorruptException(path, backup_path=backup_path)
+    error.show()
+
+    assert "Failed to load lockfile" in error.message
+    assert str(path) in error.message
+    assert str(backup_path) in error.message
+    assert error.message in capsys.readouterr().err
+
+
+def test_pipfile_corrupt_exception_preserves_specific_message(capsys, tmp_path):
+    path = tmp_path / "Pipfile"
+
+    error = PipfileCorruptException(path)
+    error.show()
+
+    assert "Failed to load Pipfile" in error.message
+    assert str(path) in error.message
+    assert error.message in capsys.readouterr().err


### PR DESCRIPTION
### The issue

GitHub Code Quality currently reports 186 open reliability findings and rates the repository Poor. Most of that backlog is imported code that Pipenv does not maintain directly, while a smaller set of Error- and Warning-level findings affects Pipenv-owned code and tests.

Inventory from the 2026-08-03 default-branch scan:

- `pipenv/patched/**`: 84 reliability findings (317 total findings)
- `pipenv/vendor/**`: 42 reliability findings (92 total findings)
- `docs/_static/konami.js`: 5 reliability findings in an imported upstream asset
- Pipenv-owned code/tests/tasks: 55 reliability findings, of which 9 are Error or Warning severity and 46 are Notes

The imported findings are useful dependency inventory, but should not drive changes to copied code. GitHub Code Quality's current generated setup does not expose a repository path-ignore option; the similarly named CodeQL `paths-ignore` configuration applies to code scanning, not the Code Quality dashboard. Those imported findings should therefore be dismissed as third-party/won't-fix in Code Quality so they remain auditable under Dismissed without affecting the open backlog.

### The fix

This PR leaves all imported sources untouched and addresses the 9 Error- and Warning-level findings in Pipenv-owned files:

- close Pipfile handles deterministically in the check/scan routines and integration test
- fix corrupt-file exception initialization and the invalid unbound `show` call, retaining the real path, backup path, and file-specific message
- suppress two deliberate wrong-argument calls that test the keyword-only API contract
- add regression coverage for corrupt Pipfile and lockfile messages

### Validation

- `python -m pytest -o addopts='' -q tests/unit/test_utils_exceptions.py tests/unit/test_routine_context.py` — 32 passed
- `python -m pytest -o addopts='' -q tests/integration/test_project.py::test_pipfile_envvar_expansion` — passed
- `python -m pytest -o addopts='' -q tests/integration/test_lock.py::test_lockfile_corrupted` — passed
- pre-commit hooks on all changed files — passed

A wider run of `tests/integration/test_project.py` had 39 passing tests and one unrelated failure because the private package-index fixture expected a service on `localhost:8080`, which was not running locally.

### The checklist

- [ ] Associated issue
- [x] A news fragment in the `news/` directory
