### PR TITLE
Fix PyPI hash TLS handling and deprecated remove guidance

### DIFF
--- a/news/6704.bugfix.rst
+++ b/news/6704.bugfix.rst
@@ -1,0 +1,1 @@
+Python-version mismatch warnings now recommend ``pipenv remove`` instead of the deprecated ``pipenv --rm`` flag.

--- a/news/6711.bugfix.rst
+++ b/news/6711.bugfix.rst
@@ -1,0 +1,1 @@
+Hash-lookup sessions now use pip's combined certificate trust configuration, so custom CA bundles do not discard the public roots trusted by pip.

--- a/news/6712.bugfix.rst
+++ b/news/6712.bugfix.rst
@@ -1,0 +1,1 @@
+PyPI hash collection now handles requests and pip network exceptions and falls back to the resolver's other hash sources.

--- a/pipenv/utils/internet.py
+++ b/pipenv/utils/internet.py
@@ -4,6 +4,9 @@ from html.parser import HTMLParser
 from typing import Optional, Tuple
 from urllib.parse import unquote, urlparse, urlunsplit
 
+from pipenv.patched.pip._internal.cli.index_command import (
+    _create_truststore_ssl_context,
+)
 from pipenv.patched.pip._internal.locations import USER_CACHE_DIR
 from pipenv.patched.pip._internal.network.download import PipSession
 from pipenv.patched.pip._vendor.urllib3 import util as urllib3_util
@@ -16,7 +19,10 @@ def get_requests_session(
     pip_client_cert = os.environ.get("PIP_CLIENT_CERT")
     index_urls = [source] if source else None
     requests_session = PipSession(
-        cache=cache_dir, retries=max_retries, index_urls=index_urls
+        cache=cache_dir,
+        retries=max_retries,
+        index_urls=index_urls,
+        ssl_context=_create_truststore_ssl_context(),
     )
     if pip_client_cert:
         requests_session.cert = pip_client_cert

--- a/pipenv/utils/project.py
+++ b/pipenv/utils/project.py
@@ -165,7 +165,7 @@ def ensure_project(
             )
             if not (system or project.s.PIPENV_USE_SYSTEM):
                 err.print(
-                    "[green]$ pipenv --rm[/green] and rebuilding the virtual environment "
+                    "[green]$ pipenv remove[/green] and rebuilding the virtual environment "
                     "may resolve the issue."
                 )
             if not deploy:

--- a/pipenv/utils/sources.py
+++ b/pipenv/utils/sources.py
@@ -28,8 +28,10 @@ from random import randint
 from urllib import parse
 from urllib.parse import urljoin
 
+from pipenv.patched.pip._internal.exceptions import PipError
 from pipenv.patched.pip._internal.models.link import Link
 from pipenv.patched.pip._internal.utils.hashes import FAVORITE_HASH
+from pipenv.patched.pip._vendor.requests.exceptions import RequestException
 from pipenv.utils import err
 from pipenv.utils.dependencies import clean_pkg_version, pep423_name
 from pipenv.utils.fileutils import open_file
@@ -133,7 +135,7 @@ class Sources:
             for release in cleaned_releases[version]:
                 collected_hashes.add(release["digests"][FAVORITE_HASH])
             return self._prepend_hash_types(collected_hashes, FAVORITE_HASH)
-        except (ValueError, KeyError, ConnectionError):
+        except (ValueError, KeyError, RequestException, PipError):
             return None
 
     def get_hashes_from_remote_index_urls(self, ireq, source):

--- a/tests/unit/test_sources.py
+++ b/tests/unit/test_sources.py
@@ -10,8 +10,12 @@ behaviours.
 
 from __future__ import annotations
 
+from unittest import mock
+
 import pytest
 
+from pipenv.patched.pip._internal.exceptions import PipError
+from pipenv.patched.pip._vendor.requests.exceptions import RequestException
 from pipenv.project import Project
 from pipenv.utils.sources import SourceNotFound, Sources
 
@@ -75,6 +79,31 @@ def test_project_sources_returns_sources_subsystem(project_single):
     assert isinstance(project_single.sources, Sources)
     # Cached: two accesses return the same instance.
     assert project_single.sources is project_single.sources
+
+
+@pytest.mark.utils
+@pytest.mark.parametrize(
+    "network_error",
+    [RequestException("requests failure"), PipError("pip network failure")],
+)
+def test_get_hashes_from_pypi_handles_network_errors(project_single, network_error):
+    """PyPI API failures fall through to the resolver's other hash sources."""
+    session = mock.Mock()
+    session.get.side_effect = network_error
+    requirement = mock.Mock()
+    requirement.name = "example"
+    requirement.specifier = None
+
+    with mock.patch.object(
+        project_single.sources,
+        "get_requests_session_for_source",
+        return_value=session,
+    ):
+        result = project_single.sources.get_hashes_from_pypi(
+            requirement, project_single.sources.default
+        )
+
+    assert result is None
 
 
 @pytest.mark.utils

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -325,6 +325,30 @@ class TestUtils:
         assert internet.is_valid_url(not_url) is False
 
     @pytest.mark.utils
+    def test_get_requests_session_uses_pip_truststore_context(self, monkeypatch):
+        ssl_context = object()
+        session = mock.MagicMock()
+        pip_session = mock.Mock(return_value=session)
+        monkeypatch.setattr(internet, "PipSession", pip_session)
+        monkeypatch.setattr(
+            internet, "_create_truststore_ssl_context", lambda: ssl_context
+        )
+
+        result = internet.get_requests_session(
+            max_retries=2,
+            cache_dir="cache-dir",
+            source="https://example.org/simple",
+        )
+
+        assert result is session
+        pip_session.assert_called_once_with(
+            cache="cache-dir",
+            retries=2,
+            index_urls=["https://example.org/simple"],
+            ssl_context=ssl_context,
+        )
+
+    @pytest.mark.utils
     def test_download_file(self, tmp_path):
         url = "https://example.com/test.md"
         output = tmp_path / "test_download.md"
@@ -986,6 +1010,30 @@ class TestEnsureProjectPythonVersionMismatch:
         assert len(ensure_virtualenv_calls) == 0, (
             "ensure_virtualenv should not be called when no --python is given and venv exists"
         )
+
+    @pytest.mark.utils
+    def test_version_warning_recommends_current_remove_command(self, monkeypatch):
+        project = self._make_project(monkeypatch)
+        project.required_python_version = "3.12"
+        project.venv_locator._which.return_value = "/fake/venv/bin/python"
+
+        monkeypatch.setattr(
+            "pipenv.utils.project.python_version",
+            lambda path: "3.11.9",
+        )
+        monkeypatch.setattr(
+            "pipenv.utils.project.ensure_pipfile",
+            lambda *a, **kw: None,
+        )
+
+        from pipenv.utils.project import ensure_project
+
+        with mock.patch("pipenv.utils.project.err.print") as err_print:
+            ensure_project(project, python=None, system=False)
+
+        output = "\n".join(call.args[0] for call in err_print.call_args_list)
+        assert "$ pipenv remove" in output
+        assert "$ pipenv --rm" not in output
 
 
 class TestPythonVersionMatchesRequired:


### PR DESCRIPTION
### The issue

Three recent reports expose related reliability and guidance problems:

- the lock-time PyPI hash session does not use pip's combined certificate trust context, so a custom `REQUESTS_CA_BUNDLE` can discard public roots (#6711)
- `get_hashes_from_pypi()` catches Python's built-in `ConnectionError` instead of the Requests exceptions raised by its session (#6712)
- Python-version mismatch warnings recommend the deprecated `pipenv --rm` flag (#6704)

### The fix

- construct Pipenv's utility `PipSession` with the same truststore SSL context used by pip
- treat both Requests exceptions and pip-native network errors as hash-source failures, allowing the existing resolver fallback to proceed
- recommend `pipenv remove` in Python-version mismatch warnings
- add focused regression coverage and one Towncrier fragment per issue

### Validation

- `python -m pytest -o addopts='' -q tests/unit/test_resolver_regressions.py tests/unit/test_utils.py tests/unit/test_sources.py` — 267 passed, 7 skipped
- pre-commit hooks on all changed files — passed
- live reproduction with `REQUESTS_CA_BUNDLE` containing only an unrelated dummy CA successfully fetched the PyPI JSON API through pip's combined trust context

Fixes #6704
Fixes #6711
Fixes #6712
