### PR TITLE
docs: the documented Python floor is 3.7, pyproject requires 3.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Table Of Contents
 Installation
 ------------
 
-**Pipenv can be installed with Python 3.7 and above.**
+**Pipenv can be installed with Python 3.10 and above.**
 
 For most users, we recommend installing Pipenv using `pip`:
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -390,7 +390,7 @@ If you encounter permission errors during installation:
 
 ### Python Version Compatibility
 
-Pipenv requires Python 3.7 or newer. If you're using an older version, you'll need to upgrade Python first.
+Pipenv requires Python 3.10 or newer. If you're using an older version, you'll need to upgrade Python first.
 
 ### pip Not Found
 


### PR DESCRIPTION
`pyproject.toml` declares `requires-python = ">=3.10"`, so `pip install pipenv` refuses on 3.7, 3.8 and 3.9. Two documents still tell those readers they are supported.

```
README.md:75             **Pipenv can be installed with Python 3.7 and above.**
docs/installation.md:393 Pipenv requires Python 3.7 or newer.
```

The second one sits under a heading called **Python Version Compatibility**, which is the first place someone checks after a failed install.

## Deliberately not changed

There are other `3.7`/`3.8`/`3.9` mentions in the docs and they are a **different claim**, so this PR leaves them alone:

- `pipenv --python 3.7` in `README.md`, and `pipenv --python 3.8` / `3.9` in `docs/best_practices.md`. These are the interpreter pipenv **provisions for a project**, which is independent of the interpreter pipenv itself runs on. They still work.
- `python_version = "3.9"` in `docs/pipfile.md`, which is the same thing, a Pipfile target.
- `docs/installation.md:39`, "Install pipx (requires Python 3.7+)" states **pipx's** requirement, not pipenv's.

Only the two lines whose subject is pipenv's own installability are touched.

Found with [docproof](https://github.com/melbinjp/docproof), which checks documentation claims against a project's own metadata. It judges a Python-requirement sentence only when the project's own distribution name is the subject standing alone, which is exactly the rule that separates the two lines changed here from the ones left alone.

