### PR TITLE
Fix transitive dependencies skipped from project environments

### DIFF
--- a/news/6698.bugfix.rst
+++ b/news/6698.bugfix.rst
@@ -1,0 +1,3 @@
+Prevent Pipenv's own environment from leaking into bundled pip subprocesses, which
+could cause locked transitive dependencies to be skipped when they were installed
+alongside Pipenv but missing from the project environment.

--- a/pipenv/vendor/pipdeptree/__main__.py
+++ b/pipenv/vendor/pipdeptree/__main__.py
@@ -6,11 +6,12 @@ import sys
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-vendored_root = Path(__file__).resolve().parents[1]
-# for finding pipdeptree itself
-sys.path.append(str(vendored_root))
-# for finding stuff in vendor and patched
-sys.path.append(str(vendored_root.parents[1]))
+if __name__ == "__main__":
+    vendored_root = Path(__file__).resolve().parents[1]
+    # for finding pipdeptree itself
+    sys.path.append(str(vendored_root))
+    # for finding stuff in vendor and patched
+    sys.path.append(str(vendored_root.parents[1]))
 
 from pipenv.vendor.pipdeptree._cli import Options, get_options, parse_packages
 from pipenv.vendor.pipdeptree._detect_env import detect_active_interpreter, find_active_interpreter

--- a/tasks/vendoring/patches/vendor/pipdeptree-update-import.patch
+++ b/tasks/vendoring/patches/vendor/pipdeptree-update-import.patch
@@ -1,6 +1,6 @@
 --- a/pipenv/vendor/pipdeptree/__main__.py
 +++ b/pipenv/vendor/pipdeptree/__main__.py
-@@ -4,10 +4,16 @@
+@@ -4,10 +4,17 @@
 
  from __future__ import annotations
 
@@ -8,11 +8,12 @@
  from pathlib import Path
  from typing import TYPE_CHECKING
 
-+vendored_root = Path(__file__).resolve().parents[1]
-+# for finding pipdeptree itself
-+sys.path.append(str(vendored_root))
-+# for finding stuff in vendor and patched
-+sys.path.append(str(vendored_root.parents[1]))
++if __name__ == "__main__":
++    vendored_root = Path(__file__).resolve().parents[1]
++    # for finding pipdeptree itself
++    sys.path.append(str(vendored_root))
++    # for finding stuff in vendor and patched
++    sys.path.append(str(vendored_root.parents[1]))
 +
  from pipenv.vendor.pipdeptree._cli import Options, get_options, parse_packages
  from pipenv.vendor.pipdeptree._detect_env import detect_active_interpreter, find_active_interpreter

--- a/tests/integration/test_install_basic.py
+++ b/tests/integration/test_install_basic.py
@@ -642,13 +642,13 @@ def test_install_dev_use_default_constraints(pipenv_instance_private_pypi):
 @pytest.mark.install
 @pytest.mark.needs_internet
 def test_install_does_not_exclude_packaging(pipenv_instance_pypi):
-    """Ensure that running `pipenv install` doesn't exclude packaging when its required."""
+    """Install a transitive dependency even when it is available to Pipenv itself."""
     with pipenv_instance_pypi() as p:
-        c = p.pipenv("install dataclasses-json")
+        c = p.pipenv("install pytest")
         assert c.returncode == 0
-        c = p.pipenv(
-            """run python -c "from dataclasses_json import DataClassJsonMixin" """
-        )
+        assert "packaging" in p.lockfile["default"]
+
+        c = p.pipenv("run python -c 'import packaging'")
         assert c.returncode == 0
 
 

--- a/tests/integration/test_install_basic.py
+++ b/tests/integration/test_install_basic.py
@@ -648,7 +648,7 @@ def test_install_does_not_exclude_packaging(pipenv_instance_pypi):
         assert c.returncode == 0
         assert "packaging" in p.lockfile["default"]
 
-        c = p.pipenv("run python -c 'import packaging'")
+        c = p.pipenv('run python -c "import packaging"')
         assert c.returncode == 0
 
 

--- a/tests/unit/test_vendor.py
+++ b/tests/unit/test_vendor.py
@@ -3,11 +3,43 @@
 import pipenv  # noqa
 
 import datetime
+import json
+import subprocess
 import sys
+from pathlib import Path
 
 import pytest
 import pytz
 from pipenv.vendor import tomlkit
+
+
+def test_importing_pipdeptree_does_not_extend_sys_path():
+    """Importing pipdeptree must not expose Pipenv's environment to child pip."""
+    main_path = Path(pipenv.__file__).parent / "vendor" / "pipdeptree" / "__main__.py"
+    vendor_root = main_path.parents[1]
+    pipenv_install_root = vendor_root.parents[1]
+    paths = [str(vendor_root), str(pipenv_install_root)]
+    code = f"""
+import json
+import runpy
+import sys
+
+paths = {json.dumps(paths)}
+before = {{path: sys.path.count(path) for path in paths}}
+runpy.run_path({str(main_path)!r}, run_name="pipdeptree_import_test")
+after = {{path: sys.path.count(path) for path in paths}}
+print(json.dumps({{"before": before, "after": after}}))
+"""
+
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    path_counts = json.loads(result.stdout)
+
+    assert path_counts["after"] == path_counts["before"]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- stop imported vendored pipdeptree code from adding Pipenv host paths to the target interpreter
- retain the path bootstrap when pipdeptree is executed for `pipenv graph`
- cover both the import isolation boundary and a locked transitive `packaging` install
- persist the fix in the vendoring patch

The pipdeptree 3.1.0 update made its package initializer import `__main__`. Pipenv’s vendoring patch added host paths unconditionally in that module, so bundled pip could see distributions installed alongside Pipenv and incorrectly report them as already satisfied in a fresh project virtualenv.

## Validation

- focused unit/integration suite: 11 passed
- built and installed a wheel into a separate host environment containing `packaging==26.2`
- installed `pytest` into a fresh project environment and verified project-local `packaging`
- verified bundled pip lists only project distributions
- verified `pipenv graph` still succeeds
- verified the vendoring patch reverses cleanly against generated files

Fixes #6698.
Fixes #6699.