### PR TITLE
feat(install): persist per-package config settings

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -22,6 +22,19 @@ This is particularly useful for:
 - Controlling cache behavior
 - Specifying platform-specific wheels
 
+### Persisting Build Backend Settings
+
+For editable packages, use `--config-settings` to pass a PEP 517 build-backend
+setting and record it with the package in the `Pipfile`:
+
+```bash
+$ pipenv install --editable . --config-settings editable_mode=strict
+```
+
+Pipenv stores the setting as package-level `pip_args`, and reuses it during
+future installs and syncs. Repeat the option when a backend needs more than
+one setting.
+
 ### Common Use Cases
 
 #### Using System Certificate Stores

--- a/news/5740.feature.rst
+++ b/news/5740.feature.rst
@@ -1,0 +1,3 @@
+Persist per-package pip build arguments from ``pipenv install --config-settings``
+in the Pipfile and lockfile so editable builds can be reproduced by later
+installs and syncs.

--- a/pipenv/cli/command.py
+++ b/pipenv/cli/command.py
@@ -93,6 +93,7 @@ def cmd_install(args, state):
         requirementstxt=state.installstate.requirementstxt,
         # execution_options
         extra_pip_args=state.installstate.extra_pip_args,
+        config_settings=state.installstate.config_settings,
         resolver=state.resolver,
     )
     do_install(state.project, ctx)

--- a/pipenv/cli/options.py
+++ b/pipenv/cli/options.py
@@ -43,6 +43,7 @@ class InstallState:
         self.packages = []
         self.editables = []
         self.extra_pip_args = []
+        self.config_settings = []
         self.categories = []
         self.skip_lock = False
         self.all_categories = False
@@ -180,6 +181,17 @@ def _add_extra_pip_args(p):
         dest="extra_pip_args",
         default=None,
         help="Additional arguments passed directly to pip.",
+    )
+
+
+def _add_config_settings_option(p):
+    p.add_argument(
+        "--config-settings",
+        dest="config_settings",
+        action="append",
+        default=None,
+        metavar="KEY=VALUE",
+        help="Pass a build-backend configuration setting to pip for this package.",
     )
 
 
@@ -362,6 +374,7 @@ def _add_sync_options(p):
 
 def _add_install_options(p):
     _add_sync_options(p)
+    _add_config_settings_option(p)
     _add_index_option(p)
     _add_requirementstxt_option(p)
     _add_ignore_pipfile_option(p)
@@ -946,6 +959,10 @@ def build_state(args):
     raw_extra_pip_args = getattr(args, "extra_pip_args", None)
     if raw_extra_pip_args:
         state.installstate.extra_pip_args = raw_extra_pip_args.split()
+
+    state.installstate.config_settings = list(
+        getattr(args, "config_settings", None) or []
+    )
 
     state.installstate.packages = list(getattr(args, "packages", []))
     state.installstate.editables = list(getattr(args, "editables", None) or [])

--- a/pipenv/routines/context.py
+++ b/pipenv/routines/context.py
@@ -124,6 +124,7 @@ class ExecutionOptions:
     """
 
     extra_pip_args: Sequence[str] = ()
+    config_settings: Sequence[str] = ()
     requirements_directory: str | None = None
     no_deps: bool = False
     ignore_hashes: bool = False
@@ -185,6 +186,7 @@ class RoutineContext:
         requirementstxt: str | None = None,
         # execution_options
         extra_pip_args: Sequence[str] = (),
+        config_settings: Sequence[str] = (),
         requirements_directory: str | None = None,
         no_deps: bool = False,
         ignore_hashes: bool = False,
@@ -203,7 +205,8 @@ class RoutineContext:
         by passing ``allow_global=`` explicitly.
 
         Sequence-typed inputs (``packages``, ``editable_packages``,
-        ``categories``, ``extra_pip_args``) are tuple-coerced so the
+        ``categories``, ``extra_pip_args``, and ``config_settings``) are
+        tuple-coerced so the
         resulting dataclasses stay genuinely immutable even if the
         caller hands in a list.
         """
@@ -241,6 +244,7 @@ class RoutineContext:
             ),
             execution_options=ExecutionOptions(
                 extra_pip_args=tuple(extra_pip_args),
+                config_settings=tuple(config_settings),
                 requirements_directory=requirements_directory,
                 no_deps=no_deps,
                 ignore_hashes=ignore_hashes,

--- a/pipenv/routines/install.py
+++ b/pipenv/routines/install.py
@@ -129,14 +129,17 @@ def _should_use_no_binary(pkg_name, extra_pip_args):
     return False
 
 
-def _config_settings_pip_args(config_settings, extra_pip_args):
-    """Return normalized pip arguments for package build settings.
+def _split_config_settings_pip_args(config_settings, extra_pip_args):
+    """Separate package build settings from generic pip arguments.
 
     ``--config-settings`` is a per-package build option. Keep it separate
     from the generic passthrough arguments so it can be recorded in the
-    package's Pipfile entry and replayed on later installs.
+    package's Pipfile entry and replayed on later installs. Returning the
+    remaining arguments prevents legacy ``--extra-pip-args`` forms from
+    leaking the setting into every package in a later install phase.
     """
     pip_args = []
+    passthrough_args = []
     for setting in config_settings or ():
         pip_args.extend(("--config-settings", setting))
 
@@ -151,23 +154,35 @@ def _config_settings_pip_args(config_settings, extra_pip_args):
             pip_args.extend(("--config-settings", arg.split("=", 1)[1]))
             index += 1
         else:
+            passthrough_args.append(arg)
             index += 1
+    return pip_args, passthrough_args
+
+
+def _config_settings_pip_args(config_settings, extra_pip_args):
+    """Return normalized pip arguments for package build settings."""
+    pip_args, _ = _split_config_settings_pip_args(config_settings, extra_pip_args)
     return pip_args
 
 
 def _pip_args_for_dependency(dependency, lockfile_section, pip_line=None):
     """Read reproducible, package-scoped pip arguments from a lock entry."""
+    from pipenv.utils.dependencies import requirement_from_lockfile
+
     dependency_name = getattr(dependency, "name", None)
 
     def normalize(name):
         return str(name).lower().replace("-", "_").replace(".", "_")
 
+    normalized_dependency_name = (
+        normalize(dependency_name) if dependency_name else None
+    )
     for package_name, entry in lockfile_section.items():
-        matches_name = dependency_name and normalize(package_name) == normalize(dependency_name)
+        matches_name = normalized_dependency_name and (
+            normalize(package_name) == normalized_dependency_name
+        )
         matches_requirement = False
         if not matches_name and pip_line and isinstance(entry, dict):
-            from pipenv.utils.dependencies import requirement_from_lockfile
-
             generated_line = requirement_from_lockfile(
                 package_name,
                 entry,
@@ -215,7 +230,7 @@ def handle_new_packages(
     editable_packages = list(sel.editable_packages) if sel.editable_packages else []
     pipfile_categories = list(sel.categories) if sel.categories else []
     extra_pip_args = list(exec_opts.extra_pip_args) if exec_opts.extra_pip_args else []
-    package_pip_args = _config_settings_pip_args(
+    package_pip_args, extra_pip_args = _split_config_settings_pip_args(
         getattr(exec_opts, "config_settings", ()), extra_pip_args
     )
     index = sel.index
@@ -921,8 +936,8 @@ def batch_install(
         for pkg_name, entry in lockfile_section.items()
         if isinstance(entry, dict) and entry.get("no_binary")
     ]
-    extra_pip_args = (
-        list(exec_opts.extra_pip_args) if exec_opts.extra_pip_args else []
+    _, extra_pip_args = _split_config_settings_pip_args(
+        getattr(exec_opts, "config_settings", ()), exec_opts.extra_pip_args
     )
     if no_binary_packages:
         extra_pip_args = list(extra_pip_args)
@@ -1030,8 +1045,13 @@ def batch_install(
                         requirements_dir,
                     )
             except StopIteration:  # noqa: PERF203
+                missing_dependencies = [
+                    dependency
+                    for dependencies in dependencies_by_args.values()
+                    for dependency in dependencies
+                ]
                 console.print(
-                    f"Unable to find {index_name} in sources, please check dependencies: {dependencies}",
+                    f"Unable to find {index_name} in sources, please check dependencies: {missing_dependencies}",
                     style="bold red",
                 )
                 sys.exit(1)

--- a/pipenv/routines/install.py
+++ b/pipenv/routines/install.py
@@ -129,6 +129,67 @@ def _should_use_no_binary(pkg_name, extra_pip_args):
     return False
 
 
+def _config_settings_pip_args(config_settings, extra_pip_args):
+    """Return normalized pip arguments for package build settings.
+
+    ``--config-settings`` is a per-package build option. Keep it separate
+    from the generic passthrough arguments so it can be recorded in the
+    package's Pipfile entry and replayed on later installs.
+    """
+    pip_args = []
+    for setting in config_settings or ():
+        pip_args.extend(("--config-settings", setting))
+
+    args = list(extra_pip_args or ())
+    index = 0
+    while index < len(args):
+        arg = args[index]
+        if arg == "--config-settings" and index + 1 < len(args):
+            pip_args.extend((arg, args[index + 1]))
+            index += 2
+        elif arg.startswith("--config-settings="):
+            pip_args.extend(("--config-settings", arg.split("=", 1)[1]))
+            index += 1
+        else:
+            index += 1
+    return pip_args
+
+
+def _pip_args_for_dependency(dependency, lockfile_section, pip_line=None):
+    """Read reproducible, package-scoped pip arguments from a lock entry."""
+    dependency_name = getattr(dependency, "name", None)
+
+    def normalize(name):
+        return str(name).lower().replace("-", "_").replace(".", "_")
+
+    for package_name, entry in lockfile_section.items():
+        matches_name = dependency_name and normalize(package_name) == normalize(dependency_name)
+        matches_requirement = False
+        if not matches_name and pip_line and isinstance(entry, dict):
+            from pipenv.utils.dependencies import requirement_from_lockfile
+
+            generated_line = requirement_from_lockfile(
+                package_name,
+                entry,
+                include_hashes=False,
+                include_markers=False,
+            )
+            matches_requirement = generated_line == pip_line
+        if not (matches_name or matches_requirement):
+            continue
+        if not isinstance(entry, dict):
+            return ()
+        pip_args = entry.get("pip_args", ())
+        if isinstance(pip_args, str):
+            return (pip_args,)
+        if isinstance(pip_args, (list, tuple)) and all(
+            isinstance(arg, str) for arg in pip_args
+        ):
+            return tuple(pip_args)
+        return ()
+    return ()
+
+
 def handle_new_packages(
     project,
     ctx: RoutineContext,
@@ -154,6 +215,9 @@ def handle_new_packages(
     editable_packages = list(sel.editable_packages) if sel.editable_packages else []
     pipfile_categories = list(sel.categories) if sel.categories else []
     extra_pip_args = list(exec_opts.extra_pip_args) if exec_opts.extra_pip_args else []
+    package_pip_args = _config_settings_pip_args(
+        getattr(exec_opts, "config_settings", ()), extra_pip_args
+    )
     index = sel.index
 
     new_packages = []
@@ -206,12 +270,17 @@ def handle_new_packages(
                                 sel.dev,
                                 category,
                                 no_binary=no_binary,
+                                pip_args=package_pip_args or None,
                             )
                             if added:
                                 new_packages.append((normalized_name, cat))
                     else:
                         added, cat, normalized_name = project.pipfile.add_package(
-                            pkg_requirement, pkg_line, sel.dev, no_binary=no_binary
+                            pkg_requirement,
+                            pkg_line,
+                            sel.dev,
+                            no_binary=no_binary,
+                            pip_args=package_pip_args or None,
                         )
                         if added:
                             new_packages.append((normalized_name, cat))
@@ -906,37 +975,60 @@ def batch_install(
     )
 
     if search_all_sources:
-        dependencies = [pip_line for _, pip_line in deps_to_install]
-        batch_install_iteration(
-            project,
-            iter_ctx,
-            dependencies,
-            sources,
-            procs,
-            requirements_dir,
-        )
+        deps_by_pip_args = defaultdict(list)
+        for dependency, pip_line in deps_to_install:
+            deps_by_pip_args[
+                _pip_args_for_dependency(dependency, lockfile_section, pip_line)
+            ].append(pip_line)
+        for package_pip_args, dependencies in deps_by_pip_args.items():
+            phase_ctx = replace(
+                iter_ctx,
+                execution_options=replace(
+                    iter_ctx.execution_options,
+                    extra_pip_args=tuple(extra_pip_args) + package_pip_args,
+                ),
+            )
+            batch_install_iteration(
+                project,
+                phase_ctx,
+                dependencies,
+                sources,
+                procs,
+                requirements_dir,
+            )
     else:
         # Sort the dependencies out by index -- include editable/vcs in the default group
-        deps_by_index = defaultdict(list)
+        deps_by_index = defaultdict(lambda: defaultdict(list))
         for dependency, pip_line in deps_to_install:
             index = project.sources.default["name"]
             if dependency.name and dependency.name in lockfile_section:
                 entry = lockfile_section[dependency.name]
                 if isinstance(entry, dict) and "index" in entry:
                     index = entry["index"]
-            deps_by_index[index].append(pip_line)
+            package_pip_args = _pip_args_for_dependency(
+                dependency, lockfile_section, pip_line
+            )
+            deps_by_index[index][package_pip_args].append(pip_line)
         # Treat each index as its own pip install phase
-        for index_name, dependencies in deps_by_index.items():
+        for index_name, dependencies_by_args in deps_by_index.items():
             try:
                 install_source = next(filter(lambda s: s["name"] == index_name, sources))
-                batch_install_iteration(
-                    project,
-                    iter_ctx,
-                    dependencies,
-                    [install_source],
-                    procs,
-                    requirements_dir,
-                )
+                for package_pip_args, dependencies in dependencies_by_args.items():
+                    phase_ctx = replace(
+                        iter_ctx,
+                        execution_options=replace(
+                            iter_ctx.execution_options,
+                            extra_pip_args=tuple(extra_pip_args) + package_pip_args,
+                        ),
+                    )
+                    batch_install_iteration(
+                        project,
+                        phase_ctx,
+                        dependencies,
+                        [install_source],
+                        procs,
+                        requirements_dir,
+                    )
             except StopIteration:  # noqa: PERF203
                 console.print(
                     f"Unable to find {index_name} in sources, please check dependencies: {dependencies}",

--- a/pipenv/utils/dependencies.py
+++ b/pipenv/utils/dependencies.py
@@ -412,6 +412,12 @@ def clean_resolved_dep(  # noqa: PLR0912
     if dep.get("no_binary"):
         lockfile["no_binary"] = True
 
+    # Preserve per-package pip arguments (for example, ``--config-settings``
+    # needed by editable build backends) so installs from the lockfile remain
+    # reproducible.
+    if dep.get("pip_args"):
+        lockfile["pip_args"] = list(dep["pip_args"])
+
     # In case we lock a uri or a file when the user supplied a path
     # remove the uri or file keys from the entry and keep the path
     if dep and isinstance(dep, dict):
@@ -1379,7 +1385,7 @@ def _validate_pipfile_entry(name: str, pipfile_dict: Dict[str, Any]) -> None:
             f"Unrecognized option(s) in Pipfile for package '{name}': "
             f"{', '.join(sorted(unknown))}. "
             "Valid options include: version, extras, editable, markers, "
-            "ref, git, svn, hg, bzr, path, file, index, subdirectory, "
+            "ref, git, svn, hg, bzr, path, file, index, subdirectory, pip_args, "
             "hashes, no_binary, skip_resolver, and PEP 508 marker keys."
         )
 

--- a/pipenv/utils/pipfile.py
+++ b/pipenv/utils/pipfile.py
@@ -945,7 +945,13 @@ class Pipfile:
         self.write_toml(parsed)
 
     def generate_entry(
-        self, package, pip_line, category=None, index_name=None, no_binary=False
+        self,
+        package,
+        pip_line,
+        category=None,
+        index_name=None,
+        no_binary=False,
+        pip_args=None,
     ):
         """Build a Pipfile entry dict from an ``InstallRequirement`` and the
         raw pip-install line that produced it.
@@ -1037,16 +1043,31 @@ class Pipfile:
         if no_binary:
             entry["no_binary"] = True
 
+        if pip_args:
+            entry["pip_args"] = list(pip_args)
+
         if len(entry) == 1 and "version" in entry:
             return name, normalized_name, specifier
         else:
             return name, normalized_name, entry
 
-    def add_package(self, package, pip_line, dev=False, category=None, no_binary=False):
+    def add_package(
+        self,
+        package,
+        pip_line,
+        dev=False,
+        category=None,
+        no_binary=False,
+        pip_args=None,
+    ):
         """Add a single package — generate entry + add to Pipfile."""
         category = category if category else "dev-packages" if dev else "packages"
         name, normalized_name, entry = self.generate_entry(
-            package, pip_line, category=category, no_binary=no_binary
+            package,
+            pip_line,
+            category=category,
+            no_binary=no_binary,
+            pip_args=pip_args,
         )
         return self.add_entry(name, normalized_name, entry, category=category)
 

--- a/pipenv/vendor/plette/models/packages.py
+++ b/pipenv/vendor/plette/models/packages.py
@@ -25,6 +25,7 @@ KNOWN_PACKAGE_KEYS = frozenset(
         "hashes",
         "index",
         "no_binary",
+        "pip_args",
         # Pipenv resolver control
         "skip_resolver",
         # Path / file source
@@ -53,7 +54,8 @@ class PackageSpecfiers(DataModel):
     __OPTIONAL__ = {
         "editable": bool,
         "version": str,
-        "extras": list
+        "extras": list,
+        "pip_args": list,
     }
 
     @classmethod
@@ -68,7 +70,7 @@ class PackageSpecfiers(DataModel):
                     f"Unrecognized Pipfile option(s): {', '.join(sorted(unknown))}. "
                     "Valid options include: version, extras, editable, markers, "
                     "ref, git, svn, hg, bzr, path, file, index, subdirectory, "
-                    "hashes, no_binary, skip_resolver, and PEP 508 marker keys."
+                    "pip_args, hashes, no_binary, skip_resolver, and PEP 508 marker keys."
                 )
 
 

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -970,6 +970,27 @@ def test_python_flag_defaults_to_none_when_absent():
 
 
 @pytest.mark.core
+def test_install_accepts_repeatable_config_settings():
+    """Build backend settings should be parsed as package install options."""
+    from pipenv.cli.options import build_parser
+
+    parser = build_parser()
+    args = parser.parse_args(
+        [
+            "install",
+            "--editable",
+            ".",
+            "--config-settings",
+            "editable_mode=strict",
+            "--config-settings",
+            "build_number=42",
+        ]
+    )
+
+    assert args.config_settings == ["editable_mode=strict", "build_number=42"]
+
+
+@pytest.mark.core
 def test_run_passes_verbose_to_remaining():
     """Regression test for GH-6626: ``pipenv run ./manage.py test --verbose``
     must pass ``--verbose`` through to the user's process, not consume it as a

--- a/tests/unit/test_dependencies.py
+++ b/tests/unit/test_dependencies.py
@@ -620,6 +620,22 @@ class TestConfigSettingsPipArgs:
             [], ["--config-settings=editable_mode=strict"]
         ) == ["--config-settings", "editable_mode=strict"]
 
+    def test_config_settings_are_removed_from_generic_pip_args(self):
+        from pipenv.routines.install import _split_config_settings_pip_args
+
+        assert _split_config_settings_pip_args(
+            ["editable_mode=strict"],
+            ["--no-build-isolation", "--config-settings=build_number=42"],
+        ) == (
+            [
+                "--config-settings",
+                "editable_mode=strict",
+                "--config-settings",
+                "build_number=42",
+            ],
+            ["--no-build-isolation"],
+        )
+
     def test_package_args_match_normalized_lockfile_name(self):
         from pipenv.routines.install import _pip_args_for_dependency
 

--- a/tests/unit/test_dependencies.py
+++ b/tests/unit/test_dependencies.py
@@ -531,6 +531,24 @@ class TestNoBinaryCleanResolvedDep:
 
         assert "no_binary" not in result.get("requests", {})
 
+    def test_pip_args_are_preserved(self):
+        """Per-package build arguments must survive lockfile generation."""
+        project = MagicMock()
+        project.pipfile.project_directory = None
+
+        dep = {
+            "name": "local-project",
+            "path": ".",
+            "editable": True,
+            "pip_args": ["--config-settings", "editable_mode=strict"],
+        }
+        result = clean_resolved_dep(project, dep)
+
+        assert result["local-project"]["pip_args"] == [
+            "--config-settings",
+            "editable_mode=strict",
+        ]
+
 
 class TestShouldUseNoBinary:
     """Tests for the _should_use_no_binary helper in routines/install.py."""
@@ -584,6 +602,59 @@ class TestShouldUseNoBinary:
 
     def test_none_pkg_name(self):
         assert self._call(None, ["--no-binary", "cartopy"]) is False
+
+
+class TestConfigSettingsPipArgs:
+    def test_explicit_settings_are_converted_to_pip_args(self):
+        from pipenv.routines.install import _config_settings_pip_args
+
+        assert _config_settings_pip_args(["editable_mode=strict"], []) == [
+            "--config-settings",
+            "editable_mode=strict",
+        ]
+
+    def test_legacy_extra_pip_args_are_recordable(self):
+        from pipenv.routines.install import _config_settings_pip_args
+
+        assert _config_settings_pip_args(
+            [], ["--config-settings=editable_mode=strict"]
+        ) == ["--config-settings", "editable_mode=strict"]
+
+    def test_package_args_match_normalized_lockfile_name(self):
+        from pipenv.routines.install import _pip_args_for_dependency
+
+        dependency = MagicMock(name="local-package")
+        dependency.name = "local_package"
+        lockfile = {
+            "local-package": {
+                "path": ".",
+                "editable": True,
+                "pip_args": ["--config-settings", "editable_mode=strict"],
+            }
+        }
+
+        assert _pip_args_for_dependency(dependency, lockfile) == (
+            "--config-settings",
+            "editable_mode=strict",
+        )
+
+    def test_path_requirement_args_match_without_requirement_name(self):
+        from pipenv.routines.install import _pip_args_for_dependency
+
+        dependency = MagicMock()
+        dependency.name = None
+        lockfile = {
+            "local-project": {
+                "path": ".",
+                "editable": True,
+                "pip_args": ["--config-settings", "editable_mode=strict"],
+            }
+        }
+
+        assert _pip_args_for_dependency(dependency, lockfile, "-e .") == (
+            "--config-settings",
+            "editable_mode=strict",
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_install.py
+++ b/tests/unit/test_install.py
@@ -1,0 +1,30 @@
+import queue
+from unittest.mock import MagicMock
+
+import pytest
+
+from pipenv.routines.context import RoutineContext
+from pipenv.routines import install
+
+
+def test_batch_install_reports_missing_index_without_masking_error(monkeypatch):
+    project = MagicMock()
+    project.settings = {}
+    project.sources.default = {"name": "missing"}
+    project.environment.is_satisfied.return_value = False
+
+    dependency = MagicMock()
+    dependency.name = "example"
+    dependency.markers = None
+
+    monkeypatch.setattr(install, "get_source_list", lambda *args, **kwargs: [])
+
+    with pytest.raises(SystemExit):
+        install.batch_install(
+            project,
+            RoutineContext.from_cli(system=True),
+            [(dependency, "example==1.0")],
+            {},
+            queue.Queue(maxsize=1),
+            None,
+        )

--- a/tests/unit/test_pipfile_entry_validation.py
+++ b/tests/unit/test_pipfile_entry_validation.py
@@ -12,12 +12,35 @@ def test_plette_accepts_skip_resolver():
     )
 
 
+def test_plette_accepts_per_package_pip_args():
+    PackageSpecfiers.validate(
+        {
+            "path": ".",
+            "editable": True,
+            "pip_args": ["--config-settings", "editable_mode=strict"],
+        }
+    )
+
+
 def test_install_requirement_accepts_skip_resolver():
     _, _, requirement = install_req_from_pipfile(
         "example", {"version": "*", "skip_resolver": True}
     )
 
     assert requirement == "example"
+
+
+def test_install_requirement_accepts_per_package_pip_args():
+    _, _, requirement = install_req_from_pipfile(
+        "example",
+        {
+            "path": ".",
+            "editable": True,
+            "pip_args": ["--config-settings", "editable_mode=strict"],
+        },
+    )
+
+    assert requirement == "-e ."
 
 
 def test_plette_rejects_unrecognized_key():

--- a/tests/unit/test_pipfile_subsystem.py
+++ b/tests/unit/test_pipfile_subsystem.py
@@ -432,6 +432,21 @@ def test_add_entry_appends_to_category(project_with_packages, tmp_path):
     assert "django" in on_disk
 
 
+@pytest.mark.utils
+def test_add_package_records_per_package_pip_args(project_bare):
+    from pipenv.utils.dependencies import expansive_install_req_from_line
+
+    package, _ = expansive_install_req_from_line("requests")
+    project_bare.pipfile.add_package(
+        package,
+        "requests",
+        pip_args=["--config-settings", "editable_mode=strict"],
+    )
+
+    entry = project_bare.pipfile.parsed["packages"]["requests"]
+    assert entry["pip_args"] == ["--config-settings", "editable_mode=strict"]
+
+
 # ---- hash ----------------------------------------------------------------
 
 


### PR DESCRIPTION
## Summary

- add a repeatable `--config-settings KEY=VALUE` option to `pipenv install`
- persist package-scoped build arguments in the Pipfile and lockfile
- replay settings in separate pip install phases so they apply only to the intended requirement

Fixes #5740

## Validation

- `pre-commit run --files ...`
- `python -m pytest -q tests/unit/test_pipfile_entry_validation.py tests/unit/test_pipfile_subsystem.py tests/unit/test_dependencies.py tests/unit/test_core.py --disable-warnings`
- `python -m pytest -q tests/unit/test_routine_context.py tests/unit/test_do_install_context_routing.py tests/unit/test_do_update_context_routing.py tests/unit/test_lock_sync_uninstall_context_routing.py --disable-warnings`
- end-to-end `pipenv install --skip-lock --editable . --config-settings editable_mode=strict` smoke test, followed by a verbose reinstall confirming the setting reaches pip
